### PR TITLE
feat(ci): add check-skill-tiers lint to surface untagged skills

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continuous-improvement
+tier: core
 description: "Install structured self-improvement loops with instinct-based learning into Claude Code — research, plan, execute, verify, reflect, learn, iterate. On-demand or weekly analysis to save tokens. Supports multi-agent parallel analysis."
 ---
 

--- a/bin/check-skill-tiers.mjs
+++ b/bin/check-skill-tiers.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Skill Tier Check
+ *
+ * Verifies that every source skill in skills/<name>.md (and the core
+ * SKILL.md at the repo root) declares a recognized `tier:` value in its
+ * YAML frontmatter. The generator groups skills into the bundled README
+ * by tier; an untagged skill silently slides into the "Other skills"
+ * bucket, which is easy to miss in review. This lint surfaces missing or
+ * unrecognized tiers as a hard failure.
+ *
+ * Recognized tier values (see src/lib/skill-tiers.mts):
+ *   "core" "featured" "1" "2" "companion"
+ *
+ * Usage:
+ *   node bin/check-skill-tiers.mjs              # Check the current repo
+ *   node bin/check-skill-tiers.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every source skill declares a recognized tier
+ *   1 — at least one skill is missing or has an unrecognized tier
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+import { normalizeTier, parseSkillFrontmatter, } from "../lib/skill-tiers.mjs";
+const SKILLS_DIR = "skills";
+const CORE_SKILL_FILE = "SKILL.md";
+const CORE_SKILL_NAME = "continuous-improvement";
+export function discoverSkillSources(repoRoot) {
+    const out = [];
+    // Core skill (root SKILL.md) is always present and represents the
+    // continuous-improvement framework itself; treat it as a checked source.
+    const corePath = join(repoRoot, CORE_SKILL_FILE);
+    try {
+        statSync(corePath);
+        out.push({ name: CORE_SKILL_NAME, path: corePath });
+    }
+    catch {
+        // No root SKILL.md — this is a misconfigured repo, but the lint should
+        // not error here; the skill-mirror lint covers that case.
+    }
+    const skillsDir = join(repoRoot, SKILLS_DIR);
+    let entries;
+    try {
+        entries = readdirSync(skillsDir);
+    }
+    catch {
+        return out;
+    }
+    for (const entry of entries) {
+        if (!entry.endsWith(".md"))
+            continue;
+        if (entry === "README.md")
+            continue;
+        const fullPath = join(skillsDir, entry);
+        try {
+            const stat = statSync(fullPath);
+            if (!stat.isFile())
+                continue;
+        }
+        catch {
+            continue;
+        }
+        out.push({ name: entry.replace(/\.md$/, ""), path: fullPath });
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+export function checkSkillTiers(repoRoot) {
+    const sources = discoverSkillSources(repoRoot);
+    const problems = [];
+    for (const src of sources) {
+        const content = readFileSync(src.path, "utf8");
+        const front = parseSkillFrontmatter(content);
+        const rawTier = front.tier;
+        if (!rawTier || rawTier.trim() === "") {
+            problems.push({ name: src.name, path: src.path, reason: "missing" });
+            continue;
+        }
+        const normalized = normalizeTier(rawTier);
+        if (normalized === "unknown") {
+            problems.push({
+                name: src.name,
+                path: src.path,
+                reason: "unrecognized",
+                rawTier,
+            });
+        }
+    }
+    return problems;
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const sources = discoverSkillSources(repoRoot);
+    const problems = checkSkillTiers(repoRoot);
+    if (problems.length === 0) {
+        console.log(`OK skill-tiers: all ${sources.length} skill source(s) declare a recognized tier.`);
+        exit(0);
+    }
+    console.error(`FAIL skill-tiers: ${problems.length} skill(s) with missing or unrecognized tier (out of ${sources.length} source(s)).\n`);
+    for (const p of problems) {
+        if (p.reason === "missing") {
+            console.error(`  - ${p.name}: no \`tier:\` field in frontmatter`);
+        }
+        else {
+            console.error(`  - ${p.name}: \`tier: ${p.rawTier ?? ""}\` is not a recognized value`);
+        }
+        console.error(`      file: ${p.path}`);
+    }
+    console.error("\nFix: add a `tier:` field to the source skill's YAML frontmatter. Recognized values: core, featured, \"1\", \"2\", companion. The generator uses this to group skills into the bundled README by tier; an untagged skill slides into the catch-all 'Other skills' bucket and is easy to miss in review.");
+    exit(1);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-tiers.mjs")) {
+    main();
+}

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lint": "node bin/lint-transcript.mjs --help",
     "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin test lib plugins",
     "verify:skill-mirror": "node bin/check-skill-mirror.mjs",
+    "verify:skill-tiers": "node bin/check-skill-tiers.mjs",
     "verify:docs-substrings": "node bin/check-docs-substrings.mjs"
   },
   "files": [

--- a/plugins/continuous-improvement/skills/continuous-improvement/SKILL.md
+++ b/plugins/continuous-improvement/skills/continuous-improvement/SKILL.md
@@ -1,5 +1,6 @@
 ---
 name: continuous-improvement
+tier: core
 description: "Install structured self-improvement loops with instinct-based learning into Claude Code — research, plan, execute, verify, reflect, learn, iterate. On-demand or weekly analysis to save tokens. Supports multi-agent parallel analysis."
 ---
 

--- a/src/bin/check-skill-tiers.mts
+++ b/src/bin/check-skill-tiers.mts
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Skill Tier Check
+ *
+ * Verifies that every source skill in skills/<name>.md (and the core
+ * SKILL.md at the repo root) declares a recognized `tier:` value in its
+ * YAML frontmatter. The generator groups skills into the bundled README
+ * by tier; an untagged skill silently slides into the "Other skills"
+ * bucket, which is easy to miss in review. This lint surfaces missing or
+ * unrecognized tiers as a hard failure.
+ *
+ * Recognized tier values (see src/lib/skill-tiers.mts):
+ *   "core" "featured" "1" "2" "companion"
+ *
+ * Usage:
+ *   node bin/check-skill-tiers.mjs              # Check the current repo
+ *   node bin/check-skill-tiers.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every source skill declares a recognized tier
+ *   1 — at least one skill is missing or has an unrecognized tier
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+import {
+  normalizeTier,
+  parseSkillFrontmatter,
+  type SkillTier,
+} from "../lib/skill-tiers.mjs";
+
+const SKILLS_DIR = "skills";
+const CORE_SKILL_FILE = "SKILL.md";
+const CORE_SKILL_NAME = "continuous-improvement";
+
+export type TierProblemReason = "missing" | "unrecognized";
+
+export interface TierProblem {
+  name: string;
+  path: string;
+  reason: TierProblemReason;
+  rawTier?: string;
+}
+
+interface SkillSource {
+  name: string;
+  path: string;
+}
+
+export function discoverSkillSources(repoRoot: string): SkillSource[] {
+  const out: SkillSource[] = [];
+
+  // Core skill (root SKILL.md) is always present and represents the
+  // continuous-improvement framework itself; treat it as a checked source.
+  const corePath = join(repoRoot, CORE_SKILL_FILE);
+  try {
+    statSync(corePath);
+    out.push({ name: CORE_SKILL_NAME, path: corePath });
+  } catch {
+    // No root SKILL.md — this is a misconfigured repo, but the lint should
+    // not error here; the skill-mirror lint covers that case.
+  }
+
+  const skillsDir = join(repoRoot, SKILLS_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsDir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    if (entry === "README.md") continue;
+    const fullPath = join(skillsDir, entry);
+    try {
+      const stat = statSync(fullPath);
+      if (!stat.isFile()) continue;
+    } catch {
+      continue;
+    }
+    out.push({ name: entry.replace(/\.md$/, ""), path: fullPath });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function checkSkillTiers(repoRoot: string): TierProblem[] {
+  const sources = discoverSkillSources(repoRoot);
+  const problems: TierProblem[] = [];
+  for (const src of sources) {
+    const content = readFileSync(src.path, "utf8");
+    const front = parseSkillFrontmatter(content);
+    const rawTier = front.tier;
+    if (!rawTier || rawTier.trim() === "") {
+      problems.push({ name: src.name, path: src.path, reason: "missing" });
+      continue;
+    }
+    const normalized: SkillTier = normalizeTier(rawTier);
+    if (normalized === "unknown") {
+      problems.push({
+        name: src.name,
+        path: src.path,
+        reason: "unrecognized",
+        rawTier,
+      });
+    }
+  }
+  return problems;
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const sources = discoverSkillSources(repoRoot);
+  const problems = checkSkillTiers(repoRoot);
+  if (problems.length === 0) {
+    console.log(
+      `OK skill-tiers: all ${sources.length} skill source(s) declare a recognized tier.`,
+    );
+    exit(0);
+  }
+  console.error(
+    `FAIL skill-tiers: ${problems.length} skill(s) with missing or unrecognized tier (out of ${sources.length} source(s)).\n`,
+  );
+  for (const p of problems) {
+    if (p.reason === "missing") {
+      console.error(`  - ${p.name}: no \`tier:\` field in frontmatter`);
+    } else {
+      console.error(
+        `  - ${p.name}: \`tier: ${p.rawTier ?? ""}\` is not a recognized value`,
+      );
+    }
+    console.error(`      file: ${p.path}`);
+  }
+  console.error(
+    "\nFix: add a `tier:` field to the source skill's YAML frontmatter. Recognized values: core, featured, \"1\", \"2\", companion. The generator uses this to group skills into the bundled README by tier; an untagged skill slides into the catch-all 'Other skills' bucket and is easy to miss in review.",
+  );
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-tiers.mjs")) {
+  main();
+}

--- a/src/test/check-skill-tiers.test.mts
+++ b/src/test/check-skill-tiers.test.mts
@@ -1,0 +1,185 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { checkSkillTiers, discoverSkillSources } from "../bin/check-skill-tiers.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-tiers.mjs");
+
+function setupRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "skill-tiers-test-"));
+  mkdirSync(join(root, "skills"), { recursive: true });
+  return root;
+}
+
+function writeCore(root: string, body: string): void {
+  writeFileSync(join(root, "SKILL.md"), body);
+}
+
+function writeSkill(root: string, name: string, body: string): void {
+  writeFileSync(join(root, "skills", `${name}.md`), body);
+}
+
+function frontmatter(fields: Record<string, string>): string {
+  const lines = ["---", ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`), "---", "", "# body", ""];
+  return lines.join("\n");
+}
+
+describe("check-skill-tiers — unit", () => {
+  it("returns no problems when every skill declares a recognized tier", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "featured" }));
+      writeSkill(root, "beta", frontmatter({ name: "beta", tier: '"1"' }));
+      writeSkill(root, "gamma", frontmatter({ name: "gamma", tier: '"2"' }));
+      writeSkill(root, "delta", frontmatter({ name: "delta", tier: "companion" }));
+      const problems = checkSkillTiers(root);
+      assert.equal(
+        problems.length,
+        0,
+        `expected zero problems, got: ${JSON.stringify(problems)}`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a skill with no `tier:` field as 'missing'", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeSkill(root, "alpha", frontmatter({ name: "alpha" })); // no tier key
+      const problems = checkSkillTiers(root);
+      assert.equal(problems.length, 1);
+      assert.equal(problems[0].name, "alpha");
+      assert.equal(problems[0].reason, "missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a skill with an unrecognized tier value as 'unrecognized'", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "premium" }));
+      const problems = checkSkillTiers(root);
+      assert.equal(problems.length, 1);
+      assert.equal(problems[0].name, "alpha");
+      assert.equal(problems[0].reason, "unrecognized");
+      assert.equal(problems[0].rawTier, "premium");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags the core SKILL.md when its tier is missing or unrecognized", () => {
+    const root = setupRepo();
+    try {
+      // Core has no tier
+      writeCore(root, frontmatter({ name: "continuous-improvement" }));
+      const problems = checkSkillTiers(root);
+      assert.equal(problems.length, 1);
+      assert.equal(problems[0].name, "continuous-improvement");
+      assert.equal(problems[0].reason, "missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores skills/README.md (it's a README, not a skill)", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeFileSync(
+        join(root, "skills", "README.md"),
+        "# README\n\nNo tier here, by design.\n",
+      );
+      const problems = checkSkillTiers(root);
+      assert.equal(problems.length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty source list when skills/ dir is missing and no root SKILL.md", () => {
+    const root = mkdtempSync(join(tmpdir(), "skill-tiers-empty-"));
+    try {
+      const sources = discoverSkillSources(root);
+      assert.equal(sources.length, 0);
+      const problems = checkSkillTiers(root);
+      assert.equal(problems.length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("accepts variants like 'tier1', 'TIER-2', 'FEATURED' via normalizeTier", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "FEATURED" }));
+      writeSkill(root, "beta", frontmatter({ name: "beta", tier: "tier1" }));
+      writeSkill(root, "gamma", frontmatter({ name: "gamma", tier: "tier-2" }));
+      const problems = checkSkillTiers(root);
+      assert.equal(
+        problems.length,
+        0,
+        `accepted variants should not flag: ${JSON.stringify(problems)}`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-skill-tiers — integration", () => {
+  it("CLI exits 0 with OK message on a clean synthetic repo", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "featured" }));
+      const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      assert.match(out, /OK skill-tiers: all 2 skill source\(s\) declare a recognized tier/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 with FAIL message when a skill is missing tier", () => {
+    const root = setupRepo();
+    try {
+      writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+      writeSkill(root, "alpha", frontmatter({ name: "alpha" })); // missing tier
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /FAIL skill-tiers: 1 skill\(s\)/);
+        assert.match(e.stderr ?? "", /no `tier:` field/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero when tier is missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies the live repo has zero tier problems", () => {
+    const problems = checkSkillTiers(REPO_ROOT);
+    assert.equal(
+      problems.length,
+      0,
+      `live repo has skill-tier problems: ${JSON.stringify(problems, null, 2)}`,
+    );
+  });
+});

--- a/test/check-skill-tiers.test.mjs
+++ b/test/check-skill-tiers.test.mjs
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { checkSkillTiers, discoverSkillSources } from "../bin/check-skill-tiers.mjs";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-tiers.mjs");
+function setupRepo() {
+    const root = mkdtempSync(join(tmpdir(), "skill-tiers-test-"));
+    mkdirSync(join(root, "skills"), { recursive: true });
+    return root;
+}
+function writeCore(root, body) {
+    writeFileSync(join(root, "SKILL.md"), body);
+}
+function writeSkill(root, name, body) {
+    writeFileSync(join(root, "skills", `${name}.md`), body);
+}
+function frontmatter(fields) {
+    const lines = ["---", ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`), "---", "", "# body", ""];
+    return lines.join("\n");
+}
+describe("check-skill-tiers — unit", () => {
+    it("returns no problems when every skill declares a recognized tier", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "featured" }));
+            writeSkill(root, "beta", frontmatter({ name: "beta", tier: '"1"' }));
+            writeSkill(root, "gamma", frontmatter({ name: "gamma", tier: '"2"' }));
+            writeSkill(root, "delta", frontmatter({ name: "delta", tier: "companion" }));
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 0, `expected zero problems, got: ${JSON.stringify(problems)}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a skill with no `tier:` field as 'missing'", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeSkill(root, "alpha", frontmatter({ name: "alpha" })); // no tier key
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 1);
+            assert.equal(problems[0].name, "alpha");
+            assert.equal(problems[0].reason, "missing");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a skill with an unrecognized tier value as 'unrecognized'", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "premium" }));
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 1);
+            assert.equal(problems[0].name, "alpha");
+            assert.equal(problems[0].reason, "unrecognized");
+            assert.equal(problems[0].rawTier, "premium");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags the core SKILL.md when its tier is missing or unrecognized", () => {
+        const root = setupRepo();
+        try {
+            // Core has no tier
+            writeCore(root, frontmatter({ name: "continuous-improvement" }));
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 1);
+            assert.equal(problems[0].name, "continuous-improvement");
+            assert.equal(problems[0].reason, "missing");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("ignores skills/README.md (it's a README, not a skill)", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeFileSync(join(root, "skills", "README.md"), "# README\n\nNo tier here, by design.\n");
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("returns empty source list when skills/ dir is missing and no root SKILL.md", () => {
+        const root = mkdtempSync(join(tmpdir(), "skill-tiers-empty-"));
+        try {
+            const sources = discoverSkillSources(root);
+            assert.equal(sources.length, 0);
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("accepts variants like 'tier1', 'TIER-2', 'FEATURED' via normalizeTier", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "FEATURED" }));
+            writeSkill(root, "beta", frontmatter({ name: "beta", tier: "tier1" }));
+            writeSkill(root, "gamma", frontmatter({ name: "gamma", tier: "tier-2" }));
+            const problems = checkSkillTiers(root);
+            assert.equal(problems.length, 0, `accepted variants should not flag: ${JSON.stringify(problems)}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+describe("check-skill-tiers — integration", () => {
+    it("CLI exits 0 with OK message on a clean synthetic repo", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: "featured" }));
+            const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            assert.match(out, /OK skill-tiers: all 2 skill source\(s\) declare a recognized tier/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 with FAIL message when a skill is missing tier", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({ name: "continuous-improvement", tier: "core" }));
+            writeSkill(root, "alpha", frontmatter({ name: "alpha" })); // missing tier
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /FAIL skill-tiers: 1 skill\(s\)/);
+                assert.match(e.stderr ?? "", /no `tier:` field/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero when tier is missing");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("verifies the live repo has zero tier problems", () => {
+        const problems = checkSkillTiers(REPO_ROOT);
+        assert.equal(problems.length, 0, `live repo has skill-tier problems: ${JSON.stringify(problems, null, 2)}`);
+    });
+});


