### PR TITLE
refactor(skills): sweep agent-agnostic phrasing across Tier-1/featured

### DIFF
--- a/plugins/continuous-improvement/skills/README.md
+++ b/plugins/continuous-improvement/skills/README.md
@@ -19,7 +19,7 @@ skill set on disk.
 - `gateguard` — Fact-forcing gate that blocks Edit/Write/Bash (including MultiEdit) and demands concrete investigation (importers, data schemas, user instruction) before allowing the action. Measurably improves output quality by +2.25 points vs ungated agents.
 - `para-memory-files` — File-based memory system using Tiago Forte's PARA method. Use this skill whenever you need to store, retrieve, update, or organize knowledge across sessions. Covers three memory layers: (1) Knowledge graph in PARA folders with atomic YAML facts, (2) Daily notes as raw timeline, (3) Tacit knowledge about user patterns. Also handles planning files, memory decay, weekly synthesis, and recall via qmd. Trigger on any memory operation: saving facts, writing daily notes, creating entities, running weekly synthesis, recalling past context, or managing plans.
 - `tdd-workflow` — Use this skill when writing new features, fixing bugs, or refactoring code. Enforces test-driven development with 80%+ coverage including unit, integration, and E2E tests.
-- `verification-loop` — A comprehensive verification system for Claude Code sessions.
+- `verification-loop` — A comprehensive verification system for agent coding sessions.
 
 ## Tier 2 — expert-mode add-ons
 - `safety-guard` — Use this skill to prevent destructive operations when working on production systems or running agents autonomously.

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -7,14 +7,14 @@ origin: community
 
 # GateGuard — Fact-Forcing Pre-Action Gate
 
-A PreToolUse hook that forces Claude to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+A PreToolUse hook that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
 
 ## When to Activate
 
 - Working on any codebase where file edits affect multiple modules
 - Projects with data files that have specific schemas or date formats
 - Teams where AI-generated code must match existing patterns
-- Any workflow where Claude tends to guess instead of investigating
+- Any workflow where the agent tends to guess instead of investigating
 
 ## Core Concept
 

--- a/plugins/continuous-improvement/skills/strategic-compact/SKILL.md
+++ b/plugins/continuous-improvement/skills/strategic-compact/SKILL.md
@@ -82,7 +82,7 @@ Understanding what persists helps you compact with confidence:
 
 | Persists | Lost |
 |----------|------|
-| CLAUDE.md instructions | Intermediate reasoning and analysis |
+| Agent instructions (from CLAUDE.md / AGENTS.md) | Intermediate reasoning and analysis |
 | TodoWrite task list | File contents you previously read |
 | Memory files (`~/.claude/memory/`) | Multi-step conversation context |
 | Git state (commits, branches) | Tool call history and counts |

--- a/plugins/continuous-improvement/skills/token-budget-advisor/SKILL.md
+++ b/plugins/continuous-improvement/skills/token-budget-advisor/SKILL.md
@@ -19,7 +19,7 @@ origin: community
 
 # Token Budget Advisor (TBA)
 
-Intercept the response flow to offer the user a choice about response depth **before** Claude answers.
+Intercept the response flow to offer the user a choice about response depth **before** the agent answers.
 
 ## When to Use
 

--- a/plugins/continuous-improvement/skills/verification-loop/SKILL.md
+++ b/plugins/continuous-improvement/skills/verification-loop/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: verification-loop
 tier: "1"
-description: "A comprehensive verification system for Claude Code sessions."
+description: "A comprehensive verification system for agent coding sessions."
 origin: continuous-improvement
 ---
 
 # Verification Loop Skill
 
-A comprehensive verification system for Claude Code sessions.
+A comprehensive verification system for agent coding sessions.
 
 ## When to Use
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -6,11 +6,11 @@ This directory holds the **source-of-truth** for the companion skills bundled wi
 
 ## Featured companion — installed by default with the plugin
 
-`proceed-with-the-recommendation` is the **recommended pairing** for the 7 Laws. It is the execution arm that turns "do all of it" into a disciplined, verified, one-concern-at-a-time walk through Claude's recommendation list. If you only adopt one companion alongside the core skill, adopt this one.
+`proceed-with-the-recommendation` is the **recommended pairing** for the 7 Laws. It is the execution arm that turns "do all of it" into a disciplined, verified, one-concern-at-a-time walk through the agent's recommendation list. If you only adopt one companion alongside the core skill, adopt this one.
 
 | Skill | What it does | Source |
 |-------|--------------|--------|
