### PR TITLE
feat(skills): past-mistake-gate (P-MAG) in proceed-with-the-recommendation

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -118,6 +118,15 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
     { file: "plugins/continuous-improvement/commands/continuous-improvement.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
     { file: "skills/proceed-with-the-recommendation.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
+    // Past Mistake Acknowledgment Gate / P-MAG (src/test/past-mistake-gate.test.mts)
+    // Source skill + plugin mirror must both contain the Phase 0 heading, the negative-prompt field marker,
+    // and the Stop Conditions clearance bullet. Dropping any of the three silently removes part of the gate.
+    { file: "skills/proceed-with-the-recommendation.md", pattern: "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)", source: "past-mistake-gate.test.mts" },
+    { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)", source: "past-mistake-gate.test.mts" },
+    { file: "skills/proceed-with-the-recommendation.md", pattern: "Will NOT repeat:", source: "past-mistake-gate.test.mts" },
+    { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Will NOT repeat:", source: "past-mistake-gate.test.mts" },
+    { file: "skills/proceed-with-the-recommendation.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
+    { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
 ];
 export function checkAssertions(repoRoot, assertions = DOCS_ASSERTIONS) {
     const fileCache = new Map();

--- a/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
+++ b/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
@@ -57,6 +57,35 @@ Do NOT use when:
 - User scoped the work ("just the first one", "only the safe ones") — honor the scope
 - Recommendations conflict with project CLAUDE.md rules
 
+## Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)
+
+Before research begins, the skill must read its own track record. The instinct system records corrections; this gate forces the read at the moment they actually matter — before a new recommendation list is touched. **Three rules, in order. None is optional.**
+
+### Rule 1 — Acknowledge before context (right context from the beginning)
+
+Scan two surfaces and quote literal evidence:
+
+- `~/.claude/instincts/<project-hash>/observations.jsonl` — last 10 entries with `type: failure` or `correction`
+- The active project's `CLAUDE.md` "Past Mistakes" section (if present)
+
+Emit one line: `Past mistake observed: <quote>. Source: <file:line>. Active in current scope: yes|no.` If both surfaces are empty, emit `No prior mistakes recorded — proceed.` Never skip silently — silent skip defeats the instinct system.
+
+### Rule 2 — Clearance gate (don't proceed until the mistake is gone)
+
+Hard halt before Phase 1 if any of these hold:
+
+- The past mistake's residue is **still present** in the working tree (unrotated key, stale README dates, unreverted bug, broken migration)
+- The verification step from the prior fix was never run
+- A `needs-approval` item from a prior session sits unresolved
+
+Halt output: `BLOCKED on prior mistake: <X>. Residue: <Y at file:line>. Required clearance: <Z>. New recommendation list will not start until cleared.` This is also enumerated under Stop Conditions below.
+
+### Rule 3 — Negative prompt (determine not to do it again)
+
+Carry one named past failure forward into Phase 2 as `Will NOT repeat: <pattern>`. The pattern must cite a specific prior session — generic anti-patterns ("will not skip verification") do not qualify. Concrete shape: `Will NOT repeat: skipped per-item typecheck on lib/ extraction the way item 3 did 2026-04-26`.
+
+Phase 6 reflection scores the run against this declared negative prompt — if honored, instincts strengthen; if violated, the violation itself becomes the next session's Rule 1 quote.
+
 ## Phase 1: Pre-Flight (Law 1 — Research)
 
 **If** the recommendation list references files, plugins, or MCP servers not obviously present in the current repo, **then** call `workspace-surface-audit` for a quick scan. Otherwise skip.

--- a/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
+++ b/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
@@ -102,7 +102,7 @@ Restate the recommendation list back in one compact block:
 
 If the list has **>3 items OR touches >150 LOC**, call `superpowers:writing-plans` to generate a bite-sized task breakdown. Save the plan to `docs/plans/YYYY-MM-DD-<slug>.md`.
 
-Otherwise, inline: restate each item as `WILL build: <X>`, `Will NOT build: <Y>`, `Verification: <Z>`, `Fallback: <W>`.
+Otherwise, inline: restate each item as `WILL build: <X>`, `Will NOT build: <Y>`, `Verification: <Z>`, `Fallback: <W>`, `Will NOT repeat: <named past failure pattern carried in from P-MAG Rule 3>`.
 
 Create a `TodoWrite` list mirroring the plan.
 
@@ -341,9 +341,9 @@ A concrete trace covering the most-failed paths: a `needs-approval` halt, a veri
 ```
 
 **Phase 2 — Plan (inline, ≤3 items):**
-- Item 1: WILL add zod schema for body, reject 400 with field-level errors. Will NOT change response shape on success. Verification: one curl with bad payload → 400. Fallback: revert if existing tests break.
+- Item 1: WILL add zod schema for body, reject 400 with field-level errors. Will NOT change response shape on success. Verification: one curl with bad payload → 400. Fallback: revert if existing tests break. Will NOT repeat: shipping a POST handler without input validation the way `/api/orders` did 2026-04-15.
 - Item 2: needs-approval — stop and ask the user before touching D1.
-- Item 3: WILL extract `paginate()` to `lib/pagination.ts`, update both callsites. Will NOT change behavior. Verification: typecheck + the existing paginate unit test green. Fallback: revert if test count drops.
+- Item 3: WILL extract `paginate()` to `lib/pagination.ts`, update both callsites. Will NOT change behavior. Verification: typecheck + the existing paginate unit test green. Fallback: revert if test count drops. Will NOT repeat: extracting a shared helper without diffing both callsite signatures first (the lib/api.ts vs lib/db.ts drift from this same example).
 
 **Phase 3 — Execute item 1:**
 Edit `routes/users.ts` adding zod schema. Run `curl -X POST .../api/users -d '{}'` → returns `400 {"errors":[{"field":"email","msg":"required"}]}`. ✓

--- a/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
+++ b/plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md
@@ -268,6 +268,7 @@ Stop immediately on any of:
 - New information contradicts the remaining list (root-cause shifted)
 - Context >80% full — write a Context Bridge before clearing
 - Any drive-by temptation that is NOT in the original list
+- Prior-mistake residue still present in working tree or operator queue (P-MAG Rule 2 — clear it before starting the new list)
 
 ### Definitions (close common rationalization routes)
 

--- a/skills/proceed-with-the-recommendation.md
+++ b/skills/proceed-with-the-recommendation.md
@@ -57,6 +57,35 @@ Do NOT use when:
 - User scoped the work ("just the first one", "only the safe ones") — honor the scope
 - Recommendations conflict with project CLAUDE.md rules
 
+## Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)
+
+Before research begins, the skill must read its own track record. The instinct system records corrections; this gate forces the read at the moment they actually matter — before a new recommendation list is touched. **Three rules, in order. None is optional.**
+
+### Rule 1 — Acknowledge before context (right context from the beginning)
+
+Scan two surfaces and quote literal evidence:
+
+- `~/.claude/instincts/<project-hash>/observations.jsonl` — last 10 entries with `type: failure` or `correction`
+- The active project's `CLAUDE.md` "Past Mistakes" section (if present)
+
+Emit one line: `Past mistake observed: <quote>. Source: <file:line>. Active in current scope: yes|no.` If both surfaces are empty, emit `No prior mistakes recorded — proceed.` Never skip silently — silent skip defeats the instinct system.
+
+### Rule 2 — Clearance gate (don't proceed until the mistake is gone)
+
+Hard halt before Phase 1 if any of these hold:
+
+- The past mistake's residue is **still present** in the working tree (unrotated key, stale README dates, unreverted bug, broken migration)
+- The verification step from the prior fix was never run
+- A `needs-approval` item from a prior session sits unresolved
+
+Halt output: `BLOCKED on prior mistake: <X>. Residue: <Y at file:line>. Required clearance: <Z>. New recommendation list will not start until cleared.` This is also enumerated under Stop Conditions below.
+
+### Rule 3 — Negative prompt (determine not to do it again)
+
+Carry one named past failure forward into Phase 2 as `Will NOT repeat: <pattern>`. The pattern must cite a specific prior session — generic anti-patterns ("will not skip verification") do not qualify. Concrete shape: `Will NOT repeat: skipped per-item typecheck on lib/ extraction the way item 3 did 2026-04-26`.
+
+Phase 6 reflection scores the run against this declared negative prompt — if honored, instincts strengthen; if violated, the violation itself becomes the next session's Rule 1 quote.
+
 ## Phase 1: Pre-Flight (Law 1 — Research)
 
 **If** the recommendation list references files, plugins, or MCP servers not obviously present in the current repo, **then** call `workspace-surface-audit` for a quick scan. Otherwise skip.

--- a/skills/proceed-with-the-recommendation.md
+++ b/skills/proceed-with-the-recommendation.md
@@ -102,7 +102,7 @@ Restate the recommendation list back in one compact block:
 
 If the list has **>3 items OR touches >150 LOC**, call `superpowers:writing-plans` to generate a bite-sized task breakdown. Save the plan to `docs/plans/YYYY-MM-DD-<slug>.md`.
 
-Otherwise, inline: restate each item as `WILL build: <X>`, `Will NOT build: <Y>`, `Verification: <Z>`, `Fallback: <W>`.
+Otherwise, inline: restate each item as `WILL build: <X>`, `Will NOT build: <Y>`, `Verification: <Z>`, `Fallback: <W>`, `Will NOT repeat: <named past failure pattern carried in from P-MAG Rule 3>`.
 
 Create a `TodoWrite` list mirroring the plan.
 
@@ -341,9 +341,9 @@ A concrete trace covering the most-failed paths: a `needs-approval` halt, a veri
 ```
 
 **Phase 2 — Plan (inline, ≤3 items):**
-- Item 1: WILL add zod schema for body, reject 400 with field-level errors. Will NOT change response shape on success. Verification: one curl with bad payload → 400. Fallback: revert if existing tests break.
+- Item 1: WILL add zod schema for body, reject 400 with field-level errors. Will NOT change response shape on success. Verification: one curl with bad payload → 400. Fallback: revert if existing tests break. Will NOT repeat: shipping a POST handler without input validation the way `/api/orders` did 2026-04-15.
 - Item 2: needs-approval — stop and ask the user before touching D1.
-- Item 3: WILL extract `paginate()` to `lib/pagination.ts`, update both callsites. Will NOT change behavior. Verification: typecheck + the existing paginate unit test green. Fallback: revert if test count drops.
+- Item 3: WILL extract `paginate()` to `lib/pagination.ts`, update both callsites. Will NOT change behavior. Verification: typecheck + the existing paginate unit test green. Fallback: revert if test count drops. Will NOT repeat: extracting a shared helper without diffing both callsite signatures first (the lib/api.ts vs lib/db.ts drift from this same example).
 
 **Phase 3 — Execute item 1:**
 Edit `routes/users.ts` adding zod schema. Run `curl -X POST .../api/users -d '{}'` → returns `400 {"errors":[{"field":"email","msg":"required"}]}`. ✓

--- a/skills/proceed-with-the-recommendation.md
+++ b/skills/proceed-with-the-recommendation.md
@@ -268,6 +268,7 @@ Stop immediately on any of:
 - New information contradicts the remaining list (root-cause shifted)
 - Context >80% full — write a Context Bridge before clearing
 - Any drive-by temptation that is NOT in the original list
+- Prior-mistake residue still present in working tree or operator queue (P-MAG Rule 2 — clear it before starting the new list)
 
 ### Definitions (close common rationalization routes)
 

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -140,6 +140,16 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
   { file: "plugins/continuous-improvement/commands/continuous-improvement.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
   { file: "skills/proceed-with-the-recommendation.md", pattern: "Iteration — Next best recommendations (ranked, top 3)", source: "reflection-iteration-field.test.mts:43" },
+
+  // Past Mistake Acknowledgment Gate / P-MAG (src/test/past-mistake-gate.test.mts)
+  // Source skill + plugin mirror must both contain the Phase 0 heading, the negative-prompt field marker,
+  // and the Stop Conditions clearance bullet. Dropping any of the three silently removes part of the gate.
+  { file: "skills/proceed-with-the-recommendation.md", pattern: "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)", source: "past-mistake-gate.test.mts" },
+  { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)", source: "past-mistake-gate.test.mts" },
+  { file: "skills/proceed-with-the-recommendation.md", pattern: "Will NOT repeat:", source: "past-mistake-gate.test.mts" },
+  { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Will NOT repeat:", source: "past-mistake-gate.test.mts" },
+  { file: "skills/proceed-with-the-recommendation.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
+  { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
 ];
 
 export interface AssertionFailure {

--- a/src/test/past-mistake-gate.test.mts
+++ b/src/test/past-mistake-gate.test.mts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+const PHASE_0_HEADING = "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)";
+const NEGATIVE_PROMPT_FIELD = "Will NOT repeat:";
+const STOP_CONDITION_BULLET = "Prior-mistake residue still present";
+
+const MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
+  {
+    path: "skills/proceed-with-the-recommendation.md",
+    label: "source skill",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+    label: "plugin mirror",
+  },
+];
+
+const REQUIRED_LITERALS: ReadonlyArray<{ literal: string; reason: string }> = [
+  {
+    literal: PHASE_0_HEADING,
+    reason: "Phase 0 section heading — dropping it removes the whole P-MAG gate.",
+  },
+  {
+    literal: NEGATIVE_PROMPT_FIELD,
+    reason: "Negative-prompt field — Rule 3 lives in the Phase 2 plan template via this marker.",
+  },
+  {
+    literal: STOP_CONDITION_BULLET,
+    reason: "Stop Conditions bullet — Rule 2 clearance gate is enumerated as a hard halt via this line.",
+  },
+];
+
+describe("proceed-with-the-recommendation past-mistake-gate (P-MAG)", () => {
+  for (const mirror of MIRRORS) {
+    const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+
+    describe(`${mirror.label} (${mirror.path})`, () => {
+      it("exists and is non-empty", () => {
+        assert.ok(content.length > 100, `${mirror.path} should not be empty`);
+      });
+
+      for (const required of REQUIRED_LITERALS) {
+        it(`contains literal: ${required.literal}`, () => {
+          assert.ok(
+            content.includes(required.literal),
+            `${mirror.path} is missing the P-MAG literal:\n  ${required.literal}\n${required.reason}`
+          );
+        });
+      }
+    });
+  }
+});

--- a/test/past-mistake-gate.test.mjs
+++ b/test/past-mistake-gate.test.mjs
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const PHASE_0_HEADING = "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)";
+const NEGATIVE_PROMPT_FIELD = "Will NOT repeat:";
+const STOP_CONDITION_BULLET = "Prior-mistake residue still present";
+const MIRRORS = [
+    {
+        path: "skills/proceed-with-the-recommendation.md",
+        label: "source skill",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+        label: "plugin mirror",
+    },
+];
+const REQUIRED_LITERALS = [
+    {
+        literal: PHASE_0_HEADING,
+        reason: "Phase 0 section heading — dropping it removes the whole P-MAG gate.",
+    },
+    {
+        literal: NEGATIVE_PROMPT_FIELD,
+        reason: "Negative-prompt field — Rule 3 lives in the Phase 2 plan template via this marker.",
+    },
+    {
+        literal: STOP_CONDITION_BULLET,
+        reason: "Stop Conditions bullet — Rule 2 clearance gate is enumerated as a hard halt via this line.",
+    },
+];
+describe("proceed-with-the-recommendation past-mistake-gate (P-MAG)", () => {
+    for (const mirror of MIRRORS) {
+        const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+        describe(`${mirror.label} (${mirror.path})`, () => {
+            it("exists and is non-empty", () => {
+                assert.ok(content.length > 100, `${mirror.path} should not be empty`);
+            });
+            for (const required of REQUIRED_LITERALS) {
+                it(`contains literal: ${required.literal}`, () => {
+                    assert.ok(content.includes(required.literal), `${mirror.path} is missing the P-MAG literal:\n  ${required.literal}\n${required.reason}`);
+                });
+            }
+        });
+    }
+});


### PR DESCRIPTION
## Summary

Adds Phase 0 (Past Mistake Acknowledgment Gate / P-MAG) to `proceed-with-the-recommendation`. Three rules in order: acknowledge before context, clearance gate, negative prompt. Forces the instinct system's prior corrections to be read at the moment they actually matter — before a new recommendation list is touched.

- **Phase 0 section** — `Rule 1` quotes literal evidence from `~/.claude/instincts/<project-hash>/observations.jsonl` and the project CLAUDE.md "Past Mistakes" section; `Rule 2` is a hard halt if residue lives in the working tree or operator queue; `Rule 3` carries one named past failure into Phase 2 as `Will NOT repeat: <pattern>`
- **Stop Conditions** gain a new bullet enumerating Rule 2's clearance gate alongside `needs-approval` halts
- **Phase 2 plan template** gains a fifth field (`Will NOT repeat:`) so every per-item plan ships a declared negative prompt; the worked example demonstrates the shape on items 1 and 3
- **CI lock** mirrors the wild-risa-floor pattern from `cb9cbdf`: 6 docs-substring assertions (3 literals × source + plugin mirror) plus a new `past-mistake-gate.test.mts` with 8 assertions

Why now: prior-session corrections were being logged to the instinct system but never read at the start of the next session. Lists kept walking past unfinished verification steps because the framework had no gate that forced acknowledgment + clearance + negative prompt.

## Commits

1. `cafc198` feat(skills): add Phase 0 Acknowledge (Past Mistake Gate / P-MAG)
2. `003fbe5` feat(skills): add P-MAG Rule 2 clearance bullet to Stop Conditions
3. `c63de36` feat(skills): add 'Will NOT repeat' negative prompt to Phase 2 plan template
4. `bcf971b` feat(ci): lock P-MAG literals via docs-substring assertion + test

One concern per commit; source skill + plugin mirror always edited together.

## Test plan

- [x] `npm run build` clean
- [x] `node bin/check-docs-substrings.mjs` — `OK docs-substrings: all 78 substring assertion(s) match`
- [x] `node --test test/past-mistake-gate.test.mjs` — 8/8 pass
- [x] `npm test` — full suite 246/246 pass
- [ ] Reviewer: confirm Phase 0 lands above Phase 1 in both source skill and plugin mirror
- [ ] Reviewer: confirm `Will NOT repeat:` reads as the fifth template field, not a sixth (count: WILL build, Will NOT build, Verification, Fallback, Will NOT repeat)
- [ ] Reviewer: confirm CI lock catches drift by temporarily deleting one of the three literals locally and seeing the test fail

## Out of scope (deferred)

- Standalone `past-mistake-gate.md` skill — only promote after the inline gate has been used for a session or two and assumption-breakages surface
- Promoting acknowledgment to an 8th Law in `SKILL.md` core — bigger leverage, bigger blast radius; revisit after this lands