### PR DESCRIPTION
## Summary

Closes the silent "## Other skills" gap from the tier-rendering generator added in `feat(skills): tier in frontmatter + generator-rendered tier table` (already on main). The bundled README groups skills by tier; an untagged skill would slide into a catch-all bucket without anyone noticing in code review. This lint fails the build when any source skill (`SKILL.md` or `skills/<name>.md`) is missing or has an unrecognized `tier:` value.

The lint caught a real problem on first run: the root `SKILL.md` was the only source that hadn't been tagged. Added `tier: core` in the same commit.

## What changed

- **`src/bin/check-skill-tiers.mts`** (new) — pure `checkSkillTiers(repoRoot)` helper for unit tests, plus a CLI `main()` that exits 0/1 with a clear failure message. Pattern-matches `src/bin/check-skill-mirror.mts`.
- **`src/test/check-skill-tiers.test.mts`** (new) — 10 tests: missing tier, unrecognized tier, ignored `README.md`, missing `skills/` dir, variant-spelling acceptance (`FEATURED`, `tier1`, `tier-2`), and CLI exit-code behavior on synthetic fixtures plus a live-repo no-drift assertion.
- **`package.json`** — adds `verify:skill-tiers` npm script alongside the existing `verify:skill-mirror` and `verify:docs-substrings` lints.
- **`SKILL.md`** — adds `tier: core` (caught by the lint).
- Generated mirror + `.mjs` siblings.

## Test plan

- [ ] `npm test` passes (228 → 238 tests; +10 from the new suite)
- [ ] `npm run verify:skill-tiers` exits 0: `OK skill-tiers: all 12 skill source(s) declare a recognized tier.`
- [ ] `npm run verify:skill-mirror` still clean (mirror updated)
- [ ] CLI surfaces clearly when a skill is intentionally untagged (manual: temporarily strip `tier:` from any skill, expect non-zero exit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)