### PR TITLE
refactor(skill): make proceed-with-the-recommendation agent-agnostic

### DIFF
--- a/commands/proceed-with-the-recommendation.md
+++ b/commands/proceed-with-the-recommendation.md
@@ -1,13 +1,13 @@
 ---
 name: proceed-with-the-recommendation
-description: "Execute Claude's prior recommendation list under the 7 Laws — walk in order, route per item, verify, reflect. Standalone companion skill with inline fallbacks when other skills are not installed."
+description: "Execute the agent's prior recommendation list under the 7 Laws — walk in order, route per item, verify, reflect. Standalone companion skill with inline fallbacks when other skills are not installed."
 ---
 
 # /proceed-with-the-recommendation
 
-Walk a Claude-generated recommendation list top-to-bottom under the continuous-improvement 7 Laws. Each item is routed to the best specialist skill when available, falls back to concrete inline behavior when it is not.
+Walk an agent-generated recommendation list top-to-bottom under the continuous-improvement 7 Laws. Each item is routed to the best specialist skill when available, falls back to concrete inline behavior when it is not.
 
-Invoke immediately after Claude has offered a numbered list of recommendations, next steps, or suggested actions.
+Invoke immediately after the agent has offered a numbered list of recommendations, next steps, or suggested actions.
 
 ## Trigger phrases
 

--- a/plugins/continuous-improvement/commands/proceed-with-the-recommendation.md
+++ b/plugins/continuous-improvement/commands/proceed-with-the-recommendation.md
@@ -1,13 +1,13 @@
 ---
 name: proceed-with-the-recommendation
-description: "Execute Claude's prior recommendation list under the 7 Laws — walk in order, route per item, verify, reflect. Standalone companion skill with inline fallbacks when other skills are not installed."
+description: "Execute the agent's prior recommendation list under the 7 Laws — walk in order, route per item, verify, reflect. Standalone companion skill with inline fallbacks when other skills are not installed."
 ---
 
 # /proceed-with-the-recommendation
 
-Walk a Claude-generated recommendation list top-to-bottom under the continuous-improvement 7 Laws. Each item is routed to the best specialist skill when available, falls back to concrete inline behavior when it is not.
+Walk an agent-generated recommendation list top-to-bottom under the continuous-improvement 7 Laws. Each item is routed to the best specialist skill when available, falls back to concrete inline behavior when it is not.
 
-Invoke immediately after Claude has offered a numbered list of recommendations, next steps, or suggested actions.
+Invoke immediately after the agent has offered a numbered list of recommendations, next steps, or suggested actions.
 
 ## Trigger phrases
 

--- a/plugins/continuous-improvement/skills/README.md
+++ b/plugins/continuous-improvement/skills/README.md
@@ -13,7 +13,7 @@ skill set on disk.
 - `continuous-improvement` — Install structured self-improvement loops with instinct-based learning into Claude Code — research, plan, execute, verify, reflect, learn, iterate. On-demand or weekly analysis to save tokens. Supports multi-agent parallel analysis.
 
 ## Featured companion
-- `proceed-with-the-recommendation` ⭐ — Walks a Claude-emitted recommendation list top-to-bottom under the 7 Laws — restate, route per item, verify before advancing, reflect at the end, close with the mandatory three-section block. Standalone with inline fallbacks; trigger phrases are matched by the companion hook, not enumerated here.
+- `proceed-with-the-recommendation` ⭐ — Walks an agent-emitted recommendation list top-to-bottom under the 7 Laws — restate, route per item, verify before advancing, reflect at the end, close with the mandatory three-section block. Standalone with inline fallbacks; trigger phrases are matched by the companion hook, not enumerated here.
 
 ## Tier 1 — beginner-mode pairing
 - `gateguard` — Fact-forcing gate that blocks Edit/Write/Bash (including MultiEdit) and demands concrete investigation (importers, data schemas, user instruction) before allowing the action. Measurably improves output quality by +2.25 points vs ungated agents.

--- a/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
+++ b/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: proceed-with-the-recommendation
 tier: featured
-description: "Walks a Claude-emitted recommendation list top-to-bottom under the 7 Laws — restate, route per item, verify before advancing, reflect at the end, close with the mandatory three-section block. Standalone with inline fallbacks; trigger phrases are matched by the companion hook, not enumerated here."
+description: "Walks an agent-emitted recommendation list top-to-bottom under the 7 Laws — restate, route per item, verify before advancing, reflect at the end, close with the mandatory three-section block. Standalone with inline fallbacks; trigger phrases are matched by the companion hook, not enumerated here."
 origin: https://github.com/naimkatiman/continuous-improvement
 ---
 
@@ -43,7 +43,7 @@ This skill is the orchestrator for the other companions in this repo. It does no
 
 ## When to Use
 
-**Hard precondition (must be true before this skill runs):** Claude emitted a numbered, bulleted, or otherwise enumerated list of recommendations / next steps / suggested actions in the **immediately prior turn**. If no such list exists in the prior turn, this skill MUST NOT activate — the trigger phrases are ambiguous on their own and "yes do it" / "all of them" can refer to anything.
+**Hard precondition (must be true before this skill runs):** The agent emitted a numbered, bulleted, or otherwise enumerated list of recommendations / next steps / suggested actions in the **immediately prior turn**. If no such list exists in the prior turn, this skill MUST NOT activate — the trigger phrases are ambiguous on their own and "yes do it" / "all of them" can refer to anything.
 
 If the precondition holds, activate when:
 - User invokes `/proceed-with-the-recommendation`
