### PR TITLE
fix(readme): restore ci_plan_init / ci_plan_status MCP tool mentions

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Hooks capture every tool call. After ~20 observations, Claude analyzes patterns 
 /dashboard                 Visual instinct health dashboard
 ```
 
+In expert mode, the same planning workflow is also available programmatically through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
+
 ---
 
 ## Bundled Skills & Plugins


### PR DESCRIPTION
## Summary

- Adds back a one-line mention of the `ci_plan_init` and `ci_plan_status` MCP tools to the README's Slash Commands section
- Closes the pre-existing `community.test.mjs` "mentions the planning workflow" failure that has been red on main since PR #26's README rewrite
- One file changed, +2/-0 LOC

## Root cause

The test at [src/test/community.test.mts:84-91](src/test/community.test.mts#L84-L91) asserts:

```ts
describe("README.md", () => {
  it("mentions the planning workflow", () => {
    const path = join(ROOT, "README.md");
    const content = readFileSync(path, "utf8");
    assert.match(content, /planning-with-files/i);
    assert.match(content, /task_plan\.md/);
    assert.match(content, /ci_plan_init/);
  });
});
```

The first two regexes still pass on the post-rewrite README. The third regex (`/ci_plan_init/`) was passing in [v3.2.0 README at commit `7f76b21`](https://github.com/naimkatiman/continuous-improvement/commit/7f76b21) (which had the mention at three different lines), but [PR #26's wholesale README rewrite at `404b680`](https://github.com/naimkatiman/continuous-improvement/commit/404b680) replaced the README and dropped all three references without updating the test.

The MCP tools themselves still exist — verified across [src/bin/mcp-server.mts](src/bin/mcp-server.mts), [bin/mcp-server.mjs](bin/mcp-server.mjs), [plugins/expert.json](plugins/expert.json), and [CHANGELOG.md](CHANGELOG.md). So this is "test was right, README forgot to mention reality after the rewrite," not "test is stale and should be deleted."

## The fix

Adds one paragraph to [README.md](README.md) directly below the Slash Commands code block:

```
In expert mode, the same planning workflow is also available
programmatically through the MCP tools `ci_plan_init` (initialize
task_plan.md, findings.md, progress.md in the project root) and
`ci_plan_status` (summarize their current contents).
```

This is contextually correct: the slash command and the MCP tools are two surfaces of the same workflow, and the README already mentions the slash command immediately above. Net diff: +2 LOC.

## Test plan

- [x] `node --test test/community.test.mjs` — 20/20 pass (previously 19/20)
- [x] `npm test` — 183/183 pass on this branch (no regressions)
- [ ] CI matrix on Node 18/20/22 in the PR check

## PR scope discipline

- **One concern.** Title is "restore the dropped MCP tool mentions" — no "and", no comma.
- **Size budget.** 1 file, +2/-0 LOC. Well under any threshold.
- **No drive-bys.** README has lots of other small things one could polish during a rewrite check; none of them are touched here.
- **Skill mirror rule.** N/A — no skill files touched.
- **Bundle regen rule.** N/A — no source change requiring rebuild.

## Out of scope (intentionally)

- Restoring the longer "Inspired By Planning-With-Files" appendix that was at the bottom of the v3.2.0 README. The rewrite's tighter shape is fine; the test only needs the three substrings to appear somewhere.
- Re-listing all 12 expert-mode MCP tools in the README. That's its own README enhancement, not a fix for this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)