-| **`proceed-with-the-recommendation`** ⭐ | Walks any Claude recommendation list top-to-bottom under the 7 Laws — routes each item to the right specialist (`superpowers:*`, `ralph`, `workspace-surface-audit`, `simplify`, `security-review`, `schedule`, `loop`), falls back to inline behavior when a specialist isn't installed, verifies per item, halts on `needs-approval` | @naimkatiman |
+| **`proceed-with-the-recommendation`** ⭐ | Walks any agent's recommendation list top-to-bottom under the 7 Laws — routes each item to the right specialist (`superpowers:*`, `ralph`, `workspace-surface-audit`, `simplify`, `security-review`, `schedule`, `loop`), falls back to inline behavior when a specialist isn't installed, verifies per item, halts on `needs-approval` | @naimkatiman |
 
 ## Tier 1 — recommended pairing for **beginner** mode
 

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -7,14 +7,14 @@ origin: community
 
 # GateGuard — Fact-Forcing Pre-Action Gate
 
-A PreToolUse hook that forces Claude to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+A PreToolUse hook that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
 
 ## When to Activate
 
 - Working on any codebase where file edits affect multiple modules
 - Projects with data files that have specific schemas or date formats
 - Teams where AI-generated code must match existing patterns
-- Any workflow where Claude tends to guess instead of investigating
+- Any workflow where the agent tends to guess instead of investigating
 
 ## Core Concept
 

--- a/skills/strategic-compact.md
+++ b/skills/strategic-compact.md
@@ -82,7 +82,7 @@ Understanding what persists helps you compact with confidence:
 
 | Persists | Lost |
 |----------|------|
-| CLAUDE.md instructions | Intermediate reasoning and analysis |
+| Agent instructions (from CLAUDE.md / AGENTS.md) | Intermediate reasoning and analysis |
 | TodoWrite task list | File contents you previously read |
 | Memory files (`~/.claude/memory/`) | Multi-step conversation context |
 | Git state (commits, branches) | Tool call history and counts |

--- a/skills/token-budget-advisor.md
+++ b/skills/token-budget-advisor.md
@@ -19,7 +19,7 @@ origin: community
 
 # Token Budget Advisor (TBA)
 
-Intercept the response flow to offer the user a choice about response depth **before** Claude answers.
+Intercept the response flow to offer the user a choice about response depth **before** the agent answers.
 
 ## When to Use
 

--- a/skills/verification-loop.md
+++ b/skills/verification-loop.md
@@ -1,13 +1,13 @@
 ---
 name: verification-loop
 tier: "1"
-description: "A comprehensive verification system for Claude Code sessions."
+description: "A comprehensive verification system for agent coding sessions."
 origin: continuous-improvement
 ---
 
 # Verification Loop Skill
 
-A comprehensive verification system for Claude Code sessions.
+A comprehensive verification system for agent coding sessions.
 
 ## When to Use
 


### PR DESCRIPTION
## Summary
Follow-up to #38. Same low-risk Claude→agent phrasing-only refactor, applied across the next batch of skills:
- `gateguard` ×2 (forces Claude → forces the agent; Claude tends to guess → the agent tends to guess)
- `token-budget-advisor` ×1 (before Claude answers → before the agent answers)
- `verification-loop` ×2 (description + prose: Claude Code sessions → agent coding sessions)
- `strategic-compact` ×1 (`CLAUDE.md instructions` → `Agent instructions (from CLAUDE.md / AGENTS.md)`)
- `skills/README.md` ×2 (Claude's recommendation list → the agent's recommendation list; any Claude recommendation list → any agent recommendation list)

## Files
- 5 source files in `skills/`
- 5 mirror files in `plugins/continuous-improvement/skills/` (regenerated by `npm run build` per the `bin/generate-plugin-manifests.mjs` pipeline; the source `skills/README.md` says these mirrors are auto-generated)

10 files total, +15 / -15. Within the 15-file commit-size gate.

## Out of scope (deliberately left alone)
- `proceed-with-the-recommendation` — already covered by #38
- `workspace-surface-audit` — most Claude references are legitimate product references (`set up Claude Code` trigger phrase, `Claude or Codex plugins` audit list, `AGENTS.md, CLAUDE.md` install-config path list). Deferred to a separate, more careful audit.
- `ralph` — both Claude references are legitimate (section header `# Using Claude Code`, file path `scripts/ralph/CLAUDE.md`)
- `token-budget-advisor.md` line 133 attribution to the upstream "Token Budget Advisor for Claude Code" project (proper noun, not generic phrasing)

## Test plan
- [x] Local `npm test`: 238/238 pass (build + tests)
- [x] `check-skill-mirror.test.mjs` passes (source + mirror byte-identical after regen)
- [ ] CI green on Node 18 / 20 / 22 + lint-transcript