### PR TITLE
feat(skills): require 5 RISA + 2 WILD floor in wild-risa-balance

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -118,6 +118,10 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
     { file: "plugins/continuous-improvement/commands/continuous-improvement.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
     { file: "skills/proceed-with-the-recommendation.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
+    // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
+    // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
+    { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },
+    { file: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },
 ];
 export function checkAssertions(repoRoot, assertions = DOCS_ASSERTIONS) {
     const fileCache = new Map();

--- a/docs/plans/2026-04-28-wild-risa-balance-skill.md
+++ b/docs/plans/2026-04-28-wild-risa-balance-skill.md
@@ -53,3 +53,23 @@ If the build fails or tests break, revert the new skill file and the README row,
 - WILD/RISA tagging requirement inside `proceed-with-the-recommendation` execution loop (Option B from the prior turn).
 - Mandatory WILD/RISA split in the 3-section close hook (Option C from the prior turn).
 - Both deferred until at least three sessions of evidence that the vocabulary actually changes outcomes.
+
+## 2026-04-28 amendment — 7-item floor
+
+After the initial skill landed (PR #35, commit `1dc4557`), operator feedback was that "1–2 bold items" + "the safe items" was too loose: lists kept degrading to flat 2+2 blocks where the bold and safe items competed equally, defeating the point. Tightened the contract to a hard floor.
+
+- **WILD pilots:** exactly 2 bold items.
+- **RISA baseline:** at least 5 safe items.
+- **Total floor:** 2 WILD + 5 RISA = 7 items minimum.
+
+Files changed by the amendment (follow-up branch `feat/wild-risa-floor`):
+- `skills/wild-risa-balance.md` — How-to-Apply prose rewritten with explicit counts; example expanded from 2+2 to 2+5 with annotated headers.
+- `plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md` — same edit mirrored for `check-skill-mirror`.
+- `bin/check-docs-substrings.mjs` — new assertion locking the literal `2 WILD + 5 RISA = 7 items minimum` into both files so CI catches future drift.
+- `skills/proceed-with-the-recommendation.md` (+ plugin mirror) — one-line cross-reference noting the upstream 7-item floor.
+
+Verification for the amendment:
+1. `node bin/check-skill-mirror.mjs` exits 0.
+2. `node bin/check-docs-substrings.mjs` exits 0 with the new assertion.
+3. `node bin/check-skill-tiers.mjs` exits 0.
+4. Diff confined to the four files above plus this plan doc.

--- a/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
+++ b/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
@@ -69,6 +69,8 @@ Restate the recommendation list back in one compact block:
 4. Proceed without waiting ONLY if every item is `safe` AND the user already said "all of them" / auto mode is active
 5. For any `needs-approval` item (deploy, force-push, DB drop, secret change), stop and ask — even if other items are safe
 
+**Upstream block-shape contract:** if the recommendation list was composed under `wild-risa-balance`, expect ≥7 items split as exactly 2 WILD + at least 5 RISA. Shorter or wrong-split blocks mean the upstream skill was bypassed or violated — flag the gap to the user (one line: "block arrived as N items instead of ≥7; was wild-risa-balance applied?") before walking, do not silently proceed.
+
 ## Phase 2: Plan (Law 2 — Plan Is Sacred)
 
 If the list has **>3 items OR touches >150 LOC**, call `superpowers:writing-plans` to generate a bite-sized task breakdown. Save the plan to `docs/plans/YYYY-MM-DD-<slug>.md`.

--- a/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
+++ b/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
@@ -53,14 +53,16 @@ WILD owns generation phases. RISA owns execution phases. The switch is intention
 
 ## How to Apply in a Recommendation List
 
-When emitting ≥3 recommendations, split them:
+When this skill is in play, every recommendation block ships **at least 7 items**, split as:
 
-1. **Top block — WILD pilots.** 1–2 bold items. Present every item; the operator picks at most one to actually run.
-2. **Bottom block — RISA baseline.** The safe items that ship now regardless of the WILD bet.
+1. **Top block — WILD pilots: exactly 2 bold items.** Present both; the operator picks at most one to actually run. If you cannot find a second genuinely bold option, stretch — do not pad with a safe item dressed up as wild.
+2. **Bottom block — RISA baseline: at least 5 safe items.** These ship now regardless of the WILD bet. If you cannot reach 5, the surface is under-explored — expand scope before emitting the list.
 3. Within each block, rank descending by impact.
 4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-the-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
 
-The point: the operator gets one bold option to weigh against a baseline they already trust, instead of a flat list where the bold option silently competes with safe ones and loses by default.
+Total floor: **2 WILD + 5 RISA = 7 items minimum.** Going above is fine; going below means the skill was not applied.
+
+The point: the operator gets a real WILD/RISA contrast (2 bold bets weighed against a 5-deep trusted baseline), not a flat list where the bold option silently competes with safe ones and loses by default.
 
 ## Integration with the 7 Laws
 
@@ -76,14 +78,19 @@ Both modes pass through Law 6 before execution. WILD without Law 6 is a wishlist
 ```
 Recommendations (descending impact within each block)
 
-WILD pilots — pick at most one
+WILD pilots — pick at most one (2 of 2)
 1. Replace the current review workflow with a single adversarial pair.
 2. Drop the staging environment in favor of feature-flagged production.
 
-RISA baseline — ship regardless
+RISA baseline — ship regardless (5 of ≥5)
 1. Add the missing test for the failure path noted in verification.
 2. Rename the ambiguous flag to match its actual behavior.
+3. Backfill the type on the public export that currently widens to `any`.
+4. Wire the existing Stop hook into the new skill's checklist gate.
+5. Update the README mirror so the bundled plugin matches the source skill.
 ```
+
+Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side if the surface warrants it.
 
 ## Related
 

--- a/skills/proceed-with-the-recommendation.md
+++ b/skills/proceed-with-the-recommendation.md
@@ -69,6 +69,8 @@ Restate the recommendation list back in one compact block:
 4. Proceed without waiting ONLY if every item is `safe` AND the user already said "all of them" / auto mode is active
 5. For any `needs-approval` item (deploy, force-push, DB drop, secret change), stop and ask — even if other items are safe
 
+**Upstream block-shape contract:** if the recommendation list was composed under `wild-risa-balance`, expect ≥7 items split as exactly 2 WILD + at least 5 RISA. Shorter or wrong-split blocks mean the upstream skill was bypassed or violated — flag the gap to the user (one line: "block arrived as N items instead of ≥7; was wild-risa-balance applied?") before walking, do not silently proceed.
+
 ## Phase 2: Plan (Law 2 — Plan Is Sacred)
 
 If the list has **>3 items OR touches >150 LOC**, call `superpowers:writing-plans` to generate a bite-sized task breakdown. Save the plan to `docs/plans/YYYY-MM-DD-<slug>.md`.

--- a/skills/wild-risa-balance.md
+++ b/skills/wild-risa-balance.md
@@ -53,14 +53,16 @@ WILD owns generation phases. RISA owns execution phases. The switch is intention
 
 ## How to Apply in a Recommendation List
 
-When emitting ≥3 recommendations, split them:
+When this skill is in play, every recommendation block ships **at least 7 items**, split as:
 
-1. **Top block — WILD pilots.** 1–2 bold items. Present every item; the operator picks at most one to actually run.
-2. **Bottom block — RISA baseline.** The safe items that ship now regardless of the WILD bet.
+1. **Top block — WILD pilots: exactly 2 bold items.** Present both; the operator picks at most one to actually run. If you cannot find a second genuinely bold option, stretch — do not pad with a safe item dressed up as wild.
+2. **Bottom block — RISA baseline: at least 5 safe items.** These ship now regardless of the WILD bet. If you cannot reach 5, the surface is under-explored — expand scope before emitting the list.
 3. Within each block, rank descending by impact.
 4. Once the list is composed, wait for the operator's "proceed" signal before invoking `proceed-with-the-recommendation`. Never auto-trigger it. This skill only changes how the list is composed.
 
-The point: the operator gets one bold option to weigh against a baseline they already trust, instead of a flat list where the bold option silently competes with safe ones and loses by default.
+Total floor: **2 WILD + 5 RISA = 7 items minimum.** Going above is fine; going below means the skill was not applied.
+
+The point: the operator gets a real WILD/RISA contrast (2 bold bets weighed against a 5-deep trusted baseline), not a flat list where the bold option silently competes with safe ones and loses by default.
 
 ## Integration with the 7 Laws
 
@@ -76,14 +78,19 @@ Both modes pass through Law 6 before execution. WILD without Law 6 is a wishlist
 ```
 Recommendations (descending impact within each block)
 
-WILD pilots — pick at most one
+WILD pilots — pick at most one (2 of 2)
 1. Replace the current review workflow with a single adversarial pair.
 2. Drop the staging environment in favor of feature-flagged production.
 
-RISA baseline — ship regardless
+RISA baseline — ship regardless (5 of ≥5)
 1. Add the missing test for the failure path noted in verification.
 2. Rename the ambiguous flag to match its actual behavior.
+3. Backfill the type on the public export that currently widens to `any`.
+4. Wire the existing Stop hook into the new skill's checklist gate.
+5. Update the README mirror so the bundled plugin matches the source skill.
 ```
+
+Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side if the surface warrants it.
 
 ## Related
 

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -140,6 +140,10 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
   { file: "plugins/continuous-improvement/commands/continuous-improvement.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
   { file: "skills/proceed-with-the-recommendation.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
+  // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
+  // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
+  { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },
+  { file: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },
 ];
 
 export interface AssertionFailure {

--- a/src/test/wild-risa-floor.test.mts
+++ b/src/test/wild-risa-floor.test.mts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+const FLOOR_LITERAL = "2 WILD + 5 RISA = 7 items minimum";
+
+const MIRRORS: ReadonlyArray<{ path: string; section: string }> = [
+  {
+    path: "skills/wild-risa-balance.md",
+    section: "How to Apply in a Recommendation List",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md",
+    section: "How to Apply in a Recommendation List (plugin mirror)",
+  },
+];
+
+describe("wild-risa-balance recommendation floor", () => {
+  for (const mirror of MIRRORS) {
+    describe(mirror.path, () => {
+      let content = "";
+
+      it("exists and is readable", () => {
+        content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+        assert.ok(content.length > 100, `${mirror.path} should not be empty`);
+      });
+
+      it(`contains the floor literal in ${mirror.section}`, () => {
+        assert.ok(
+          content.includes(FLOOR_LITERAL),
+          `${mirror.path} is missing the recommendation floor literal. The skill must specify:\n  ${FLOOR_LITERAL}\nDropping this floor silently degrades lists to flat 2+2 blocks where bold and safe items compete equally.`
+        );
+      });
+    });
+  }
+});

--- a/test/wild-risa-floor.test.mjs
+++ b/test/wild-risa-floor.test.mjs
@@ -1,0 +1,32 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const FLOOR_LITERAL = "2 WILD + 5 RISA = 7 items minimum";
+const MIRRORS = [
+    {
+        path: "skills/wild-risa-balance.md",
+        section: "How to Apply in a Recommendation List",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md",
+        section: "How to Apply in a Recommendation List (plugin mirror)",
+    },
+];
+describe("wild-risa-balance recommendation floor", () => {
+    for (const mirror of MIRRORS) {
+        describe(mirror.path, () => {
+            let content = "";
+            it("exists and is readable", () => {
+                content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+                assert.ok(content.length > 100, `${mirror.path} should not be empty`);
+            });
+            it(`contains the floor literal in ${mirror.section}`, () => {
+                assert.ok(content.includes(FLOOR_LITERAL), `${mirror.path} is missing the recommendation floor literal. The skill must specify:\n  ${FLOOR_LITERAL}\nDropping this floor silently degrades lists to flat 2+2 blocks where bold and safe items compete equally.`);
+            });
+        });
+    }
+});


### PR DESCRIPTION
## Summary

Follow-up to PR #35. Tightens the recommendation-block contract for `wild-risa-balance` so every list emitted under the skill ships at least 7 items (exactly 2 WILD + at least 5 RISA), and locks the contract via a CI assertion + a downstream cross-reference.

Operator feedback after #35 merged: the loose prose ("1-2 bold items" / "the safe items") let lists degrade into flat 2+2 blocks where the bold and safe items competed equally and the bold ones lost by default. The 7-item floor restores the original intent — a real WILD/RISA contrast, not a flat menu.

## Commits

1. `feat(skills): require 5 RISA + 2 WILD floor in wild-risa-balance` — How-to-Apply prose rewritten with explicit count floors; example expanded from 2+2 to 2+5 with annotated headers; plugin mirror updated.
2. `docs(plans): record 7-item floor amendment for wild-risa-balance` — plan doc now carries the amendment so it stays the source of truth.
3. `feat(ci): lock 2 WILD + 5 RISA floor literal via docs-substring assertion` — new `wild-risa-floor.test.mts` + 2 new entries in the docs-substring inventory; both mirrors guarded.
4. `docs(skills): cross-reference wild-risa-balance floor in proceed-with-the-recommendation` — the execution arm now flags blocks that arrive shorter than 7 instead of walking them silently.

## Test plan

- [x] `node bin/check-skill-mirror.mjs` — 13 pairs match
- [x] `node bin/check-docs-substrings.mjs` — 74 assertions (was 72) all pass
- [x] `node bin/check-skill-tiers.mjs` — 13 sources tier-tagged
- [x] `npm test` — 242 tests pass, 0 fail
- [ ] Reviewer spot-checks the new "Upstream block-shape contract" note in Phase 1 of the proceed skill reads cleanly
- [ ] Reviewer confirms the plan-doc amendment captures the rationale for future readers