@@ -55,7 +55,7 @@ Do NOT use when:
 - No enumerated recommendation list exists in the prior turn — ask what to proceed with instead of guessing
 - Recommendations include destructive actions (deploy, force-push, DB drops, secret changes) without prior explicit authorization
 - User scoped the work ("just the first one", "only the safe ones") — honor the scope
-- Recommendations conflict with project CLAUDE.md rules
+- Recommendations conflict with project agent-instruction files (CLAUDE.md / AGENTS.md / GEMINI.md / equivalent)
 
 ## Phase 1: Pre-Flight (Law 1 — Research)
 
@@ -294,7 +294,7 @@ Install them together for the full continuous-improvement experience, or use thi
 
 A concrete trace covering the most-failed paths: a `needs-approval` halt, a verification failure-and-retry, and the Phase 7 close. Use this to calibrate output shape — don't copy the wording.
 
-**Prior turn (Claude's recommendation block):**
+**Prior turn (the agent's recommendation block):**
 ```
 1. Add input validation to the /api/users POST handler
 2. Drop the unused `legacy_users` table

--- a/skills/proceed-with-the-recommendation.md
+++ b/skills/proceed-with-the-recommendation.md
@@ -1,7 +1,7 @@
 ---
 name: proceed-with-the-recommendation
 tier: featured
-description: "Walks a Claude-emitted recommendation list top-to-bottom under the 7 Laws — restate, route per item, verify before advancing, reflect at the end, close with the mandatory three-section block. Standalone with inline fallbacks; trigger phrases are matched by the companion hook, not enumerated here."
+description: "Walks an agent-emitted recommendation list top-to-bottom under the 7 Laws — restate, route per item, verify before advancing, reflect at the end, close with the mandatory three-section block. Standalone with inline fallbacks; trigger phrases are matched by the companion hook, not enumerated here."
 origin: https://github.com/naimkatiman/continuous-improvement
 ---
 
@@ -43,7 +43,7 @@ This skill is the orchestrator for the other companions in this repo. It does no
 
 ## When to Use
 
-**Hard precondition (must be true before this skill runs):** Claude emitted a numbered, bulleted, or otherwise enumerated list of recommendations / next steps / suggested actions in the **immediately prior turn**. If no such list exists in the prior turn, this skill MUST NOT activate — the trigger phrases are ambiguous on their own and "yes do it" / "all of them" can refer to anything.
+**Hard precondition (must be true before this skill runs):** The agent emitted a numbered, bulleted, or otherwise enumerated list of recommendations / next steps / suggested actions in the **immediately prior turn**. If no such list exists in the prior turn, this skill MUST NOT activate — the trigger phrases are ambiguous on their own and "yes do it" / "all of them" can refer to anything.
 
 If the precondition holds, activate when:
 - User invokes `/proceed-with-the-recommendation`
@@ -55,7 +55,7 @@ Do NOT use when:
 - No enumerated recommendation list exists in the prior turn — ask what to proceed with instead of guessing
 - Recommendations include destructive actions (deploy, force-push, DB drops, secret changes) without prior explicit authorization
 - User scoped the work ("just the first one", "only the safe ones") — honor the scope
-- Recommendations conflict with project CLAUDE.md rules
+- Recommendations conflict with project agent-instruction files (CLAUDE.md / AGENTS.md / GEMINI.md / equivalent)
 
 ## Phase 1: Pre-Flight (Law 1 — Research)
 
@@ -294,7 +294,7 @@ Install them together for the full continuous-improvement experience, or use thi
 
 A concrete trace covering the most-failed paths: a `needs-approval` halt, a verification failure-and-retry, and the Phase 7 close. Use this to calibrate output shape — don't copy the wording.
 
-**Prior turn (Claude's recommendation block):**
+**Prior turn (the agent's recommendation block):**
 ```
 1. Add input validation to the /api/users POST handler
 2. Drop the unused `legacy_users` table


### PR DESCRIPTION
## Summary
- Rewrite Claude-specific phrasing in `proceed-with-the-recommendation` (skill, plugin mirror, command, README) to neutral "agent" terminology so the skill is invocable from any AI coding agent (Claude Code, Codex, Gemini, etc.).
- Broaden the precondition rule from "CLAUDE.md rules" to "agent-instruction files (CLAUDE.md / AGENTS.md / GEMINI.md / equivalent)".
- 5 files, +15 / -15. No behavior change — phrasing only.

## Files
- `commands/proceed-with-the-recommendation.md`
- `plugins/continuous-improvement/commands/proceed-with-the-recommendation.md`
- `plugins/continuous-improvement/skills/README.md`
- `plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md`
- `skills/proceed-with-the-recommendation.md`

## Out of scope (deliberately left alone)
- The `Restart the Claude Code session` install line stays — install path is genuinely Claude-Code-specific even if the skill content is portable. A future PR can add per-agent install sections if needed.

## Test plan
- [x] Local `npm test`: 238/238 pass
- [ ] CI green on Node 18 / 20 / 22
- [ ] CI lint-transcript green
- [ ] Spot-check rendered SKILL.md to confirm agent-agnostic phrasing reads naturally