### PR TITLE
docs(contributing): add One Concern Per PR rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,37 @@ npm test
 3. Write tests for new functionality
 4. Run `npm test` — all tests must pass
 5. Commit with conventional format (`feat:`, `fix:`, `docs:`, etc.)
-6. Open a PR against `main`
+6. Open a PR against `main` — see [Pull Request Scope](#pull-request-scope) for the one-concern-per-PR rule
+
+### Pull Request Scope
+
+**One concern per PR.** Every PR should answer one well-defined question: "Why is this change needed?" If the answer has multiple unrelated parts ("add feature X *and* refactor Y *and* regenerate build artifacts *and* update unrelated docs"), split it into separate PRs.
+
+This rule extends the project's broader commit-hygiene principle:
+
+> No bundled concerns: CI, tooling, and infra changes ship alone. Never in the same commit as product features.
+
+Squash-merging is fine as long as each PR is one concern; merge-commit-merging is fine as long as each commit on the branch is one concern. Either way, **the unit of one-concern hygiene is the merge boundary, not just local commits** — clean local history can still produce a bundled merge.
+
+#### PR Author Checklist
+
+Before opening a PR, verify:
+
+- [ ] **One concern.** The PR title fits the form `<type>(<scope>): <single observable outcome>` without "and" or commas. If you need a comma, split the PR.
+- [ ] **Size budget.** ≤15 hand-edited source files OR ≤500 LOC of hand-edited source. Generated artifacts (bundle regen, lockfiles, snapshots) don't count toward the budget but must ride with the source change that produced them — never separately, never alongside unrelated source.
+- [ ] **No drive-bys.** Edits unrelated to the stated concern get their own PR, even if they're small. "While I was here" is not a justification.
+- [ ] **Bundle regen rule.** If a source change requires `npm run build`, the regenerated `bin/*.mjs`, `lib/*.mjs`, `test/*.test.mjs`, and `plugins/*.json` ship in the same PR as the source. The CI gate `npm run verify:generated` enforces this, but you should verify locally before pushing.
+- [ ] **Skill mirror rule.** If you edit `plugins/continuous-improvement/skills/<name>/SKILL.md`, mirror the same change to `skills/<name>.md` (or vice versa) in the same PR. The two distribution copies must not drift across PR boundaries — installs from `~/.claude/skills/` (curl path) and from the plugin bundle must produce identical skill content.
+
+#### When you have multiple concerns
+
+Sequence the PRs:
+
+1. Land each source concern in its own PR. Each gets the bundle regeneration that its source change requires (one PR = source + its own regen output).
+2. If unrelated companion skills, hooks, or commands need to ship, open separate PRs per concern. Stack them on top of each other if there are dependencies; otherwise open them in parallel.
+3. Avoid the "feature-branch dumping ground" pattern — a long-lived branch that accumulates several unrelated changes and merges as one. If a branch is going to land more than one concern, split before merging.
+
+A single PR that touches multiple skills (e.g. `proceed-with-claude-recommendation`, `tdd-workflow`, `safety-guard`), README mode descriptions, and bundle artifacts is **five concerns**, not one — even if every commit on the branch was clean locally. Five concerns get five PRs.
 
 ### Share Instinct Packs
 Have a set of instincts that work well for a specific stack? Add them to `instinct-packs/`:


### PR DESCRIPTION
## Summary

- Adds a **Pull Request Scope** section to [CONTRIBUTING.md](CONTRIBUTING.md) establishing one-concern-per-PR as the unit of hygiene at the merge boundary
- Includes a 5-item PR author checklist covering title shape, size budget, drive-by guard, bundle-regen rule, and skill-mirror rule
- Adds sequencing guidance for multi-concern work and names the "feature-branch dumping ground" anti-pattern explicitly

## Motivation

[PR #26](https://github.com/naimkatiman/continuous-improvement/pull/26) merged at 2026-04-27 bundled 9+ logical concerns into one merge commit (28 files, +2689/-48 LOC): tightening of `proceed-with-claude-recommendation`, addition of 7 new companion skills, the `/learn-eval` command, README updates, and bundle regen. Every individual commit on the feature branch was clean, but the merge itself was a bundled concern.

The project's commit-hygiene guidance (and the global Claude Code Discipline Fixes) already says "no bundled concerns" — but the rule was scoped to commits, not PRs. This adds the missing PR-boundary guidance so clean local history can't be undone by a wide feature-branch merge.

## Test plan

- [ ] Read the new section end-to-end and confirm the checklist is concrete enough to run before opening a PR (no abstract advice)
- [ ] Verify the bundle-regen rule and the skill-mirror rule match how the codebase actually wants those changes shipped (`npm run verify:generated` CI gate + standalone `skills/<name>.md` paired with `plugins/continuous-improvement/skills/<name>/SKILL.md`)
- [ ] Confirm no markdown rendering issues — table-free section, anchor link from "Submit PRs" works in the GitHub preview

## Out of scope

- Not retroactively splitting PR #26
- Not changing branch-protection rules or merge-button defaults (this is a docs change; enforcement at the GitHub-config level is a separate decision)

🤖 Generated with [Claude Code](https://claude.com/claude-code)