### PR TITLE
feat(ci): add skill-mirror lint enforcing CONTRIBUTING.md mirror rule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,9 @@ jobs:
             fi
           done
 
+      - name: Verify skill-mirror parity (plugin copy == standalone copy)
+        run: npm run verify:skill-mirror
+
       - name: Verify instinct packs are valid JSON
         run: |
           for pack in instinct-packs/*.json; do

--- a/bin/check-skill-mirror.mjs
+++ b/bin/check-skill-mirror.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Skill Mirror Check
+ *
+ * Verifies that every skill exists as both a plugin copy
+ * (plugins/continuous-improvement/skills/<name>/SKILL.md) and a standalone
+ * copy (skills/<name>.md, or root SKILL.md for the core continuous-improvement
+ * skill), and that the two copies are byte-identical.
+ *
+ * Enforces the "Skill mirror rule" from CONTRIBUTING.md so the curl-install
+ * path and the plugin-bundle path produce the same skill content.
+ *
+ * Usage:
+ *   node bin/check-skill-mirror.mjs              # Check the current repo
+ *   node bin/check-skill-mirror.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every pair matches
+ *   1 — at least one drift detected (missing standalone or content mismatch)
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const PLUGIN_SKILLS_DIR = "plugins/continuous-improvement/skills";
+const CORE_SKILL_NAME = "continuous-improvement";
+export function discoverPairs(repoRoot) {
+    const pluginDir = join(repoRoot, PLUGIN_SKILLS_DIR);
+    let entries;
+    try {
+        entries = readdirSync(pluginDir);
+    }
+    catch {
+        return [];
+    }
+    const pairs = [];
+    for (const name of entries) {
+        const skillDir = join(pluginDir, name);
+        let stat;
+        try {
+            stat = statSync(skillDir);
+        }
+        catch {
+            continue;
+        }
+        if (!stat.isDirectory())
+            continue;
+        const skillFile = join(skillDir, "SKILL.md");
+        try {
+            statSync(skillFile);
+        }
+        catch {
+            continue;
+        }
+        const standalonePath = name === CORE_SKILL_NAME
+            ? join(repoRoot, "SKILL.md")
+            : join(repoRoot, "skills", `${name}.md`);
+        pairs.push({ name, pluginPath: skillFile, standalonePath });
+    }
+    return pairs.sort((a, b) => a.name.localeCompare(b.name));
+}
+export function checkPairs(repoRoot) {
+    const pairs = discoverPairs(repoRoot);
+    const drifts = [];
+    for (const pair of pairs) {
+        let standaloneContent;
+        try {
+            standaloneContent = readFileSync(pair.standalonePath, "utf8");
+        }
+        catch {
+            drifts.push({
+                name: pair.name,
+                reason: "missing-standalone",
+                pluginPath: pair.pluginPath,
+                standalonePath: pair.standalonePath,
+            });
+            continue;
+        }
+        const pluginContent = readFileSync(pair.pluginPath, "utf8");
+        if (pluginContent !== standaloneContent) {
+            drifts.push({
+                name: pair.name,
+                reason: "content-drift",
+                pluginPath: pair.pluginPath,
+                standalonePath: pair.standalonePath,
+                pluginLines: pluginContent.split("\n").length,
+                standaloneLines: standaloneContent.split("\n").length,
+            });
+        }
+    }
+    return drifts;
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const pairs = discoverPairs(repoRoot);
+    const drifts = checkPairs(repoRoot);
+    if (drifts.length === 0) {
+        console.log(`OK skill-mirror: all ${pairs.length} skill pair(s) match between plugin and standalone copies.`);
+        exit(0);
+    }
+    console.error(`FAIL skill-mirror: ${drifts.length} drift(s) detected across ${pairs.length} skill pair(s).\n`);
+    for (const d of drifts) {
+        if (d.reason === "missing-standalone") {
+            console.error(`  - ${d.name}: plugin copy exists but standalone copy is missing.`);
+            console.error(`      plugin:     ${d.pluginPath}`);
+            console.error(`      standalone: ${d.standalonePath} (NOT FOUND)`);
+        }
+        else {
+            console.error(`  - ${d.name}: content drift between plugin and standalone copy (${d.pluginLines} vs ${d.standaloneLines} lines).`);
+            console.error(`      plugin:     ${d.pluginPath}`);
+            console.error(`      standalone: ${d.standalonePath}`);
+        }
+    }
+    console.error("\nFix per CONTRIBUTING.md \"Skill mirror rule\": every change to a skill must be applied to both the plugin copy and the standalone copy in the same PR. The two distribution paths (curl-install and plugin-bundle) must produce identical content.");
+    exit(1);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-mirror.mjs")) {
+    main();
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "clean": "node -e \"const fs=require('node:fs'); for (const dir of ['bin','test','lib']) { if (!fs.existsSync(dir)) continue; for (const file of fs.readdirSync(dir)) { if (file.endsWith('.mjs')) fs.rmSync(dir + '/' + file, { force: true }); } }\"",
     "test": "npm run build && node --test test/*.test.mjs",
     "lint": "node bin/lint-transcript.mjs --help",
-    "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin test lib plugins"
+    "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin test lib plugins",
+    "verify:skill-mirror": "node bin/check-skill-mirror.mjs"
   },
   "files": [
     ".claude-plugin/",

--- a/src/bin/check-skill-mirror.mts
+++ b/src/bin/check-skill-mirror.mts
@@ -1,0 +1,147 @@
+#!/usr/bin/env node
+
+/**
+ * Skill Mirror Check
+ *
+ * Verifies that every skill exists as both a plugin copy
+ * (plugins/continuous-improvement/skills/<name>/SKILL.md) and a standalone
+ * copy (skills/<name>.md, or root SKILL.md for the core continuous-improvement
+ * skill), and that the two copies are byte-identical.
+ *
+ * Enforces the "Skill mirror rule" from CONTRIBUTING.md so the curl-install
+ * path and the plugin-bundle path produce the same skill content.
+ *
+ * Usage:
+ *   node bin/check-skill-mirror.mjs              # Check the current repo
+ *   node bin/check-skill-mirror.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every pair matches
+ *   1 — at least one drift detected (missing standalone or content mismatch)
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const PLUGIN_SKILLS_DIR = "plugins/continuous-improvement/skills";
+const CORE_SKILL_NAME = "continuous-improvement";
+
+interface SkillPair {
+  name: string;
+  pluginPath: string;
+  standalonePath: string;
+}
+
+export interface DriftReport {
+  name: string;
+  reason: "missing-standalone" | "content-drift";
+  pluginPath: string;
+  standalonePath: string;
+  pluginLines?: number;
+  standaloneLines?: number;
+}
+
+export function discoverPairs(repoRoot: string): SkillPair[] {
+  const pluginDir = join(repoRoot, PLUGIN_SKILLS_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(pluginDir);
+  } catch {
+    return [];
+  }
+  const pairs: SkillPair[] = [];
+  for (const name of entries) {
+    const skillDir = join(pluginDir, name);
+    let stat;
+    try {
+      stat = statSync(skillDir);
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    const skillFile = join(skillDir, "SKILL.md");
+    try {
+      statSync(skillFile);
+    } catch {
+      continue;
+    }
+    const standalonePath =
+      name === CORE_SKILL_NAME
+        ? join(repoRoot, "SKILL.md")
+        : join(repoRoot, "skills", `${name}.md`);
+    pairs.push({ name, pluginPath: skillFile, standalonePath });
+  }
+  return pairs.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function checkPairs(repoRoot: string): DriftReport[] {
+  const pairs = discoverPairs(repoRoot);
+  const drifts: DriftReport[] = [];
+  for (const pair of pairs) {
+    let standaloneContent: string;
+    try {
+      standaloneContent = readFileSync(pair.standalonePath, "utf8");
+    } catch {
+      drifts.push({
+        name: pair.name,
+        reason: "missing-standalone",
+        pluginPath: pair.pluginPath,
+        standalonePath: pair.standalonePath,
+      });
+      continue;
+    }
+    const pluginContent = readFileSync(pair.pluginPath, "utf8");
+    if (pluginContent !== standaloneContent) {
+      drifts.push({
+        name: pair.name,
+        reason: "content-drift",
+        pluginPath: pair.pluginPath,
+        standalonePath: pair.standalonePath,
+        pluginLines: pluginContent.split("\n").length,
+        standaloneLines: standaloneContent.split("\n").length,
+      });
+    }
+  }
+  return drifts;
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const pairs = discoverPairs(repoRoot);
+  const drifts = checkPairs(repoRoot);
+  if (drifts.length === 0) {
+    console.log(
+      `OK skill-mirror: all ${pairs.length} skill pair(s) match between plugin and standalone copies.`,
+    );
+    exit(0);
+  }
+  console.error(
+    `FAIL skill-mirror: ${drifts.length} drift(s) detected across ${pairs.length} skill pair(s).\n`,
+  );
+  for (const d of drifts) {
+    if (d.reason === "missing-standalone") {
+      console.error(
+        `  - ${d.name}: plugin copy exists but standalone copy is missing.`,
+      );
+      console.error(`      plugin:     ${d.pluginPath}`);
+      console.error(`      standalone: ${d.standalonePath} (NOT FOUND)`);
+    } else {
+      console.error(
+        `  - ${d.name}: content drift between plugin and standalone copy (${d.pluginLines} vs ${d.standaloneLines} lines).`,
+      );
+      console.error(`      plugin:     ${d.pluginPath}`);
+      console.error(`      standalone: ${d.standalonePath}`);
+    }
+  }
+  console.error(
+    "\nFix per CONTRIBUTING.md \"Skill mirror rule\": every change to a skill must be applied to both the plugin copy and the standalone copy in the same PR. The two distribution paths (curl-install and plugin-bundle) must produce identical content.",
+  );
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-mirror.mjs")) {
+  main();
+}

--- a/src/test/check-skill-mirror.test.mts
+++ b/src/test/check-skill-mirror.test.mts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { checkPairs, discoverPairs } from "../bin/check-skill-mirror.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-mirror.mjs");
+const PLUGIN_SKILLS = "plugins/continuous-improvement/skills";
+
+function setupRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "skill-mirror-test-"));
+  mkdirSync(join(root, PLUGIN_SKILLS), { recursive: true });
+  mkdirSync(join(root, "skills"), { recursive: true });
+  return root;
+}
+
+function writePair(
+  root: string,
+  name: string,
+  pluginContent: string,
+  standaloneContent: string | null,
+): void {
+  const skillDir = join(root, PLUGIN_SKILLS, name);
+  mkdirSync(skillDir, { recursive: true });
+  writeFileSync(join(skillDir, "SKILL.md"), pluginContent);
+  if (standaloneContent !== null) {
+    const standalonePath =
+      name === "continuous-improvement"
+        ? join(root, "SKILL.md")
+        : join(root, "skills", `${name}.md`);
+    writeFileSync(standalonePath, standaloneContent);
+  }
+}
+
+describe("check-skill-mirror — unit", () => {
+  it("returns no drifts when every pair is byte-identical", () => {
+    const root = setupRepo();
+    try {
+      writePair(root, "alpha", "alpha body\n", "alpha body\n");
+      writePair(root, "beta", "beta body\n", "beta body\n");
+      const drifts = checkPairs(root);
+      assert.equal(
+        drifts.length,
+        0,
+        `expected no drifts, got: ${JSON.stringify(drifts)}`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("detects content drift between plugin and standalone copy", () => {
+    const root = setupRepo();
+    try {
+      writePair(root, "alpha", "alpha body v2\n", "alpha body v1\n");
+      const drifts = checkPairs(root);
+      assert.equal(drifts.length, 1);
+      assert.equal(drifts[0].name, "alpha");
+      assert.equal(drifts[0].reason, "content-drift");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("detects missing standalone copy", () => {
+    const root = setupRepo();
+    try {
+      writePair(root, "alpha", "alpha body\n", null);
+      const drifts = checkPairs(root);
+      assert.equal(drifts.length, 1);
+      assert.equal(drifts[0].name, "alpha");
+      assert.equal(drifts[0].reason, "missing-standalone");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("maps the core continuous-improvement skill to root SKILL.md", () => {
+    const root = setupRepo();
+    try {
+      writePair(
+        root,
+        "continuous-improvement",
+        "core body\n",
+        "core body\n",
+      );
+      const pairs = discoverPairs(root);
+      assert.equal(pairs.length, 1);
+      assert.equal(pairs[0].name, "continuous-improvement");
+      const standaloneSuffix = pairs[0].standalonePath
+        .replace(/\\/g, "/")
+        .slice(root.replace(/\\/g, "/").length);
+      assert.equal(
+        standaloneSuffix,
+        "/SKILL.md",
+        `core skill standalone path should be root SKILL.md, got: ${pairs[0].standalonePath}`,
+      );
+      const drifts = checkPairs(root);
+      assert.equal(drifts.length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores non-directory entries and dirs without a SKILL.md", () => {
+    const root = setupRepo();
+    try {
+      writePair(root, "alpha", "alpha body\n", "alpha body\n");
+      mkdirSync(join(root, PLUGIN_SKILLS, "empty-dir"), { recursive: true });
+      writeFileSync(join(root, PLUGIN_SKILLS, "stray.txt"), "noise");
+      const pairs = discoverPairs(root);
+      assert.equal(pairs.length, 1);
+      assert.equal(pairs[0].name, "alpha");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty list when plugin skills dir is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "skill-mirror-empty-"));
+    try {
+      const pairs = discoverPairs(root);
+      assert.equal(pairs.length, 0);
+      const drifts = checkPairs(root);
+      assert.equal(drifts.length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-skill-mirror — integration", () => {
+  it("CLI exits 0 with OK message on a clean synthetic repo", () => {
+    const root = setupRepo();
+    try {
+      writePair(root, "alpha", "alpha\n", "alpha\n");
+      writePair(root, "beta", "beta\n", "beta\n");
+      const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      assert.match(out, /OK skill-mirror: all 2 skill pair\(s\) match/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 with FAIL message on a drifted synthetic repo", () => {
+    const root = setupRepo();
+    try {
+      writePair(root, "alpha", "alpha v2\n", "alpha v1\n");
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /FAIL skill-mirror: 1 drift\(s\)/);
+        assert.match(e.stderr ?? "", /content drift/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero on drift");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies the live repo has zero drifts", () => {
+    const drifts = checkPairs(REPO_ROOT);
+    assert.equal(
+      drifts.length,
+      0,
+      `live repo has skill-mirror drift: ${JSON.stringify(drifts, null, 2)}`,
+    );
+  });
+});

--- a/test/check-skill-mirror.test.mjs
+++ b/test/check-skill-mirror.test.mjs
@@ -1,0 +1,152 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { checkPairs, discoverPairs } from "../bin/check-skill-mirror.mjs";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-mirror.mjs");
+const PLUGIN_SKILLS = "plugins/continuous-improvement/skills";
+function setupRepo() {
+    const root = mkdtempSync(join(tmpdir(), "skill-mirror-test-"));
+    mkdirSync(join(root, PLUGIN_SKILLS), { recursive: true });
+    mkdirSync(join(root, "skills"), { recursive: true });
+    return root;
+}
+function writePair(root, name, pluginContent, standaloneContent) {
+    const skillDir = join(root, PLUGIN_SKILLS, name);
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, "SKILL.md"), pluginContent);
+    if (standaloneContent !== null) {
+        const standalonePath = name === "continuous-improvement"
+            ? join(root, "SKILL.md")
+            : join(root, "skills", `${name}.md`);
+        writeFileSync(standalonePath, standaloneContent);
+    }
+}
+describe("check-skill-mirror — unit", () => {
+    it("returns no drifts when every pair is byte-identical", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "alpha", "alpha body\n", "alpha body\n");
+            writePair(root, "beta", "beta body\n", "beta body\n");
+            const drifts = checkPairs(root);
+            assert.equal(drifts.length, 0, `expected no drifts, got: ${JSON.stringify(drifts)}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("detects content drift between plugin and standalone copy", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "alpha", "alpha body v2\n", "alpha body v1\n");
+            const drifts = checkPairs(root);
+            assert.equal(drifts.length, 1);
+            assert.equal(drifts[0].name, "alpha");
+            assert.equal(drifts[0].reason, "content-drift");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("detects missing standalone copy", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "alpha", "alpha body\n", null);
+            const drifts = checkPairs(root);
+            assert.equal(drifts.length, 1);
+            assert.equal(drifts[0].name, "alpha");
+            assert.equal(drifts[0].reason, "missing-standalone");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("maps the core continuous-improvement skill to root SKILL.md", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "continuous-improvement", "core body\n", "core body\n");
+            const pairs = discoverPairs(root);
+            assert.equal(pairs.length, 1);
+            assert.equal(pairs[0].name, "continuous-improvement");
+            const standaloneSuffix = pairs[0].standalonePath
+                .replace(/\\/g, "/")
+                .slice(root.replace(/\\/g, "/").length);
+            assert.equal(standaloneSuffix, "/SKILL.md", `core skill standalone path should be root SKILL.md, got: ${pairs[0].standalonePath}`);
+            const drifts = checkPairs(root);
+            assert.equal(drifts.length, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("ignores non-directory entries and dirs without a SKILL.md", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "alpha", "alpha body\n", "alpha body\n");
+            mkdirSync(join(root, PLUGIN_SKILLS, "empty-dir"), { recursive: true });
+            writeFileSync(join(root, PLUGIN_SKILLS, "stray.txt"), "noise");
+            const pairs = discoverPairs(root);
+            assert.equal(pairs.length, 1);
+            assert.equal(pairs[0].name, "alpha");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("returns empty list when plugin skills dir is missing", () => {
+        const root = mkdtempSync(join(tmpdir(), "skill-mirror-empty-"));
+        try {
+            const pairs = discoverPairs(root);
+            assert.equal(pairs.length, 0);
+            const drifts = checkPairs(root);
+            assert.equal(drifts.length, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+describe("check-skill-mirror — integration", () => {
+    it("CLI exits 0 with OK message on a clean synthetic repo", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "alpha", "alpha\n", "alpha\n");
+            writePair(root, "beta", "beta\n", "beta\n");
+            const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            assert.match(out, /OK skill-mirror: all 2 skill pair\(s\) match/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 with FAIL message on a drifted synthetic repo", () => {
+        const root = setupRepo();
+        try {
+            writePair(root, "alpha", "alpha v2\n", "alpha v1\n");
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /FAIL skill-mirror: 1 drift\(s\)/);
+                assert.match(e.stderr ?? "", /content drift/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero on drift");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("verifies the live repo has zero drifts", () => {
+        const drifts = checkPairs(REPO_ROOT);
+        assert.equal(drifts.length, 0, `live repo has skill-mirror drift: ${JSON.stringify(drifts, null, 2)}`);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a CI lint that fails any PR where `plugins/continuous-improvement/skills/<name>/SKILL.md` and the corresponding standalone copy (`skills/<name>.md`, or root `SKILL.md` for the core skill) diverge in content, or where one of the two copies is missing.
- Mechanical enforcement of the "Skill mirror rule" landed in PR #27 — turns the soft rule into a hard one without further human review burden.
- Live repo verifies clean: 12/12 skill pairs are byte-identical today.

## What ships (one concern, 6 files)

- `src/bin/check-skill-mirror.mts` — zero-runtime-dep checker (discovers pairs, byte-compares, reports drifts, exits 1 on any drift)
- `src/test/check-skill-mirror.test.mts` — 9 tests: 6 unit (drift detection, missing-standalone, core-skill special case, edge cases) + 3 integration (CLI exit codes + live-repo zero-drift assertion)
- `bin/check-skill-mirror.mjs` and `test/check-skill-mirror.test.mjs` — build artifacts (npm run build), committed alongside source per `verify:generated` CI gate
- `package.json` — new `verify:skill-mirror` script
- `.github/workflows/ci.yml` — new "Verify skill-mirror parity" step in the `test` job

## How it surfaces failures

```
FAIL skill-mirror: 1 drift(s) detected across 12 skill pair(s).

  - proceed-with-claude-recommendation: content drift between plugin and standalone copy (381 vs 277 lines).
      plugin:     plugins/continuous-improvement/skills/proceed-with-claude-recommendation/SKILL.md
      standalone: skills/proceed-with-claude-recommendation.md

Fix per CONTRIBUTING.md "Skill mirror rule": every change to a skill must be applied to both the plugin copy and the standalone copy in the same PR. ...
```

## PR scope discipline (eating my own dog food)

This PR follows the rules added in [PR #27](https://github.com/naimkatiman/continuous-improvement/pull/27):

- **One concern.** Title is "add skill-mirror lint" — no "and", no comma. Just the lint.
- **Size budget.** 6 files, +607/-1 LOC; 4 of the 6 are the new skill-mirror lint files (split source + generated). Well under the 15-file/500-LOC hand-edited budget.
- **No drive-bys.** No unrelated source changes. The pre-existing `community.test.mjs` "mentions the planning workflow" failure (README.md missing `ci_plan_init`) is **not addressed here** — it predates this branch and is its own concern.
- **Bundle regen rule.** Both source (`src/bin/`, `src/test/`) and generated (`bin/`, `test/`) ride together in this PR.
- **Skill mirror rule.** This PR doesn't touch any skill files, so the rule is trivially satisfied — but the lint it adds will catch future violations.

## Test plan

- [ ] CI runs: `npm test` (192 tests, expect 191 pass / 1 pre-existing fail), `npm run verify:skill-mirror` (expect OK on 12 pairs), `npm run verify:generated` (expect clean), Node 18/20/22 matrix
- [ ] Sanity check the failure surface by temporarily editing one `skills/<name>.md` to drift it from its plugin copy, running `npm run verify:skill-mirror` locally, and confirming exit 1 + the drift name appears in stderr
- [ ] Confirm the new CI step appears in the GitHub Actions run for this PR and is required before merge

## Out of scope (downstream of this landing)

- PR-title lint enforcing "no `and` / no comma" rule
- Branch-protection settings update on GitHub (squash-merge default, required checks)
- Drift audit pass — moot once this lint is in place; any backfill the lint discovers becomes its own PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)