### PR TITLE
docs(contributing): add Test/docs sync rule to PR Author Checklist

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Before opening a PR, verify:
 - [ ] **No drive-bys.** Edits unrelated to the stated concern get their own PR, even if they're small. "While I was here" is not a justification.
 - [ ] **Bundle regen rule.** If a source change requires `npm run build`, the regenerated `bin/*.mjs`, `lib/*.mjs`, `test/*.test.mjs`, and `plugins/*.json` ship in the same PR as the source. The CI gate `npm run verify:generated` enforces this, but you should verify locally before pushing.
 - [ ] **Skill mirror rule.** If you edit `plugins/continuous-improvement/skills/<name>/SKILL.md`, mirror the same change to `skills/<name>.md` (or vice versa) in the same PR. The two distribution copies must not drift across PR boundaries — installs from `~/.claude/skills/` (curl path) and from the plugin bundle must produce identical skill content.
+- [ ] **Test/docs sync rule.** Tests that assert on prose content (`assert.match` against a `*.md` file like `README.md`, `CHANGELOG.md`, or any skill markdown) must ship in the same PR as the docs change adding the asserted substring. Wholesale rewrites of a docs file (README rewrites, CHANGELOG restructures) must verify every existing prose-substring assertion in `src/test/*.mts` still matches before merging — the rewrite PR is responsible for either preserving the asserted strings or updating the tests, not the next contributor's PR.
 
 #### When you have multiple concerns
 


### PR DESCRIPTION
## Summary

- Adds a sixth bullet to the PR Author Checklist in [CONTRIBUTING.md](CONTRIBUTING.md): when a test asserts on prose content in a `*.md` file, the docs change adding that substring must ship in the same PR as the test that asserts it
- Names the specific failure mode from PR #29: wholesale rewrites of a docs file must verify every existing prose-substring assertion still matches before merging
- One file changed, +1/-0 LOC

## Motivation

[PR #26](https://github.com/naimkatiman/continuous-improvement/pull/26) replaced README.md wholesale and dropped three `ci_plan_init` mentions. [`community.test.mts:90`](src/test/community.test.mts#L90) asserts the README contains `/ci_plan_init/`, so main shipped with a red CI step from the moment PR #26 merged until [PR #29](https://github.com/naimkatiman/continuous-improvement/pull/29) restored the mention.

The cause was a single missing check at PR #26's authoring time: "did this rewrite preserve every prose substring the test suite expects?" That's a tractable check (`grep "assert.match.*\.md" src/test/*.mts` lists them) and codifying it in the checklist puts the responsibility on the rewriting PR rather than the next contributor whose PR happens to hit the failure.

## What ships

```diff
+ - [ ] **Test/docs sync rule.** Tests that assert on prose content (`assert.match` against a `*.md` file like `README.md`, `CHANGELOG.md`, or any skill markdown) must ship in the same PR as the docs change adding the asserted substring. Wholesale rewrites of a docs file (README rewrites, CHANGELOG restructures) must verify every existing prose-substring assertion in `src/test/*.mts` still matches before merging — the rewrite PR is responsible for either preserving the asserted strings or updating the tests, not the next contributor's PR.
```

## Test plan

- [ ] Read the new bullet in context with the existing five and confirm the style matches (no decorative formatting, concrete examples, no abstract advice)
- [ ] Verify the suggested grep command (`grep "assert.match.*\.md" src/test/*.mts`) actually surfaces the assertions a contributor would need to verify

## PR scope discipline

This PR follows the rules in [CONTRIBUTING.md](CONTRIBUTING.md):

- **One concern.** Title is "add Test/docs sync rule" — no "and", no comma.
- **Size budget.** 1 file, +1/-0 LOC. Tightest possible.
- **No drive-bys.** No other CONTRIBUTING.md edits, no formatting passes, no other rule additions.
- **Bundle regen rule.** N/A — docs change.
- **Skill mirror rule.** N/A — no skill files touched.
- **Test/docs sync rule.** N/A — this PR adds the rule itself; no `assert.match` on `CONTRIBUTING.md` content exists today.

## Out of scope (intentionally)

- Backfilling the rule with a CI lint that mechanically enforces it (e.g. detect rewrites of `README.md`/`CHANGELOG.md` and refuse merge if any prose-substring assertion fails). This is a soft rule for now; a CI lint would be a separate PR after this one lands.
- A docs-substring audit pass scanning every existing `assert.match` against `*.md` files for current pass/fail status. Already deferred in the prior session reflection — that's a fresh PR's worth of work, not a rider.

🤖 Generated with [Claude Code](https://claude.com/claude-code)