### PR TITLE
feat(skills): add wild-risa-balance Tier-2 lens for split recommendation lists

### DIFF
--- a/.cloudplugin/marketplace.json
+++ b/.cloudplugin/marketplace.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "workspace-surface-audit",
-      "description": "Audit repo, MCP servers, plugins, and env surfaces to recommend ECC-native skills and workflows",
+      "description": "Audit repo, MCP servers, plugins, and env surfaces to recommend continuous-improvement-native skills and workflows",
       "file": "skills/workspace-surface-audit.md",
       "triggers": [
         "audit my workspace",
@@ -77,7 +77,7 @@
     },
     {
       "name": "workspace-surface-audit",
-      "description": "Audit workspace capabilities and recommend ECC-native skills"
+      "description": "Audit workspace capabilities and recommend continuous-improvement-native skills"
     },
     {
       "name": "ralph",

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Drop-in single-file skills, copy to `~/.claude/skills/<name>/SKILL.md`.
 |-------|--------------|--------|
 | `ralph` | Autonomous loop that executes a PRD story-by-story with quality checks between iterations | [snarktank/ralph](https://github.com/snarktank/ralph) |
 | `superpowers` | Activates task-appropriate skills automatically (brainstorming, git-worktrees, TDD, code review, etc.) | [obra/superpowers](https://github.com/obra/superpowers) |
-| `workspace-surface-audit` | Audits the active repo, MCP servers, plugins, and env, then recommends high-value skills/workflows | ECC |
+| `workspace-surface-audit` | Audits the active repo, MCP servers, plugins, and env, then recommends high-value skills/workflows | continuous-improvement |
 
 ### Plugin marketplace ([`plugins/`](plugins/))
 

--- a/commands/proceed-with-the-recommendation.md
+++ b/commands/proceed-with-the-recommendation.md
@@ -43,7 +43,7 @@ Invoke immediately after Claude has offered a numbered list of recommendations, 
 | `superpowers:writing-plans` | Plan breakdown when the list >3 items or >150 LOC |
 | `superpowers:*` | Per-item specialist routing (TDD, debugging, review, verification, parallel) |
 | `ralph` | Long-running PRD-style autonomous execution |
-| `simplify`, `security-review`, `documentation-lookup`, `schedule`, `loop`, `update-config`, `commit-commands:*` | ECC helpers |
+| `simplify`, `security-review`, `documentation-lookup`, `schedule`, `loop`, `update-config`, `commit-commands:*` | continuous-improvement helpers |
 
 If none of those are installed, the skill still works — every routing row has an inline fallback and every item still gets a verification step.
 

--- a/commands/workspace-surface-audit.md
+++ b/commands/workspace-surface-audit.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-surface-audit
-description: "Audit workspace capabilities and recommend ECC-native skills, hooks, and workflows"
+description: "Audit workspace capabilities and recommend continuous-improvement-native skills, hooks, and workflows"
 ---
 
 # /workspace-surface-audit
@@ -18,7 +18,7 @@ Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harne
 1. **Repo surface** — `package.json`, lockfiles, framework config, `.mcp.json`, `.claude/settings*.json`, `AGENTS.md`
 2. **Environment surface** — `.env*` files (key names only, no secrets)
 3. **Connected tools** — installed plugins, MCP servers, LSPs, app integrations
-4. **ECC surface** — existing skills, commands, hooks, agents
+4. **continuous-improvement surface** — existing skills, commands, hooks, agents
 
 ## Output Format
 
@@ -29,23 +29,23 @@ Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harne
 - [What is usable right now]
 
 ## Parity
-- [Where ECC matches or exceeds benchmarks]
+- [Where continuous-improvement matches or exceeds benchmarks]
 
 ## Primitive-Only Gaps
-- [Tools exist, but ECC lacks clean operator skills]
+- [Tools exist, but continuous-improvement lacks clean operator skills]
 
 ## Missing Integrations
 - [Capabilities not available yet]
 
 ## Top 3-5 Next Moves
-1. [Concrete ECC-native addition]
+1. [Concrete continuous-improvement-native addition]
 2. [Ordered by impact]
 ```
 
 ## Rules
 
 - **Never print secrets** — only provider names, capability names, file paths
-- **Prefer ECC-native** over generic "install another plugin" advice
+- **Prefer continuous-improvement** over generic "install another plugin" advice
 - **Organize by workflows**, not API brands
 - **Specific recommendations** — concrete enough to implement without another discovery pass
 

--- a/docs/plans/2026-04-28-rebrand-from-ecc.md
+++ b/docs/plans/2026-04-28-rebrand-from-ecc.md
@@ -38,8 +38,8 @@ No "Everything Claude Code" full-form references exist in source, so no full-for
 - `skills/tdd-workflow.md` (1 ref) + plugins mirror
 - `skills/verification-loop.md` (1 ref) + plugins mirror
 - `skills/wild-risa-balance.md` (1 ref) + plugins mirror
-- `skills/proceed-with-claude-recommendation.md` (1 ref) + plugins mirror
-- `commands/proceed-with-claude-recommendation.md` (1 ref) + plugins mirror
+- `skills/proceed-with-the-recommendation.md` (1 ref) + plugins mirror
+- `commands/proceed-with-the-recommendation.md` (1 ref) + plugins mirror
 - `skills/README.md` (1 ref) + plugins mirror
 - `docs/plans/2026-04-28-wild-risa-balance-skill.md` (1 ref)
 
@@ -51,7 +51,7 @@ Total: 25 files. The `skill-mirror` lint enforces that `skills/<name>.md` matche
 2. **C2 — workspace-surface-audit**: skill + command + 2 mirrors (4 files, 28 refs).
 3. **C3 — governance skills**: `safety-guard` + `gateguard` + 2 mirrors (4 files).
 4. **C4 — workflow skills**: `tdd-workflow` + `verification-loop` + `strategic-compact` + 3 mirrors (6 files).
-5. **C5 — meta + plans**: `proceed-with-claude-recommendation` skill + command + `wild-risa-balance` + `skills/README` + 4 mirrors + plan doc (9 files).
+5. **C5 — meta + plans**: `proceed-with-the-recommendation` skill + command + `wild-risa-balance` + `skills/README` + 4 mirrors + plan doc (9 files).
 
 ## Verification (per commit)
 

--- a/docs/plans/2026-04-28-rebrand-from-ecc.md
+++ b/docs/plans/2026-04-28-rebrand-from-ecc.md
@@ -1,0 +1,75 @@
+# Rebrand: drop "ECC" abbreviation, use `continuous-improvement` branding
+
+**Date:** 2026-04-28
+**Owner:** Naim Katiman
+**Status:** in progress
+
+## Why
+
+The "ECC" / "Everything Claude Code" abbreviation is the public branding of `https://github.com/affaan-m/everything-claude-code` (affaan-m's project). This repo (`https://github.com/naimkatiman/continuous-improvement`) currently borrows that branding in 25 source files and one public-facing marketplace manifest, which:
+
+1. Confuses users about provenance and affiliation.
+2. Implicitly suggests this repo is a fork or unofficial mirror of affaan-m's project.
+3. Advertises with a different project's brand under this repo's marketplace listing.
+
+## Replacement rules (mechanical, brand-preserving)
+
+| Pattern | Replacement |
+|---|---|
+| `origin: ECC` (frontmatter) | `origin: continuous-improvement` |
+| `ECC-native` | `continuous-improvement-native` |
+| `ECC` (standalone, brand context) | `continuous-improvement` |
+| `ECC 2.0` | `continuous-improvement v2` |
+| `the ECC hook` | `the continuous-improvement hook` |
+| `ECC helpers` | `continuous-improvement helpers` |
+| `adjacent ECC workspaces` | `adjacent continuous-improvement workspaces` |
+
+No "Everything Claude Code" full-form references exist in source, so no full-form replacement is needed.
+
+## Scope (excluding `node_modules/` and historical commit messages)
+
+- `README.md` (1 ref)
+- `.cloudplugin/marketplace.json` (2 refs)
+- `skills/workspace-surface-audit.md` (22 refs) + plugins mirror
+- `commands/workspace-surface-audit.md` (6 refs) + plugins mirror
+- `skills/safety-guard.md` (2 refs) + plugins mirror
+- `skills/gateguard.md` (1 ref) + plugins mirror
+- `skills/strategic-compact.md` (1 ref) + plugins mirror
+- `skills/tdd-workflow.md` (1 ref) + plugins mirror
+- `skills/verification-loop.md` (1 ref) + plugins mirror
+- `skills/wild-risa-balance.md` (1 ref) + plugins mirror
+- `skills/proceed-with-claude-recommendation.md` (1 ref) + plugins mirror
+- `commands/proceed-with-claude-recommendation.md` (1 ref) + plugins mirror
+- `skills/README.md` (1 ref) + plugins mirror
+- `docs/plans/2026-04-28-wild-risa-balance-skill.md` (1 ref)
+
+Total: 25 files. The `skill-mirror` lint enforces that `skills/<name>.md` matches `plugins/continuous-improvement/skills/<name>/SKILL.md` byte-for-byte (front-matter aside), so each rename must land in both trees in the same commit.
+
+## Commit split (each commit one concern, ≤15 files)
+
+1. **C1 — Public face**: `README.md` + `.cloudplugin/marketplace.json` (2 files).
+2. **C2 — workspace-surface-audit**: skill + command + 2 mirrors (4 files, 28 refs).
+3. **C3 — governance skills**: `safety-guard` + `gateguard` + 2 mirrors (4 files).
+4. **C4 — workflow skills**: `tdd-workflow` + `verification-loop` + `strategic-compact` + 3 mirrors (6 files).
+5. **C5 — meta + plans**: `proceed-with-claude-recommendation` skill + command + `wild-risa-balance` + `skills/README` + 4 mirrors + plan doc (9 files).
+
+## Verification (per commit)
+
+After each commit:
+
+```bash
+grep -rn "ECC\b\|Everything Claude Code" --include="*.md" --include="*.json" \
+  d:/Ai/continuous-improvement \
+  | grep -v node_modules \
+  | grep -v "docs/plans/2026-04-28-rebrand-from-ecc.md"
+```
+
+Expected: zero hits in the files included in that commit's scope. Remaining hits roll forward into the next commit.
+
+After the final commit, the entire repo (excluding `node_modules` and this plan doc) should produce zero hits.
+
+## Out of scope
+
+- Git commit message history. Old commits with `ECC` in subject lines stay untouched. Rewriting public history is high-blast-radius for negligible benefit.
+- Any reference inside `node_modules/`. Vendor code.
+- This plan doc itself (which intentionally documents the old term to explain the rebrand).

--- a/docs/plans/2026-04-28-wild-risa-balance-skill.md
+++ b/docs/plans/2026-04-28-wild-risa-balance-skill.md
@@ -1,0 +1,55 @@
+---
+title: WILD/RISA balance skill
+date: 2026-04-28
+slug: wild-risa-balance-skill
+status: done
+branch: feat/wild-risa-skill
+---
+
+# WILD/RISA balance skill
+
+## Goal
+
+Add a Tier-2 companion skill named `wild-risa-balance` that gives the agent a deliberate switch between two opposing decision modes:
+
+- **RISA (Execution)** — Realistic, Important, Specific, Agreeable. Safe, average, ships.
+- **WILD (Creation)** — Wild, Imaginative, Limitless, Disruptive. Cool ideas that often never ship.
+
+The skill is a thinking lens, not a runtime hook. It is referenced by `proceed-with-claude-recommendation` and any session that emits a multi-item recommendation block, so the agent can split items WILD-on-top / RISA-on-bottom and route them differently.
+
+## WILL build
+
+1. New source skill file: `skills/wild-risa-balance.md`.
+   - YAML frontmatter: `name`, `tier: "2"`, `description`, `origin: ECC`.
+   - Body sections (in order): `When to Use`, `The Two Modes`, `The Trap`, `Switching Deliberately`, `How to Apply in a Recommendation List`, `Integration with the 7 Laws`, `Example`, `Related`.
+   - Length budget: 80–150 lines. No code samples beyond a small markdown example block.
+2. Update `skills/README.md` Tier 2 table to add a row for `wild-risa-balance` with a one-line description and a "When it pays off" cell.
+3. Regenerate the bundled plugin manifest by running `npm run build`. This rewrites `plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md` and the bundled-skills README from the source files.
+
+## WILL NOT build
+
+- No new hook. The 3-section close hook stays unchanged.
+- No edit to `skills/proceed-with-claude-recommendation.md`. A future PR can add a "consult `wild-risa-balance`" line; this PR is content-only.
+- No edit to `commands/discipline.md`. The 7 Laws card stays as-is.
+- No new MCP tool, command, or `bin/` script.
+- No change to `bin/check-skill-tiers.mjs` or its test (the new skill must satisfy the existing tier check, not require a new one).
+- No commit on `main`. Work stays on `feat/wild-risa-skill`.
+- No push or PR. User authorizes those separately.
+
+## Verification
+
+1. `node bin/check-skill-tiers.mjs` exits 0 and lists the new skill source.
+2. `npm test` passes (build + node --test on every test file).
+3. `npm run verify:generated` passes — meaning the regenerated bundle in `plugins/continuous-improvement` is committed alongside the source so CI does not flag drift.
+4. Manual diff check: every file changed lives under `skills/`, `plugins/continuous-improvement/skills/`, or `docs/plans/`. No drive-by edits elsewhere.
+5. The new skill renders correctly in `plugins/continuous-improvement/skills/README.md` under "Tier 2 — expert-mode add-ons".
+
+## Fallback
+
+If the build fails or tests break, revert the new skill file and the README row, leaving only the plan doc on the branch as a record of the attempt. Do not paper over a build error by hand-editing the generated bundle.
+
+## Out of scope (deferred)
+
+- WILD/RISA tagging requirement inside `proceed-with-claude-recommendation` execution loop (Option B from the prior turn).
+- Mandatory WILD/RISA split in the 3-section close hook (Option C from the prior turn).
+- Both deferred until at least three sessions of evidence that the vocabulary actually changes outcomes.

--- a/docs/plans/2026-04-28-wild-risa-balance-skill.md
+++ b/docs/plans/2026-04-28-wild-risa-balance-skill.md
@@ -15,7 +15,7 @@ Add a Tier-2 companion skill named `wild-risa-balance` that gives the agent a de
 - **RISA (Execution)** — Realistic, Important, Specific, Agreeable. Safe, average, ships.
 - **WILD (Creation)** — Wild, Imaginative, Limitless, Disruptive. Cool ideas that often never ship.
 
-The skill is a thinking lens, not a runtime hook. It is referenced by `proceed-with-claude-recommendation` and any session that emits a multi-item recommendation block, so the agent can split items WILD-on-top / RISA-on-bottom and route them differently.
+The skill is a thinking lens, not a runtime hook. It is referenced by `proceed-with-the-recommendation` and any session that emits a multi-item recommendation block, so the agent can split items WILD-on-top / RISA-on-bottom and route them differently.
 
 ## WILL build
 
@@ -29,7 +29,7 @@ The skill is a thinking lens, not a runtime hook. It is referenced by `proceed-w
 ## WILL NOT build
 
 - No new hook. The 3-section close hook stays unchanged.
-- No edit to `skills/proceed-with-claude-recommendation.md`. A future PR can add a "consult `wild-risa-balance`" line; this PR is content-only.
+- No edit to `skills/proceed-with-the-recommendation.md`. A future PR can add a "consult `wild-risa-balance`" line; this PR is content-only.
 - No edit to `commands/discipline.md`. The 7 Laws card stays as-is.
 - No new MCP tool, command, or `bin/` script.
 - No change to `bin/check-skill-tiers.mjs` or its test (the new skill must satisfy the existing tier check, not require a new one).
@@ -50,6 +50,6 @@ If the build fails or tests break, revert the new skill file and the README row,
 
 ## Out of scope (deferred)
 
-- WILD/RISA tagging requirement inside `proceed-with-claude-recommendation` execution loop (Option B from the prior turn).
+- WILD/RISA tagging requirement inside `proceed-with-the-recommendation` execution loop (Option B from the prior turn).
 - Mandatory WILD/RISA split in the 3-section close hook (Option C from the prior turn).
 - Both deferred until at least three sessions of evidence that the vocabulary actually changes outcomes.

--- a/docs/plans/2026-04-28-wild-risa-balance-skill.md
+++ b/docs/plans/2026-04-28-wild-risa-balance-skill.md
@@ -20,7 +20,7 @@ The skill is a thinking lens, not a runtime hook. It is referenced by `proceed-w
 ## WILL build
 
 1. New source skill file: `skills/wild-risa-balance.md`.
-   - YAML frontmatter: `name`, `tier: "2"`, `description`, `origin: ECC`.
+   - YAML frontmatter: `name`, `tier: "2"`, `description`, `origin: continuous-improvement`.
    - Body sections (in order): `When to Use`, `The Two Modes`, `The Trap`, `Switching Deliberately`, `How to Apply in a Recommendation List`, `Integration with the 7 Laws`, `Example`, `Related`.
    - Length budget: 80–150 lines. No code samples beyond a small markdown example block.
 2. Update `skills/README.md` Tier 2 table to add a row for `wild-risa-balance` with a one-line description and a "When it pays off" cell.

--- a/plugins/continuous-improvement/commands/proceed-with-the-recommendation.md
+++ b/plugins/continuous-improvement/commands/proceed-with-the-recommendation.md
@@ -43,7 +43,7 @@ Invoke immediately after Claude has offered a numbered list of recommendations, 
 | `superpowers:writing-plans` | Plan breakdown when the list >3 items or >150 LOC |
 | `superpowers:*` | Per-item specialist routing (TDD, debugging, review, verification, parallel) |
 | `ralph` | Long-running PRD-style autonomous execution |
-| `simplify`, `security-review`, `documentation-lookup`, `schedule`, `loop`, `update-config`, `commit-commands:*` | ECC helpers |
+| `simplify`, `security-review`, `documentation-lookup`, `schedule`, `loop`, `update-config`, `commit-commands:*` | continuous-improvement helpers |
 
 If none of those are installed, the skill still works — every routing row has an inline fallback and every item still gets a verification step.
 

--- a/plugins/continuous-improvement/commands/workspace-surface-audit.md
+++ b/plugins/continuous-improvement/commands/workspace-surface-audit.md
@@ -1,6 +1,6 @@
 ---
 name: workspace-surface-audit
-description: "Audit workspace capabilities and recommend ECC-native skills, hooks, and workflows"
+description: "Audit workspace capabilities and recommend continuous-improvement-native skills, hooks, and workflows"
 ---
 
 # /workspace-surface-audit
@@ -18,7 +18,7 @@ Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harne
 1. **Repo surface** — `package.json`, lockfiles, framework config, `.mcp.json`, `.claude/settings*.json`, `AGENTS.md`
 2. **Environment surface** — `.env*` files (key names only, no secrets)
 3. **Connected tools** — installed plugins, MCP servers, LSPs, app integrations
-4. **ECC surface** — existing skills, commands, hooks, agents
+4. **continuous-improvement surface** — existing skills, commands, hooks, agents
 
 ## Output Format
 
@@ -29,23 +29,23 @@ Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harne
 - [What is usable right now]
 
 ## Parity
-- [Where ECC matches or exceeds benchmarks]
+- [Where continuous-improvement matches or exceeds benchmarks]
 
 ## Primitive-Only Gaps
-- [Tools exist, but ECC lacks clean operator skills]
+- [Tools exist, but continuous-improvement lacks clean operator skills]
 
 ## Missing Integrations
 - [Capabilities not available yet]
 
 ## Top 3-5 Next Moves
-1. [Concrete ECC-native addition]
+1. [Concrete continuous-improvement-native addition]
 2. [Ordered by impact]
 ```
 
 ## Rules
 
 - **Never print secrets** — only provider names, capability names, file paths
-- **Prefer ECC-native** over generic "install another plugin" advice
+- **Prefer continuous-improvement** over generic "install another plugin" advice
 - **Organize by workflows**, not API brands
 - **Specific recommendations** — concrete enough to implement without another discovery pass
 

--- a/plugins/continuous-improvement/skills/README.md
+++ b/plugins/continuous-improvement/skills/README.md
@@ -25,6 +25,7 @@ skill set on disk.
 - `safety-guard` — Use this skill to prevent destructive operations when working on production systems or running agents autonomously.
 - `strategic-compact` — Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction.
 - `token-budget-advisor` — Offers the user an informed choice about how much response depth to consume before answering. Use this skill when the user explicitly wants to control response length, depth, or token budget. TRIGGER when: "token budget", "token count", "token usage", "token limit", "response length", "answer depth", "short version", "brief answer", "detailed answer", "exhaustive answer", "respuesta corta vs larga", "cuántos tokens", "ahorrar tokens", "responde al 50%", "dame la versión corta", "quiero controlar cuánto usas", or clear variants where the user is explicitly asking to control answer size or depth. DO NOT TRIGGER when: user has already specified a level in the current session (maintain it), the request is clearly a one-word answer, or "token" refers to auth/session/payment tokens rather than response size.
+- `wild-risa-balance` — Decision-framing lens that pairs WILD generation with RISA execution when emitting recommendation lists. Not a runtime hook.
 
 ## Always-bundled companions
 - `ralph` — Ralph is an autonomous AI agent loop that runs repeatedly until all PRD items are complete. Converts PRDs to executable JSON, implements stories iteratively with quality checks, and tracks progress.

--- a/plugins/continuous-improvement/skills/README.md
+++ b/plugins/continuous-improvement/skills/README.md
@@ -30,4 +30,4 @@ skill set on disk.
 ## Always-bundled companions
 - `ralph` — Ralph is an autonomous AI agent loop that runs repeatedly until all PRD items are complete. Converts PRDs to executable JSON, implements stories iteratively with quality checks, and tracks progress.
 - `superpowers` — Agentic skills framework with mandatory workflows. Activates skills automatically before tasks: brainstorming, git-worktrees, writing-plans, test-driven-development, code-review, and more.
-- `workspace-surface-audit` — Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value ECC-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment.
+- `workspace-surface-audit` — Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value continuous-improvement-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment.

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -90,7 +90,7 @@ Quote the user's current instruction verbatim.
 
 ## Quick Start
 
-### Option A: Use the ECC hook (zero install)
+### Option A: Use the continuous-improvement hook (zero install)
 
 The hook at `scripts/hooks/gateguard-fact-force.js` is included in this plugin. Enable it via hooks.json.
 

--- a/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
+++ b/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
@@ -9,7 +9,7 @@ origin: https://github.com/naimkatiman/continuous-improvement
 
 ## Overview
 
-One reusable skill that ties the continuous-improvement framework to a concrete execution engine. When the user greenlights a list of recommendations, this skill walks them in order under the **7 Laws**, routes each item to the best companion (`workspace-surface-audit`, `superpowers:*`, `ralph`, ECC helpers), and falls back to explicit inline behavior when a companion is not installed. Never silent no-op, never drive-by, never skip verification.
+One reusable skill that ties the continuous-improvement framework to a concrete execution engine. When the user greenlights a list of recommendations, this skill walks them in order under the **7 Laws**, routes each item to the best companion (`workspace-surface-audit`, `superpowers:*`, `ralph`, continuous-improvement helpers), and falls back to explicit inline behavior when a companion is not installed. Never silent no-op, never drive-by, never skip verification.
 
 Core principle: **execute in order, one concern at a time, verify before advancing, reflect at the end.**
 

--- a/plugins/continuous-improvement/skills/safety-guard/SKILL.md
+++ b/plugins/continuous-improvement/skills/safety-guard/SKILL.md
@@ -2,7 +2,7 @@
 name: safety-guard
 tier: "2"
 description: Use this skill to prevent destructive operations when working on production systems or running agents autonomously.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Safety Guard — Prevent Destructive Operations
@@ -72,5 +72,5 @@ Uses PreToolUse hooks to intercept Bash, Write, Edit, and MultiEdit tool calls. 
 ## Integration
 
 - Enable by default for `codex -a never` sessions
-- Pair with observability risk scoring in ECC 2.0
+- Pair with observability risk scoring in continuous-improvement v2
 - Logs all blocked actions to `~/.claude/safety-guard.log`

--- a/plugins/continuous-improvement/skills/strategic-compact/SKILL.md
+++ b/plugins/continuous-improvement/skills/strategic-compact/SKILL.md
@@ -2,7 +2,7 @@
 name: strategic-compact
 tier: "2"
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Strategic Compact Skill

--- a/plugins/continuous-improvement/skills/tdd-workflow/SKILL.md
+++ b/plugins/continuous-improvement/skills/tdd-workflow/SKILL.md
@@ -2,7 +2,7 @@
 name: tdd-workflow
 tier: "1"
 description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Test-Driven Development Workflow

--- a/plugins/continuous-improvement/skills/verification-loop/SKILL.md
+++ b/plugins/continuous-improvement/skills/verification-loop/SKILL.md
@@ -2,7 +2,7 @@
 name: verification-loop
 tier: "1"
 description: "A comprehensive verification system for Claude Code sessions."
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Verification Loop Skill

--- a/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
+++ b/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
@@ -2,7 +2,7 @@
 name: wild-risa-balance
 tier: "2"
 description: Decision-framing lens that pairs WILD generation with RISA execution when emitting recommendation lists. Not a runtime hook.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # WILD / RISA Balance

--- a/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
+++ b/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
@@ -12,7 +12,7 @@ origin: continuous-improvement
 - Emitting a multi-item recommendation block (≥3 items)
 - Choosing between a safe option and a bold option
 - Reviewing your own plan for over-cautiousness or over-fantasy
-- Pairing with `proceed-with-claude-recommendation` to decide which items belong above and below the cut
+- Pairing with `proceed-with-the-recommendation` to decide which items belong above and below the cut
 
 ## The Two Modes
 
@@ -58,7 +58,7 @@ When emitting ≥3 recommendations, split them:
 1. **Top block — WILD pilots.** 1–2 bold items. Present every item; the operator picks at most one to actually run.
 2. **Bottom block — RISA baseline.** The safe items that ship now regardless of the WILD bet.
 3. Within each block, rank descending by impact.
-4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-claude-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
+4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-the-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
 
 The point: the operator gets one bold option to weigh against a baseline they already trust, instead of a flat list where the bold option silently competes with safe ones and loses by default.
 
@@ -88,6 +88,6 @@ RISA baseline — ship regardless
 ## Related
 
 - `continuous-improvement` — the 7 Laws card (core skill)
-- `proceed-with-claude-recommendation` — execution arm
+- `proceed-with-the-recommendation` — execution arm
 - `superpowers:brainstorming` — upstream WILD generator
 - `verification-loop` — downstream RISA verifier

--- a/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
+++ b/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: wild-risa-balance
+tier: "2"
+description: Decision-framing lens that pairs WILD generation with RISA execution when emitting recommendation lists. Not a runtime hook.
+origin: ECC
+---
+
+# WILD / RISA Balance
+
+## When to Use
+
+- Emitting a multi-item recommendation block (≥3 items)
+- Choosing between a safe option and a bold option
+- Reviewing your own plan for over-cautiousness or over-fantasy
+- Pairing with `proceed-with-claude-recommendation` to decide which items belong above and below the cut
+
+## The Two Modes
+
+### RISA (Execution)
+
+- **R**ealistic — fits the constraints in front of you
+- **I**mportant — moves a stated goal, not a vanity metric
+- **S**pecific — names files, commands, or owners
+- **A**greeable — the operator can approve it without a meeting
+
+If you only stay in RISA, you ship safe, average results.
+
+### WILD (Creation)
+
+- **W**ild — breaks the default frame
+- **I**maginative — invents an option that did not exist a minute ago
+- **L**imitless — ignores current budget, headcount, or stack
+- **D**isruptive — replaces a workflow rather than tuning it
+
+If you only stay in WILD, you generate cool ideas that never ship.
+
+## The Trap
+
+RISA alone produces a backlog of incremental fixes that never compound. WILD alone produces a graveyard of demos that never reach production. The bigger failure is unconscious switching: drifting into WILD during execution, or drifting into RISA during brainstorming, without naming the switch. Name the mode you are in before you write the next line.
+
+## Switching Deliberately
+
+| Phase                   | Mode  | Why                                                |
+|-------------------------|-------|----------------------------------------------------|
+| Brainstorm              | WILD  | Quantity and range beat early filtering            |
+| Roadmap framing         | WILD  | Frame the bigger bet before scoping it down        |
+| Per-item recommendation | Mixed | Top items can be WILD, baseline items must be RISA |
+| Per-item execution      | RISA  | One thing, verified, shipped                       |
+| Verification            | RISA  | Reality check, no new invention                    |
+| Reflection              | WILD  | Counterfactuals, "what would have been bolder"     |
+
+WILD owns generation phases. RISA owns execution phases. The switch is intentional, not accidental.
+
+## How to Apply in a Recommendation List
+
+When emitting ≥3 recommendations, split them:
+
+1. **Top block — WILD pilots.** 1–2 bold items. Present every item; the operator picks at most one to actually run.
+2. **Bottom block — RISA baseline.** The safe items that ship now regardless of the WILD bet.
+3. Within each block, rank descending by impact.
+4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-claude-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
+
+The point: the operator gets one bold option to weigh against a baseline they already trust, instead of a flat list where the bold option silently competes with safe ones and loses by default.
+
+## Integration with the 7 Laws
+
+| Mode | Reinforces                                              | Tempered by              |
+|------|---------------------------------------------------------|--------------------------|
+| RISA | Law 2 (Plan), Law 3 (One Thing), Law 4 (Verify)         | Law 6 (Iterate One Thing) |
+| WILD | Law 1 (Research — broader exploration), Law 5 (Reflect) | Law 6 (Iterate One Thing) |
+
+Both modes pass through Law 6 before execution. WILD without Law 6 is a wishlist. RISA without Law 6 ships safe fixes while the real bottleneck waits.
+
+## Example
+
+```
+Recommendations (descending impact within each block)
+
+WILD pilots — pick at most one
+1. Replace the current review workflow with a single adversarial pair.
+2. Drop the staging environment in favor of feature-flagged production.
+
+RISA baseline — ship regardless
+1. Add the missing test for the failure path noted in verification.
+2. Rename the ambiguous flag to match its actual behavior.
+```
+
+## Related
+
+- `continuous-improvement` — the 7 Laws card (core skill)
+- `proceed-with-claude-recommendation` — execution arm
+- `superpowers:brainstorming` — upstream WILD generator
+- `verification-loop` — downstream RISA verifier

--- a/plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md
+++ b/plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md
@@ -1,32 +1,32 @@
 ---
 name: workspace-surface-audit
 tier: companion
-description: "Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value ECC-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment."
-origin: ECC
+description: "Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value continuous-improvement-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment."
+origin: continuous-improvement
 ---
 
 # Workspace Surface Audit
 
 Read-only audit skill for answering the question "what can this workspace and machine actually do right now, and what should we add or enable next?"
 
-This is the ECC-native answer to setup-audit plugins. It does not modify files unless the user explicitly asks for follow-up implementation.
+This is the continuous-improvement answer to setup-audit plugins. It does not modify files unless the user explicitly asks for follow-up implementation.
 
 ## When to Use
 
 - User says "set up Claude Code", "recommend automations", "what plugins or MCPs should I use?", or "what am I missing?"
 - Auditing a machine or repo before installing more skills, hooks, or connectors
-- Comparing official marketplace plugins against ECC-native coverage
+- Comparing official marketplace plugins against continuous-improvement coverage
 - Reviewing `.env`, `.mcp.json`, plugin settings, or connected-app surfaces to find missing workflow layers
 - Deciding whether a capability should be a skill, hook, agent, MCP, or external connector
 
 ## Non-Negotiable Rules
 
 - Never print secret values. Surface only provider names, capability names, file paths, and whether a key or config exists.
-- Prefer ECC-native workflows over generic "install another plugin" advice when ECC can reasonably own the surface.
+- Prefer continuous-improvement workflows over generic "install another plugin" advice when continuous-improvement can reasonably own the surface.
 - Treat external plugins as benchmarks and inspiration, not authoritative product boundaries.
 - Separate three things clearly:
   - already available now
-  - available but not wrapped well in ECC
+  - available but not wrapped well in continuous-improvement
   - not available and would require a new integration
 
 ## Audit Inputs
@@ -38,11 +38,11 @@ Inspect only the files and settings needed to answer the question well:
    - `.mcp.json`, `.lsp.json`, `.claude/settings*.json`, `.codex/*`
    - `AGENTS.md`, `CLAUDE.md`, install manifests, hook configs
 2. **Environment surface**
-   - `.env*` files in the active repo and obvious adjacent ECC workspaces
+   - `.env*` files in the active repo and obvious adjacent continuous-improvement workspaces
    - Surface only key names such as `STRIPE_API_KEY`, `TWILIO_AUTH_TOKEN`, `FAL_KEY`
 3. **Connected tool surface**
    - Installed plugins, enabled connectors, MCP servers, LSPs, and app integrations
-4. **ECC surface**
+4. **continuous-improvement surface**
    - Existing skills, commands, hooks, agents, and install modules that already cover the need
 
 ## Audit Process
@@ -56,12 +56,12 @@ Produce a compact inventory:
 - configured MCP servers
 - configured LSP servers
 - env-backed services implied by key names
-- existing ECC skills already relevant to the workspace
+- existing continuous-improvement skills already relevant to the workspace
 
 If a surface exists only as a primitive, call that out. Example:
 
-- "Stripe is available via connected app, but ECC lacks a billing-operator skill"
-- "Google Drive is connected, but there is no ECC-native Google Workspace operator workflow"
+- "Stripe is available via connected app, but continuous-improvement lacks a billing-operator skill"
+- "Google Drive is connected, but there is no continuous-improvement-native Google Workspace operator workflow"
 
 ### Phase 2: Benchmark Against Official and Installed Surfaces
 
@@ -74,15 +74,15 @@ Compare the workspace against:
 Do not just list names. For each comparison, answer:
 
 1. what they actually do
-2. whether ECC already has parity
-3. whether ECC only has primitives
-4. whether ECC is missing the workflow entirely
+2. whether continuous-improvement already has parity
+3. whether continuous-improvement only has primitives
+4. whether continuous-improvement is missing the workflow entirely
 
-### Phase 3: Turn Gaps Into ECC Decisions
+### Phase 3: Turn Gaps Into continuous-improvement Decisions
 
-For every real gap, recommend the correct ECC-native shape:
+For every real gap, recommend the correct continuous-improvement-native shape:
 
-| Gap Type | Preferred ECC Shape |
+| Gap Type | Preferred continuous-improvement Shape |
 |----------|---------------------|
 | Repeatable operator workflow | Skill |
 | Automatic enforcement or side-effect | Hook |
@@ -97,10 +97,10 @@ Default to user-facing skills that orchestrate existing tools when the need is o
 Return five sections in this order:
 
 1. **Current surface** — what is already usable right now
-2. **Parity** — where ECC already matches or exceeds the benchmark
-3. **Primitive-only gaps** — tools exist, but ECC lacks a clean operator skill
+2. **Parity** — where continuous-improvement already matches or exceeds the benchmark
+3. **Primitive-only gaps** — tools exist, but continuous-improvement lacks a clean operator skill
 4. **Missing integrations** — capability not available yet
-5. **Top 3-5 next moves** — concrete ECC-native additions, ordered by impact
+5. **Top 3-5 next moves** — concrete continuous-improvement-native additions, ordered by impact
 
 ## Recommendation Rules
 
@@ -112,10 +112,10 @@ Return five sections in this order:
   - Google Workspace ops
   - deployment/ops control
 - If a connector is company-specific, recommend it only when it is genuinely available or clearly useful to the user's workflow.
-- If ECC already has a strong primitive, propose a wrapper skill instead of inventing a brand-new subsystem.
+- If continuous-improvement already has a strong primitive, propose a wrapper skill instead of inventing a brand-new subsystem.
 
 ## Good Outcomes
 
-- The user can immediately see what is connected, what is missing, and what ECC should own next.
+- The user can immediately see what is connected, what is missing, and what continuous-improvement should own next.
 - Recommendations are specific enough to implement in the repo without another discovery pass.
 - The final answer is organized around workflows, not API brands.

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,7 +44,7 @@ These ship in the same plugin bundle regardless of mode and are available the mo
 |-------|--------------|--------|
 | `ralph` | Autonomous loop that executes a PRD story-by-story with quality checks between iterations | [snarktank/ralph](https://github.com/snarktank/ralph) |
 | `superpowers` | Activates task-appropriate skills automatically (brainstorming, git-worktrees, TDD, code review, etc.) | [obra/superpowers](https://github.com/obra/superpowers) |
-| `workspace-surface-audit` | Audits the active repo, MCP servers, plugins, and env, then recommends high-value skills/workflows | ECC |
+| `workspace-surface-audit` | Audits the active repo, MCP servers, plugins, and env, then recommends high-value skills/workflows | continuous-improvement |
 
 ## How they get to your machine
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -32,6 +32,7 @@ Tier-2 skills layer on top of tier-1 for users running `npx continuous-improveme
 | `safety-guard` | Three-mode runtime guard (careful/freeze/guard) that blocks destructive commands and locks edits to a directory | Autonomous loops, prod systems, `--dangerously-skip-permissions` sessions |
 | `token-budget-advisor` | Heuristic input/output token estimator that offers 25%/50%/75%/100% depth choices before answering | Long sessions where response size matters |
 | `strategic-compact` | PreToolUse hook that suggests `/compact` at logical phase boundaries (research→plan, plan→implement, debug→next) instead of arbitrary auto-compaction | Multi-phase tasks that approach context limits |
+| `wild-risa-balance` | Decision-framing lens that pairs WILD (Wild/Imaginative/Limitless/Disruptive) generation with RISA (Realistic/Important/Specific/Agreeable) execution, used to split recommendation lists into bold pilots above a safe baseline | Multi-item recommendation blocks where bold options keep losing to safe ones in a flat list |
 
 The `/learn-eval` slash command also ships as part of the expert install: extract a session pattern, run a checklist quality gate, and decide global-vs-project save location before writing any skill file.
 

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -90,7 +90,7 @@ Quote the user's current instruction verbatim.
 
 ## Quick Start
 
-### Option A: Use the ECC hook (zero install)
+### Option A: Use the continuous-improvement hook (zero install)
 
 The hook at `scripts/hooks/gateguard-fact-force.js` is included in this plugin. Enable it via hooks.json.
 

--- a/skills/proceed-with-the-recommendation.md
+++ b/skills/proceed-with-the-recommendation.md
@@ -9,7 +9,7 @@ origin: https://github.com/naimkatiman/continuous-improvement
 
 ## Overview
 
-One reusable skill that ties the continuous-improvement framework to a concrete execution engine. When the user greenlights a list of recommendations, this skill walks them in order under the **7 Laws**, routes each item to the best companion (`workspace-surface-audit`, `superpowers:*`, `ralph`, ECC helpers), and falls back to explicit inline behavior when a companion is not installed. Never silent no-op, never drive-by, never skip verification.
+One reusable skill that ties the continuous-improvement framework to a concrete execution engine. When the user greenlights a list of recommendations, this skill walks them in order under the **7 Laws**, routes each item to the best companion (`workspace-surface-audit`, `superpowers:*`, `ralph`, continuous-improvement helpers), and falls back to explicit inline behavior when a companion is not installed. Never silent no-op, never drive-by, never skip verification.
 
 Core principle: **execute in order, one concern at a time, verify before advancing, reflect at the end.**
 

--- a/skills/safety-guard.md
+++ b/skills/safety-guard.md
@@ -2,7 +2,7 @@
 name: safety-guard
 tier: "2"
 description: Use this skill to prevent destructive operations when working on production systems or running agents autonomously.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Safety Guard — Prevent Destructive Operations
@@ -72,5 +72,5 @@ Uses PreToolUse hooks to intercept Bash, Write, Edit, and MultiEdit tool calls. 
 ## Integration
 
 - Enable by default for `codex -a never` sessions
-- Pair with observability risk scoring in ECC 2.0
+- Pair with observability risk scoring in continuous-improvement v2
 - Logs all blocked actions to `~/.claude/safety-guard.log`

--- a/skills/strategic-compact.md
+++ b/skills/strategic-compact.md
@@ -2,7 +2,7 @@
 name: strategic-compact
 tier: "2"
 description: Suggests manual context compaction at logical intervals to preserve context through task phases rather than arbitrary auto-compaction.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Strategic Compact Skill

--- a/skills/tdd-workflow.md
+++ b/skills/tdd-workflow.md
@@ -2,7 +2,7 @@
 name: tdd-workflow
 tier: "1"
 description: Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Test-Driven Development Workflow

--- a/skills/verification-loop.md
+++ b/skills/verification-loop.md
@@ -2,7 +2,7 @@
 name: verification-loop
 tier: "1"
 description: "A comprehensive verification system for Claude Code sessions."
-origin: ECC
+origin: continuous-improvement
 ---
 
 # Verification Loop Skill

--- a/skills/wild-risa-balance.md
+++ b/skills/wild-risa-balance.md
@@ -2,7 +2,7 @@
 name: wild-risa-balance
 tier: "2"
 description: Decision-framing lens that pairs WILD generation with RISA execution when emitting recommendation lists. Not a runtime hook.
-origin: ECC
+origin: continuous-improvement
 ---
 
 # WILD / RISA Balance

--- a/skills/wild-risa-balance.md
+++ b/skills/wild-risa-balance.md
@@ -12,7 +12,7 @@ origin: continuous-improvement
 - Emitting a multi-item recommendation block (≥3 items)
 - Choosing between a safe option and a bold option
 - Reviewing your own plan for over-cautiousness or over-fantasy
-- Pairing with `proceed-with-claude-recommendation` to decide which items belong above and below the cut
+- Pairing with `proceed-with-the-recommendation` to decide which items belong above and below the cut
 
 ## The Two Modes
 
@@ -58,7 +58,7 @@ When emitting ≥3 recommendations, split them:
 1. **Top block — WILD pilots.** 1–2 bold items. Present every item; the operator picks at most one to actually run.
 2. **Bottom block — RISA baseline.** The safe items that ship now regardless of the WILD bet.
 3. Within each block, rank descending by impact.
-4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-claude-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
+4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-the-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
 
 The point: the operator gets one bold option to weigh against a baseline they already trust, instead of a flat list where the bold option silently competes with safe ones and loses by default.
 
@@ -88,6 +88,6 @@ RISA baseline — ship regardless
 ## Related
 
 - `continuous-improvement` — the 7 Laws card (core skill)
-- `proceed-with-claude-recommendation` — execution arm
+- `proceed-with-the-recommendation` — execution arm
 - `superpowers:brainstorming` — upstream WILD generator
 - `verification-loop` — downstream RISA verifier

--- a/skills/wild-risa-balance.md
+++ b/skills/wild-risa-balance.md
@@ -1,0 +1,93 @@
+---
+name: wild-risa-balance
+tier: "2"
+description: Decision-framing lens that pairs WILD generation with RISA execution when emitting recommendation lists. Not a runtime hook.
+origin: ECC
+---
+
+# WILD / RISA Balance
+
+## When to Use
+
+- Emitting a multi-item recommendation block (≥3 items)
+- Choosing between a safe option and a bold option
+- Reviewing your own plan for over-cautiousness or over-fantasy
+- Pairing with `proceed-with-claude-recommendation` to decide which items belong above and below the cut
+
+## The Two Modes
+
+### RISA (Execution)
+
+- **R**ealistic — fits the constraints in front of you
+- **I**mportant — moves a stated goal, not a vanity metric
+- **S**pecific — names files, commands, or owners
+- **A**greeable — the operator can approve it without a meeting
+
+If you only stay in RISA, you ship safe, average results.
+
+### WILD (Creation)
+
+- **W**ild — breaks the default frame
+- **I**maginative — invents an option that did not exist a minute ago
+- **L**imitless — ignores current budget, headcount, or stack
+- **D**isruptive — replaces a workflow rather than tuning it
+
+If you only stay in WILD, you generate cool ideas that never ship.
+
+## The Trap
+
+RISA alone produces a backlog of incremental fixes that never compound. WILD alone produces a graveyard of demos that never reach production. The bigger failure is unconscious switching: drifting into WILD during execution, or drifting into RISA during brainstorming, without naming the switch. Name the mode you are in before you write the next line.
+
+## Switching Deliberately
+
+| Phase                   | Mode  | Why                                                |
+|-------------------------|-------|----------------------------------------------------|
+| Brainstorm              | WILD  | Quantity and range beat early filtering            |
+| Roadmap framing         | WILD  | Frame the bigger bet before scoping it down        |
+| Per-item recommendation | Mixed | Top items can be WILD, baseline items must be RISA |
+| Per-item execution      | RISA  | One thing, verified, shipped                       |
+| Verification            | RISA  | Reality check, no new invention                    |
+| Reflection              | WILD  | Counterfactuals, "what would have been bolder"     |
+
+WILD owns generation phases. RISA owns execution phases. The switch is intentional, not accidental.
+
+## How to Apply in a Recommendation List
+
+When emitting ≥3 recommendations, split them:
+
+1. **Top block — WILD pilots.** 1–2 bold items. Present every item; the operator picks at most one to actually run.
+2. **Bottom block — RISA baseline.** The safe items that ship now regardless of the WILD bet.
+3. Within each block, rank descending by impact.
+4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-claude-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
+
+The point: the operator gets one bold option to weigh against a baseline they already trust, instead of a flat list where the bold option silently competes with safe ones and loses by default.
+
+## Integration with the 7 Laws
+
+| Mode | Reinforces                                              | Tempered by              |
+|------|---------------------------------------------------------|--------------------------|
+| RISA | Law 2 (Plan), Law 3 (One Thing), Law 4 (Verify)         | Law 6 (Iterate One Thing) |
+| WILD | Law 1 (Research — broader exploration), Law 5 (Reflect) | Law 6 (Iterate One Thing) |
+
+Both modes pass through Law 6 before execution. WILD without Law 6 is a wishlist. RISA without Law 6 ships safe fixes while the real bottleneck waits.
+
+## Example
+
+```
+Recommendations (descending impact within each block)
+
+WILD pilots — pick at most one
+1. Replace the current review workflow with a single adversarial pair.
+2. Drop the staging environment in favor of feature-flagged production.
+
+RISA baseline — ship regardless
+1. Add the missing test for the failure path noted in verification.
+2. Rename the ambiguous flag to match its actual behavior.
+```
+
+## Related
+
+- `continuous-improvement` — the 7 Laws card (core skill)
+- `proceed-with-claude-recommendation` — execution arm
+- `superpowers:brainstorming` — upstream WILD generator
+- `verification-loop` — downstream RISA verifier

--- a/skills/workspace-surface-audit.md
+++ b/skills/workspace-surface-audit.md
@@ -1,32 +1,32 @@
 ---
 name: workspace-surface-audit
 tier: companion
-description: "Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value ECC-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment."
-origin: ECC
+description: "Audit the active repo, MCP servers, plugins, connectors, env surfaces, and harness setup, then recommend the highest-value continuous-improvement-native skills, hooks, agents, and operator workflows. Use when the user wants help setting up Claude Code or understanding what capabilities are actually available in their environment."
+origin: continuous-improvement
 ---
 
 # Workspace Surface Audit
 
 Read-only audit skill for answering the question "what can this workspace and machine actually do right now, and what should we add or enable next?"
 
-This is the ECC-native answer to setup-audit plugins. It does not modify files unless the user explicitly asks for follow-up implementation.
+This is the continuous-improvement answer to setup-audit plugins. It does not modify files unless the user explicitly asks for follow-up implementation.
 
 ## When to Use
 
 - User says "set up Claude Code", "recommend automations", "what plugins or MCPs should I use?", or "what am I missing?"
 - Auditing a machine or repo before installing more skills, hooks, or connectors
-- Comparing official marketplace plugins against ECC-native coverage
+- Comparing official marketplace plugins against continuous-improvement coverage
 - Reviewing `.env`, `.mcp.json`, plugin settings, or connected-app surfaces to find missing workflow layers
 - Deciding whether a capability should be a skill, hook, agent, MCP, or external connector
 
 ## Non-Negotiable Rules
 
 - Never print secret values. Surface only provider names, capability names, file paths, and whether a key or config exists.
-- Prefer ECC-native workflows over generic "install another plugin" advice when ECC can reasonably own the surface.
+- Prefer continuous-improvement workflows over generic "install another plugin" advice when continuous-improvement can reasonably own the surface.
 - Treat external plugins as benchmarks and inspiration, not authoritative product boundaries.
 - Separate three things clearly:
   - already available now
-  - available but not wrapped well in ECC
+  - available but not wrapped well in continuous-improvement
   - not available and would require a new integration
 
 ## Audit Inputs
@@ -38,11 +38,11 @@ Inspect only the files and settings needed to answer the question well:
    - `.mcp.json`, `.lsp.json`, `.claude/settings*.json`, `.codex/*`
    - `AGENTS.md`, `CLAUDE.md`, install manifests, hook configs
 2. **Environment surface**
-   - `.env*` files in the active repo and obvious adjacent ECC workspaces
+   - `.env*` files in the active repo and obvious adjacent continuous-improvement workspaces
    - Surface only key names such as `STRIPE_API_KEY`, `TWILIO_AUTH_TOKEN`, `FAL_KEY`
 3. **Connected tool surface**
    - Installed plugins, enabled connectors, MCP servers, LSPs, and app integrations
-4. **ECC surface**
+4. **continuous-improvement surface**
    - Existing skills, commands, hooks, agents, and install modules that already cover the need
 
 ## Audit Process
@@ -56,12 +56,12 @@ Produce a compact inventory:
 - configured MCP servers
 - configured LSP servers
 - env-backed services implied by key names
-- existing ECC skills already relevant to the workspace
+- existing continuous-improvement skills already relevant to the workspace
 
 If a surface exists only as a primitive, call that out. Example:
 
-- "Stripe is available via connected app, but ECC lacks a billing-operator skill"
-- "Google Drive is connected, but there is no ECC-native Google Workspace operator workflow"
+- "Stripe is available via connected app, but continuous-improvement lacks a billing-operator skill"
+- "Google Drive is connected, but there is no continuous-improvement-native Google Workspace operator workflow"
 
 ### Phase 2: Benchmark Against Official and Installed Surfaces
 
@@ -74,15 +74,15 @@ Compare the workspace against:
 Do not just list names. For each comparison, answer:
 
 1. what they actually do
-2. whether ECC already has parity
-3. whether ECC only has primitives
-4. whether ECC is missing the workflow entirely
+2. whether continuous-improvement already has parity
+3. whether continuous-improvement only has primitives
+4. whether continuous-improvement is missing the workflow entirely
 
-### Phase 3: Turn Gaps Into ECC Decisions
+### Phase 3: Turn Gaps Into continuous-improvement Decisions
 
-For every real gap, recommend the correct ECC-native shape:
+For every real gap, recommend the correct continuous-improvement-native shape:
 
-| Gap Type | Preferred ECC Shape |
+| Gap Type | Preferred continuous-improvement Shape |
 |----------|---------------------|
 | Repeatable operator workflow | Skill |
 | Automatic enforcement or side-effect | Hook |
@@ -97,10 +97,10 @@ Default to user-facing skills that orchestrate existing tools when the need is o
 Return five sections in this order:
 
 1. **Current surface** — what is already usable right now
-2. **Parity** — where ECC already matches or exceeds the benchmark
-3. **Primitive-only gaps** — tools exist, but ECC lacks a clean operator skill
+2. **Parity** — where continuous-improvement already matches or exceeds the benchmark
+3. **Primitive-only gaps** — tools exist, but continuous-improvement lacks a clean operator skill
 4. **Missing integrations** — capability not available yet
-5. **Top 3-5 next moves** — concrete ECC-native additions, ordered by impact
+5. **Top 3-5 next moves** — concrete continuous-improvement-native additions, ordered by impact
 
 ## Recommendation Rules
 
@@ -112,10 +112,10 @@ Return five sections in this order:
   - Google Workspace ops
   - deployment/ops control
 - If a connector is company-specific, recommend it only when it is genuinely available or clearly useful to the user's workflow.
-- If ECC already has a strong primitive, propose a wrapper skill instead of inventing a brand-new subsystem.
+- If continuous-improvement already has a strong primitive, propose a wrapper skill instead of inventing a brand-new subsystem.
 
 ## Good Outcomes
 
-- The user can immediately see what is connected, what is missing, and what ECC should own next.
+- The user can immediately see what is connected, what is missing, and what continuous-improvement should own next.
 - Recommendations are specific enough to implement in the repo without another discovery pass.
 - The final answer is organized around workflows, not API brands.


### PR DESCRIPTION
## Summary

- New Tier-2 source skill `skills/wild-risa-balance.md` (94 lines): decision-framing lens that pairs WILD (Wild/Imaginative/Limitless/Disruptive) generation with RISA (Realistic/Important/Specific/Agreeable) execution, used to split multi-item recommendation blocks into a top WILD pilot bet and a bottom RISA baseline.
- Composition only — execution still routes through `proceed-with-claude-recommendation`. No hook change. No edit to the 7 Laws card.
- Bundled artifacts under `plugins/continuous-improvement/skills/wild-risa-balance/` regenerated by `npm run build`. Tier 2 row added to `skills/README.md` and the generated bundled README.
- Plan doc at `docs/plans/2026-04-28-wild-risa-balance-skill.md` records goal, WILL build / WILL NOT build, verification steps, and explicitly defers Option B (require WILD/RISA tagging inside `proceed-with-claude-recommendation`) and Option C (require WILD/RISA split in the 3-section close hook).

## Why

Multi-item recommendation lists tend to flatten bold options against safe ones, and the bold options lose by default. This skill makes the split deliberate: present a clearly-labeled top WILD block with 1–2 bold pilots and a clearly-labeled bottom RISA block with the safe baseline that ships regardless. The operator gets a single bold bet to weigh against a baseline they already trust.

## Process

Built using `superpowers:subagent-driven-development`:
1. Implementer subagent drafted the skill from a detailed spec.
2. Spec-compliance reviewer — verdict: SPEC COMPLIANT.
3. Code-quality reviewer first pass — verdict: CHANGES REQUESTED (3 IMPORTANT issues: dead `discipline` cross-reference, operator-vs-agent ambiguity in step 1, vague handoff in step 4).
4. Fix subagent applied all four edits (3 IMPORTANT plus 1 NIT).
5. Code-quality reviewer second pass — verdict: APPROVED.
6. Final reviewer on full diff — verdict: READY TO COMMIT after one NIT (plan doc status flipped to done).

## Test plan

- [x] `node bin/check-skill-tiers.mjs` exits 0 — all 13 source skills declare a recognized tier
- [x] `npm test` — 238 pass / 0 fail
- [x] `npm run build` — bundle regenerated cleanly, source/generated parity verified
- [x] `git status` clean after commit; only the five expected paths touched
- [ ] Smoke test in a real session: emit a recommendation block following the WILD-top / RISA-bottom shape and confirm operator pick rate on bold options is at least as good as a flat list
- [ ] After 2–3 sessions of evidence, revisit Option B (require WILD/RISA tagging in `proceed-with-claude-recommendation`)

## Out of scope (deferred)

- No edit to `skills/proceed-with-claude-recommendation.md` (Option B)
- No edit to `hooks/three-section-close.mjs` (Option C)
- No new MCP tool, command, or `bin/` script