### PR TITLE
feat: skill-hardening — behavioral specs + hook telemetry

### DIFF
--- a/bin/generate-plugin-manifests.mjs
+++ b/bin/generate-plugin-manifests.mjs
@@ -102,6 +102,7 @@ async function writePluginBundle() {
         copyDirectory(join(REPO_ROOT, "templates", "planning-with-files"), join(PLUGIN_BUNDLE_DIR, "templates", "planning-with-files")),
         copyFileTo(join(REPO_ROOT, "bin", "mcp-server.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "mcp-server.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "plugin-metadata.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs")),
+        copyFileTo(join(REPO_ROOT, "lib", "resolve-home-dir.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "resolve-home-dir.mjs")),
         copyFileTo(join(REPO_ROOT, "LICENSE"), join(PLUGIN_BUNDLE_DIR, "LICENSE")),
         writePluginBundleReadme(),
     ]);

--- a/bin/hook-stats.mjs
+++ b/bin/hook-stats.mjs
@@ -42,9 +42,10 @@
  */
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { join } from "node:path";
-import { argv, cwd, env, exit, stderr, stdout } from "node:process";
+import { argv, cwd, exit, stderr, stdout } from "node:process";
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 const USAGE = `Usage: node bin/hook-stats.mjs [options]
 
 Reads JSONL telemetry from <HOME>/.claude/hook-telemetry/*.jsonl and
@@ -99,28 +100,6 @@ function parseArgs(rawArgs) {
         throw new Error(`unknown argument: ${arg}`);
     }
     return opts;
-}
-function resolveHomeDir() {
-    // Mirrors the hook: explicit opt-out requires BOTH env vars empty.
-    // OR-semantic would silently disable the CLI when a shell happened to
-    // clear one variable while the other still pointed at a valid path.
-    const home = env.HOME;
-    const userProfile = env.USERPROFILE;
-    if (home === "" && userProfile === "")
-        return "";
-    if (home)
-        return home;
-    if (userProfile)
-        return userProfile;
-    try {
-        const fromOs = homedir();
-        if (fromOs)
-            return fromOs;
-    }
-    catch {
-        // ignore
-    }
-    return "";
 }
 export function projectHashForCwd(workingDir) {
     let normalized = workingDir.split("\\").join("/");

--- a/bin/hook-stats.mjs
+++ b/bin/hook-stats.mjs
@@ -101,9 +101,12 @@ function parseArgs(rawArgs) {
     return opts;
 }
 function resolveHomeDir() {
+    // Mirrors the hook: explicit opt-out requires BOTH env vars empty.
+    // OR-semantic would silently disable the CLI when a shell happened to
+    // clear one variable while the other still pointed at a valid path.
     const home = env.HOME;
     const userProfile = env.USERPROFILE;
-    if (home === "" || userProfile === "")
+    if (home === "" && userProfile === "")
         return "";
     if (home)
         return home;

--- a/bin/hook-stats.mjs
+++ b/bin/hook-stats.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Hook Stats Reader
+ *
+ * Reads JSONL telemetry written by Claude Code Stop hooks (e.g. the
+ * three-section-close hook) from `<HOME>/.claude/hook-telemetry/*.jsonl`
+ * and prints per-hook aggregate counts over a recent time window.
+ *
+ * Each input line is JSON of the shape:
+ *   {
+ *     "ts": "<ISO timestamp>",
+ *     "hook": "<hook-name>",
+ *     "action": "pass" | "block" | "skip-short",
+ *     "textLength": <number>,
+ *     "missing": <string[]>,
+ *     "durationMs": <number>
+ *   }
+ *
+ * The reader is parse-tolerant: malformed lines are skipped silently so
+ * the CLI keeps working even when the hook has been crash-restarted mid
+ * append. The hook itself is fail-open; the reader matches that posture.
+ *
+ * Project hash:
+ *   The hook keys telemetry files by a 12-char sha256 prefix of the
+ *   *project* directory (the dir containing the transcript). For the CLI,
+ *   the "project" is the current working directory: we normalize path
+ *   separators to forward slash, lowercase on win32, then sha256 and
+ *   slice the first 12 hex chars. Pass `--hash=<value>` to override.
+ *
+ * Usage:
+ *   node bin/hook-stats.mjs [--hours=<n>] [--hash=<hash>] [--telemetry-dir=<path>]
+ *   node bin/hook-stats.mjs --help
+ *
+ * Defaults:
+ *   --hours          24
+ *   --hash           sha256(normalize(process.cwd())).slice(0, 12)
+ *   --telemetry-dir  <HOME>/.claude/hook-telemetry
+ *
+ * Exit codes:
+ *   0 — printed aggregate (or "no records" message)
+ *   1 — unexpected error
+ */
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { argv, cwd, env, exit, stderr, stdout } from "node:process";
+const USAGE = `Usage: node bin/hook-stats.mjs [options]
+
+Reads JSONL telemetry from <HOME>/.claude/hook-telemetry/*.jsonl and
+prints per-hook aggregate counts over a recent time window.
+
+Options:
+  --hours=<n>            Time window in hours (default: 24)
+  --hash=<hash>          Only read this single <hash>.jsonl file
+                         (default: sha256 of the current working directory,
+                         normalized to forward slashes and lowercased on
+                         Windows, then first 12 hex chars)
+  --telemetry-dir=<path> Override telemetry dir
+                         (default: <HOME>/.claude/hook-telemetry)
+  --help                 Show this help and exit 0
+
+Output:
+  One line per hook: "<hook> last <hours>h: pass=<n> block=<n>
+  skip-short=<n> total=<n> avg-duration=<X>ms".
+  If there are no records in the window: "no records in last <hours>h".
+
+The reader is parse-tolerant: malformed JSONL lines are skipped silently.
+`;
+function parseArgs(rawArgs) {
+    const opts = {
+        hours: 24,
+        hash: null,
+        telemetryDir: null,
+        help: false,
+    };
+    for (const arg of rawArgs) {
+        if (arg === "--help" || arg === "-h") {
+            opts.help = true;
+            continue;
+        }
+        if (arg.startsWith("--hours=")) {
+            const raw = arg.slice("--hours=".length);
+            const n = Number(raw);
+            if (!Number.isFinite(n) || n <= 0) {
+                throw new Error(`invalid --hours value: ${raw}`);
+            }
+            opts.hours = n;
+            continue;
+        }
+        if (arg.startsWith("--hash=")) {
+            opts.hash = arg.slice("--hash=".length);
+            continue;
+        }
+        if (arg.startsWith("--telemetry-dir=")) {
+            opts.telemetryDir = arg.slice("--telemetry-dir=".length);
+            continue;
+        }
+        throw new Error(`unknown argument: ${arg}`);
+    }
+    return opts;
+}
+function resolveHomeDir() {
+    const home = env.HOME;
+    const userProfile = env.USERPROFILE;
+    if (home === "" || userProfile === "")
+        return "";
+    if (home)
+        return home;
+    if (userProfile)
+        return userProfile;
+    try {
+        const fromOs = homedir();
+        if (fromOs)
+            return fromOs;
+    }
+    catch {
+        // ignore
+    }
+    return "";
+}
+export function projectHashForCwd(workingDir) {
+    let normalized = workingDir.split("\\").join("/");
+    if (platform() === "win32")
+        normalized = normalized.toLowerCase();
+    return createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+}
+function listJsonlFiles(dir, hashFilter) {
+    let entries;
+    try {
+        entries = readdirSync(dir);
+    }
+    catch {
+        return [];
+    }
+    const out = [];
+    for (const name of entries) {
+        if (!name.endsWith(".jsonl"))
+            continue;
+        if (hashFilter !== null) {
+            if (name !== `${hashFilter}.jsonl`)
+                continue;
+        }
+        const full = join(dir, name);
+        try {
+            const stat = statSync(full);
+            if (!stat.isFile())
+                continue;
+        }
+        catch {
+            continue;
+        }
+        out.push(full);
+    }
+    return out;
+}
+function safeJsonParse(line) {
+    try {
+        const parsed = JSON.parse(line);
+        if (parsed &&
+            typeof parsed === "object" &&
+            typeof parsed.hook === "string" &&
+            typeof parsed.ts === "string" &&
+            typeof parsed.action === "string") {
+            return parsed;
+        }
+        return null;
+    }
+    catch {
+        return null;
+    }
+}
+export function aggregate(records, cutoffMs) {
+    const byHook = new Map();
+    for (const rec of records) {
+        const tsMs = Date.parse(rec.ts);
+        if (!Number.isFinite(tsMs))
+            continue;
+        if (tsMs < cutoffMs)
+            continue;
+        let agg = byHook.get(rec.hook);
+        if (!agg) {
+            agg = {
+                hook: rec.hook,
+                pass: 0,
+                block: 0,
+                skipShort: 0,
+                total: 0,
+                durationSum: 0,
+                durationCount: 0,
+            };
+            byHook.set(rec.hook, agg);
+        }
+        agg.total += 1;
+        if (rec.action === "pass")
+            agg.pass += 1;
+        else if (rec.action === "block")
+            agg.block += 1;
+        else if (rec.action === "skip-short")
+            agg.skipShort += 1;
+        if (typeof rec.durationMs === "number" && Number.isFinite(rec.durationMs)) {
+            agg.durationSum += rec.durationMs;
+            agg.durationCount += 1;
+        }
+    }
+    return Array.from(byHook.values()).sort((a, b) => a.hook.localeCompare(b.hook));
+}
+function formatAggregate(agg, hours) {
+    const avg = agg.durationCount > 0
+        ? Math.round(agg.durationSum / agg.durationCount)
+        : 0;
+    return `${agg.hook} last ${hours}h: pass=${agg.pass} block=${agg.block} skip-short=${agg.skipShort} total=${agg.total} avg-duration=${avg}ms`;
+}
+function main() {
+    const opts = parseArgs(argv.slice(2));
+    if (opts.help) {
+        stdout.write(USAGE);
+        exit(0);
+    }
+    let telemetryDir;
+    if (opts.telemetryDir !== null) {
+        telemetryDir = opts.telemetryDir;
+    }
+    else {
+        const home = resolveHomeDir();
+        if (!home) {
+            stderr.write("no telemetry dir resolved\n");
+            exit(0);
+        }
+        telemetryDir = join(home, ".claude", "hook-telemetry");
+    }
+    const hashFilter = opts.hash ?? projectHashForCwd(cwd());
+    // When the user did not pass --hash, we still read all files (per spec).
+    // Only restrict to a single file when --hash is explicitly set.
+    const useHashFilter = opts.hash !== null;
+    const files = listJsonlFiles(telemetryDir, useHashFilter ? hashFilter : null);
+    const records = [];
+    for (const file of files) {
+        let content;
+        try {
+            content = readFileSync(file, "utf8");
+        }
+        catch {
+            continue;
+        }
+        for (const rawLine of content.split(/\r?\n/)) {
+            const line = rawLine.trim();
+            if (!line)
+                continue;
+            const rec = safeJsonParse(line);
+            if (rec)
+                records.push(rec);
+        }
+    }
+    const cutoffMs = Date.now() - opts.hours * 3600 * 1000;
+    const aggregates = aggregate(records, cutoffMs);
+    if (aggregates.length === 0) {
+        stdout.write(`no records in last ${opts.hours}h\n`);
+        exit(0);
+    }
+    for (const agg of aggregates) {
+        stdout.write(formatAggregate(agg, opts.hours) + "\n");
+    }
+    exit(0);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].split("\\").join("/"));
+if (invokedDirectly || argv[1]?.endsWith("hook-stats.mjs")) {
+    try {
+        main();
+    }
+    catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        stderr.write(`${message}\n`);
+        exit(1);
+    }
+}

--- a/docs/plans/2026-04-29-skill-hardening-design.md
+++ b/docs/plans/2026-04-29-skill-hardening-design.md
@@ -1,0 +1,165 @@
+# Skill Hardening — Behavioral Specs, Hook Telemetry, Composition
+
+- Date: 2026-04-29
+- Branch: `harden-skills`
+- Author: Naim
+- Slug: `skill-hardening`
+
+## Goal
+
+Lock down the three recently shipped skills so a regression in `main` cannot ship undetected:
+
+1. `proceed-with-the-recommendation` (P-MAG, Phase 7 close shape)
+2. `wild-risa-balance` (5+2 floor + composition rules)
+3. `three-section-close` Stop hook (block/pass behavior)
+
+Current tests are static literal-substring checks. They confirm a heading or phrase still exists; they do not confirm the skill's *behavioral spec* (what the skill obligates the agent to do) is intact, nor do they catch hooks that silently degrade.
+
+## Non-goals (YAGNI)
+
+- No live-agent eval harness (Claude API calls). Out of scope. Cost + flakiness not justified for this pass.
+- No new runtime dependencies. CI's "Verify zero runtime dependencies" gate is sacred.
+- No reformat / rename / refactor of unrelated SKILL.md content.
+- No telemetry beyond JSONL counts. No dashboards, no remote sinks, no PII.
+- No false-positive-rate computation for hooks (requires labeled feedback we don't have).
+- No coverage of skills not in the three-skill scope.
+
+## Approach (recommended, vs. alternatives)
+
+Three approaches considered:
+
+- **A. Behavioral-spec tests (parse SKILL.md, assert structure beyond literals)** + **fixture-replay tests against the hook script** + **JSONL hook telemetry**. All three additive, zero-runtime-dep, runs under existing `node --test` harness. **CHOSEN.**
+- B. Live-agent eval via Claude API. Highest fidelity, but adds runtime dep, adds cost, adds flakiness. Punt.
+- C. Pure literal-substring expansion (more grep tests). Cheapest, but does not actually catch behavioral drift — same failure class as today.
+
+Trade-off accepted: behavioral-spec tests assert on parsed structure (sections, sub-rules, required clauses), not on actual agent behavior. They catch SKILL.md edits that silently drop a rule or weaken a verb. They do not catch a model that ignores a still-intact rule. That second failure class needs a live eval, which is out of scope.
+
+## Tracks and tasks
+
+### Track A — Behavioral drift (3 tasks)
+
+#### A1. P-MAG behavioral spec test
+
+- **WILL build:**
+  - New file `src/test/pmag-spec.test.mts` → emits `test/pmag-spec.test.mjs` via `npm run build`.
+  - Parses Phase 0 section in both source skill (`skills/proceed-with-the-recommendation.md`) and plugin mirror (`plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md`).
+  - Asserts each of the three rules has its required behavioral clauses:
+    - **Rule 1** must reference `observations.jsonl`, `Past Mistake` quote-line format, and the empty-surfaces fallback `No prior mistakes recorded — proceed.`
+    - **Rule 2** must contain `BLOCKED on prior mistake:` halt prefix and the three residue triggers (residue in working tree / unrun verification / unresolved `needs-approval`).
+    - **Rule 3** must require `Will NOT repeat:` carried into Phase 2 with a *specific prior session* citation requirement (not generic).
+- **Will NOT build:** any test that hits the network, spawns an agent, or modifies SKILL.md.
+- **Files touched:** `src/test/pmag-spec.test.mts` (new), `test/pmag-spec.test.mjs` (generated, must be committed per CI).
+- **Verification:** `npm test` passes locally; deliberately edit one of the asserted clauses out of SKILL.md and confirm the new test fails; revert.
+- **Acceptance:** All three Rule-level assertions exist and run on both mirrors. Test fails if any single rule's required clause is removed.
+
+#### A2. Wild/RISA behavioral spec test
+
+- **WILL build:**
+  - New file `src/test/wild-risa-spec.test.mts` → emits `test/wild-risa-spec.test.mjs`.
+  - Parses `How to Apply in a Recommendation List` section in both mirrors.
+  - Asserts:
+    - 4 numbered sub-rules present.
+    - "exactly 2" present in WILD rule, "at least 5" present in RISA rule.
+    - "rank descending by impact" present.
+    - "Never auto-trigger" wording present.
+    - The "Example" block contains exactly 2 WILD entries and 5 RISA entries (parsed from numbered list under each header).
+- **Will NOT build:** assertions on the philosophical sections (The Trap, Switching Deliberately) — those are explanatory, not normative.
+- **Files touched:** `src/test/wild-risa-spec.test.mts` (new), `test/wild-risa-spec.test.mjs` (generated).
+- **Verification:** same pattern — edit "exactly 2" → "at least 1", confirm test fails, revert.
+- **Acceptance:** All structural claims asserted. Test fails on any silent softening.
+
+#### A3. Phase 7 close-shape spec test
+
+- **WILL build:**
+  - New file `src/test/phase7-close-spec.test.mts` → emits `test/phase7-close-spec.test.mjs`.
+  - Parses Phase 7 section in both mirrors.
+  - Asserts:
+    - Three section headings present in this exact order: `What has been done`, `What is next`, `Recommendation`.
+    - Tier 1 / Tier 2 / Skip table structure required.
+    - Tier 1 mandates citation (literal `concrete file/line/rule citation` or equivalent).
+    - `Want me to:` block requires exactly 2 options.
+    - Tiny-list exemption clause present (≤1 item path).
+- **Will NOT build:** assertions on the worked example block — that's illustrative, not normative.
+- **Files touched:** `src/test/phase7-close-spec.test.mts` (new), `test/phase7-close-spec.test.mjs` (generated).
+- **Verification:** same flip-and-revert pattern.
+- **Acceptance:** All five structural claims asserted on both mirrors.
+
+### Track B — Hook telemetry (2 tasks)
+
+#### B1. JSONL telemetry sink in `three-section-close.mjs`
+
+- **WILL build:**
+  - Modify `hooks/three-section-close.mjs` to append one JSONL line per invocation to `~/.claude/instincts/<project-hash>/hook-telemetry.jsonl` (use `process.env.HOME` or `process.env.USERPROFILE`; on missing env, no-op silently).
+  - Line shape: `{"ts":"<ISO>","hook":"three-section-close","action":"pass|block|skip","textLength":<n>,"missing":[<heading...>],"durationMs":<n>}`.
+  - Must be fail-open: telemetry write failure must not block the response or throw.
+  - Must remain zero-runtime-dep: only `node:fs`, `node:path`, `node:crypto` for hashing project path.
+  - Project hash: `crypto.createHash('sha256').update(cwdOrTranscriptDir).digest('hex').slice(0, 12)`.
+- **Will NOT build:**
+  - No remote sink. No environment-variable-driven endpoint. No PII (no transcript content captured — only metadata).
+  - No telemetry on the failure-to-parse-stdin path (already noisy).
+- **Files touched:** `hooks/three-section-close.mjs` (modify), `src/test/hook.test.mts` (extend with telemetry assertion using a temp HOME), `test/hook.test.mjs` (generated).
+- **Verification:** spawn the hook with a synthetic stdin payload pointing at a fake transcript, confirm JSONL line appears at expected path, confirm hook still exits 0/blocks correctly.
+- **Acceptance:** Telemetry written on pass + block + skip paths. Hook still fail-open on telemetry-write errors. Zero-deps gate still green.
+
+#### B2. `bin/hook-stats.mjs` reader + npm script
+
+- **WILL build:**
+  - New file `src/bin/hook-stats.mts` → emits `bin/hook-stats.mjs`.
+  - Reads `~/.claude/instincts/<hash>/hook-telemetry.jsonl`, prints one-line summary per hook: `<hook> last <hours>h: pass=N block=M skip=K avg-duration=Xms`.
+  - Args: `--hours=<n>` (default 24), `--hash=<hash>` (default = current cwd hash).
+  - New `npm run hooks:stats` script in `package.json`.
+  - New file `src/test/hook-stats.test.mts` → emits `test/hook-stats.test.mjs`. Synthesizes a tiny JSONL fixture in a temp dir, points the script at it, asserts on stdout shape.
+- **Will NOT build:** no JSON output mode, no per-day breakdown, no global aggregate across hashes.
+- **Files touched:** `src/bin/hook-stats.mts` (new), `bin/hook-stats.mjs` (generated), `package.json` (script entry only — single line), `src/test/hook-stats.test.mts` (new), `test/hook-stats.test.mjs` (generated).
+- **Verification:** populate a temp JSONL with 10 lines (5 pass, 3 block, 2 skip), run `npm run hooks:stats -- --hash=<temp>`, assert numbers match.
+- **Acceptance:** Stats command runs without runtime deps, prints expected counts, test green.
+
+### Track C — Composition (1 task)
+
+#### C1. Compound fixture + cross-skill contract test
+
+- **WILL build:**
+  - New file `src/test/composition-spec.test.mts` → emits `test/composition-spec.test.mjs`.
+  - Two parts:
+    - **Part 1 — fixture replay against the hook.** Spawn `node hooks/three-section-close.mjs` with stdin payloads pointing at fixture transcripts saved under `test/fixtures/three-section-close/`. Three fixtures: (a) good reply with all three sections → hook exits 0, no block; (b) reply missing Recommendation → hook emits `decision: block` with reason naming `Recommendation`; (c) short reply (<600 chars) → hook exits 0, no block.
+    - **Part 2 — cross-skill contract.** Assert that `proceed-with-the-recommendation` SKILL.md still references `wild-risa-balance` by name in the Phase 1 upstream-block-shape contract (the literal `2 WILD + at least 5 RISA` must appear in the Phase 1 section of both mirrors). Assert that `wild-risa-balance` SKILL.md still references `proceed-with-the-recommendation` as its execution arm.
+- **Will NOT build:** fixtures of compound replies that simultaneously satisfy WILD/RISA + 3-section close. The hook only sees the assistant text — it cannot validate semantic compliance with the recommendation skill, only the close shape. Conflating them would invent guarantees the hook does not provide.
+- **Files touched:** `src/test/composition-spec.test.mts` (new), `test/composition-spec.test.mjs` (generated), `test/fixtures/three-section-close/` (3 small JSONL fixtures, each one assistant message).
+- **Verification:** run new test alone, confirm 3 fixture cases all behave as asserted; corrupt one cross-skill reference in SKILL.md, confirm test fails; revert.
+- **Acceptance:** Hook-replay fixtures pass; cross-skill literal references guarded.
+
+## Order
+
+Sequential, one-task-per-subagent, two-stage review per task:
+
+1. A1 (P-MAG behavioral spec) — establishes the parse-section-then-assert pattern other tasks copy.
+2. A2 (Wild/RISA behavioral spec) — same pattern, different skill.
+3. A3 (Phase 7 close-shape spec) — same pattern, third section.
+4. B1 (Hook JSONL telemetry) — modifies a hook in production; needs care.
+5. B2 (`hook-stats` reader + script) — depends on B1's JSONL shape.
+6. C1 (Compound fixture + cross-skill contract) — depends on B1's hook still passing post-modification.
+
+Each task = its own commit. No bundling. CI must stay green after each.
+
+## Risks
+
+- **CI's `git diff --exit-code -- bin test`** gate means every `.mts` change forces a `.mjs` regen + commit. Subagents must run `npm run build` before committing each task. Plan-doc-only commit is exempt (no source changes).
+- **Skill-mirror parity:** every test assertion must run on both `skills/<name>.md` and `plugins/continuous-improvement/skills/<name>/SKILL.md`. Existing tests use a `MIRRORS` array; new tests must do the same.
+- **Windows path handling:** project hash logic in B1 must work across Windows backslash and POSIX forward-slash paths. Normalize before hashing.
+- **Hook telemetry write race:** concurrent invocations writing to the same JSONL. Use `appendFileSync` (atomic at the OS level for small writes); accept tiny risk of interleaved partial lines as not blocking — JSONL parser tolerates blank/garbled lines (B2 must skip unparseable lines).
+- **Skill-tier lint** (`bin/check-skill-tiers.mjs`) currently runs on every change. New tests should not need to interact with it, but changes to SKILL.md frontmatter would. Plan: zero SKILL.md edits in this branch.
+
+## Success criteria
+
+- All 6 task commits land on `harden-skills`.
+- `npm test` green locally.
+- CI green on push (when authorized).
+- Inverting a behavioral clause in any of the three skills causes the matching new test to fail.
+- `npm run hooks:stats` returns counts after one real hook fire.
+
+## Out of scope follow-ups (logged, not built)
+
+- Live-agent eval harness (would need Claude API, budget, fixture model).
+- Telemetry export / dashboard.
+- Behavioral specs for skills outside the three-skill scope.
+- False-positive labeling pipeline for hook telemetry.

--- a/docs/plans/2026-04-29-skill-hardening-design.md
+++ b/docs/plans/2026-04-29-skill-hardening-design.md
@@ -163,3 +163,13 @@ Each task = its own commit. No bundling. CI must stay green after each.
 - Telemetry export / dashboard.
 - Behavioral specs for skills outside the three-skill scope.
 - False-positive labeling pipeline for hook telemetry.
+
+## Execution notes (post-ship — what actually shipped vs. spec)
+
+- **C1 Part 1 (fixture-replay against the three-section-close hook) was cut at execution time.** B1 expanded scope to add a dedicated `src/test/three-section-close.test.mts` covering the pass / block / skip-short paths via spawned hook invocations with crafted transcripts. C1 Part 1 would have duplicated that surface using fixture files instead of inline strings — pure refactor, no new coverage. Cut as YAGNI. C1 shipped Part 2 only (cross-skill contract) under commit `335622d`.
+- **B1 telemetry path simplified:** plan called for `~/.claude/instincts/<hash>/hook-telemetry.jsonl`; shipped as `~/.claude/hook-telemetry/<hash>.jsonl`. B1 + B2 are mutually consistent on this path. Plan path was over-nested.
+- **B1 action label refined:** plan called for `skip`; shipped as `skip-short`. More descriptive in JSONL aggregates.
+- **Two follow-up fix commits landed beyond the original 6-task list** in response to code-review findings:
+  - `1241671 fix(hooks): empty-HOME opt-out + eliminate test-time telemetry leak` — closed a false-positive no-HOME test in `src/test/three-section-close.test.mts` AND a parallel leak in the older `src/test/hook.test.mts` runThreeSectionClose helper that was polluting the developer's real `~/.claude/hook-telemetry/` on every `npm test` run.
+  - `c42d06b fix(hooks): require BOTH env vars empty for telemetry opt-out` — corrected an over-aggressive OR semantic in `resolveHomeDir` (hook + CLI). The opt-out now triggers ONLY when BOTH `HOME` and `USERPROFILE` are explicitly empty strings; a single empty-with-other-valid case correctly falls through.
+- **Final branch state (9 commits ahead of `main`):** all 6 tasks complete, 342 tests passing, zero runtime deps, no test-time telemetry pollution, fail-open hook contract preserved. Verdict: READY WITH CAVEATS resolved by this note.

--- a/hooks/three-section-close.mjs
+++ b/hooks/three-section-close.mjs
@@ -94,18 +94,20 @@ function emitBlock(missing) {
 }
 
 function resolveHomeDir() {
-  // Explicit operator opt-out: if EITHER HOME or USERPROFILE is set to the
-  // empty string (set, not undefined), skip telemetry entirely. Do NOT fall
-  // back to os.homedir() in that case — empty-string is a deliberate signal
-  // (used by tests and by operators who want telemetry disabled without
-  // editing settings.json).
+  // Explicit operator opt-out: only when BOTH HOME and USERPROFILE are set
+  // to the empty string (set, not undefined) do we skip telemetry entirely.
+  // Empty-string-on-both is a deliberate signal (used by tests and by
+  // operators who want telemetry disabled without editing settings.json).
+  // If only one var is empty and the other points at a valid path, fall
+  // back to the valid one — otherwise telemetry would silently disable
+  // whenever a shell happens to clear one variable.
   const home = process.env.HOME;
   const userProfile = process.env.USERPROFILE;
-  if (home === "" || userProfile === "") return "";
+  if (home === "" && userProfile === "") return "";
   if (home) return home;
   if (userProfile) return userProfile;
-  // Both undefined: legitimately fall back to os.homedir() so normal
-  // non-test usage keeps working when env vars are merely missing.
+  // Neither set to a truthy path: legitimately fall back to os.homedir()
+  // so normal non-test usage keeps working when env vars are merely missing.
   try {
     const fromOs = homedir();
     if (fromOs) return fromOs;

--- a/hooks/three-section-close.mjs
+++ b/hooks/three-section-close.mjs
@@ -15,8 +15,16 @@
 // Heuristic: skip messages shorter than 600 chars. Pure clarifying replies
 // don't need the close; only substantive technical responses (work
 // summaries, plan responses, post-execution reports) get gated.
+//
+// Telemetry: best-effort JSONL line per gated invocation written to
+// ~/.claude/hook-telemetry/<project-hash>.jsonl. Never throws, never
+// blocks the response. No network. No transcript content recorded.
 
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 
 const MIN_LENGTH_TO_GATE = 600;
 
@@ -85,7 +93,48 @@ function emitBlock(missing) {
   process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
 }
 
+function resolveHomeDir() {
+  const fromEnv = process.env.HOME || process.env.USERPROFILE;
+  if (fromEnv) return fromEnv;
+  try {
+    const fromOs = homedir();
+    if (fromOs) return fromOs;
+  } catch {
+    // os.homedir() can throw in pathological env conditions
+  }
+  return "";
+}
+
+function projectHashFor(transcriptPath) {
+  const dir = dirname(transcriptPath);
+  let normalized = dir.split("\\").join("/");
+  if (platform() === "win32") normalized = normalized.toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+}
+
+function recordTelemetry(entry, transcriptPath) {
+  try {
+    const home = resolveHomeDir();
+    if (!home) return;
+    const telemetryDir = join(home, ".claude", "hook-telemetry");
+    try {
+      mkdirSync(telemetryDir, { recursive: true });
+    } catch {
+      return;
+    }
+    const file = join(telemetryDir, `${projectHashFor(transcriptPath)}.jsonl`);
+    try {
+      appendFileSync(file, JSON.stringify(entry) + "\n", "utf8");
+    } catch {
+      return;
+    }
+  } catch {
+    // belt-and-suspenders: telemetry must never throw
+  }
+}
+
 function main() {
+  const startedAt = performance.now();
   const stdin = readStdinSync();
   if (!stdin) return;
 
@@ -100,12 +149,32 @@ function main() {
     return; // fail open on read error
   }
   if (!lastText) return;
-  if (lastText.length < MIN_LENGTH_TO_GATE) return;
 
-  const missing = REQUIRED_SECTIONS.filter((s) => !s.pattern.test(lastText));
-  if (missing.length === 0) return;
+  const textLength = lastText.length;
+  let action;
+  let missing = [];
 
-  emitBlock(missing);
+  if (textLength < MIN_LENGTH_TO_GATE) {
+    action = "skip-short";
+  } else {
+    missing = REQUIRED_SECTIONS.filter((s) => !s.pattern.test(lastText));
+    if (missing.length === 0) {
+      action = "pass";
+    } else {
+      action = "block";
+      emitBlock(missing);
+    }
+  }
+
+  const entry = {
+    ts: new Date().toISOString(),
+    hook: "three-section-close",
+    action,
+    textLength,
+    missing: missing.map((s) => s.heading),
+    durationMs: Math.round((performance.now() - startedAt) * 1000) / 1000,
+  };
+  recordTelemetry(entry, payload.transcript_path);
 }
 
 try {

--- a/hooks/three-section-close.mjs
+++ b/hooks/three-section-close.mjs
@@ -22,9 +22,11 @@
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 
 const MIN_LENGTH_TO_GATE = 600;
 
@@ -91,30 +93,6 @@ function emitBlock(missing) {
   const reason =
     `Your reply is missing the required 3-section close. Add these sections at the end of the reply with these exact headings:\n${bullets}`;
   process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
-}
-
-function resolveHomeDir() {
-  // Explicit operator opt-out: only when BOTH HOME and USERPROFILE are set
-  // to the empty string (set, not undefined) do we skip telemetry entirely.
-  // Empty-string-on-both is a deliberate signal (used by tests and by
-  // operators who want telemetry disabled without editing settings.json).
-  // If only one var is empty and the other points at a valid path, fall
-  // back to the valid one — otherwise telemetry would silently disable
-  // whenever a shell happens to clear one variable.
-  const home = process.env.HOME;
-  const userProfile = process.env.USERPROFILE;
-  if (home === "" && userProfile === "") return "";
-  if (home) return home;
-  if (userProfile) return userProfile;
-  // Neither set to a truthy path: legitimately fall back to os.homedir()
-  // so normal non-test usage keeps working when env vars are merely missing.
-  try {
-    const fromOs = homedir();
-    if (fromOs) return fromOs;
-  } catch {
-    // os.homedir() can throw in pathological env conditions
-  }
-  return "";
 }
 
 function projectHashFor(transcriptPath) {

--- a/hooks/three-section-close.mjs
+++ b/hooks/three-section-close.mjs
@@ -94,8 +94,18 @@ function emitBlock(missing) {
 }
 
 function resolveHomeDir() {
-  const fromEnv = process.env.HOME || process.env.USERPROFILE;
-  if (fromEnv) return fromEnv;
+  // Explicit operator opt-out: if EITHER HOME or USERPROFILE is set to the
+  // empty string (set, not undefined), skip telemetry entirely. Do NOT fall
+  // back to os.homedir() in that case — empty-string is a deliberate signal
+  // (used by tests and by operators who want telemetry disabled without
+  // editing settings.json).
+  const home = process.env.HOME;
+  const userProfile = process.env.USERPROFILE;
+  if (home === "" || userProfile === "") return "";
+  if (home) return home;
+  if (userProfile) return userProfile;
+  // Both undefined: legitimately fall back to os.homedir() so normal
+  // non-test usage keeps working when env vars are merely missing.
   try {
     const fromOs = homedir();
     if (fromOs) return fromOs;

--- a/lib/resolve-home-dir.mjs
+++ b/lib/resolve-home-dir.mjs
@@ -1,0 +1,43 @@
+// resolve-home-dir.mts — Single source of truth for the telemetry home dir
+// resolution rule shared by hooks/three-section-close.mjs and bin/hook-stats.mjs.
+//
+// Previously this 20-line function lived in three byte-equivalent copies; this
+// module collapses them. Behavior is unchanged.
+import { homedir } from "node:os";
+/**
+ * Resolve the home directory used to locate `.claude/hook-telemetry/`.
+ *
+ * Contract (AND-semantic opt-out):
+ *   - If BOTH `HOME` and `USERPROFILE` are explicitly set to the empty string
+ *     (set, not merely undefined), return `""`. This is the operator/test
+ *     opt-out signal: telemetry is intentionally disabled.
+ *   - Otherwise return the first truthy value from, in order:
+ *     `process.env.HOME`, `process.env.USERPROFILE`, `os.homedir()`.
+ *   - If none yields a truthy path, return `""`.
+ *
+ * The AND-semantic is deliberate: an OR-semantic would silently disable
+ * telemetry whenever a shell happened to clear one variable while the other
+ * still pointed at a valid path.
+ *
+ * Never throws. `os.homedir()` is wrapped in try/catch because it can throw
+ * in pathological env conditions.
+ */
+export function resolveHomeDir() {
+    const home = process.env.HOME;
+    const userProfile = process.env.USERPROFILE;
+    if (home === "" && userProfile === "")
+        return "";
+    if (home)
+        return home;
+    if (userProfile)
+        return userProfile;
+    try {
+        const fromOs = homedir();
+        if (fromOs)
+            return fromOs;
+    }
+    catch {
+        // os.homedir() can throw in pathological env conditions
+    }
+    return "";
+}

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "build": "tsc -p tsconfig.json && node bin/generate-plugin-manifests.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "clean": "node -e \"const fs=require('node:fs'); for (const dir of ['bin','test','lib']) { if (!fs.existsSync(dir)) continue; for (const file of fs.readdirSync(dir)) { if (file.endsWith('.mjs')) fs.rmSync(dir + '/' + file, { force: true }); } }\"",
+    "hooks:stats": "node bin/hook-stats.mjs",
     "test": "npm run build && node --test test/*.test.mjs",
     "lint": "node bin/lint-transcript.mjs --help",
     "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin test lib plugins",

--- a/plugins/continuous-improvement/hooks/three-section-close.mjs
+++ b/plugins/continuous-improvement/hooks/three-section-close.mjs
@@ -94,18 +94,20 @@ function emitBlock(missing) {
 }
 
 function resolveHomeDir() {
-  // Explicit operator opt-out: if EITHER HOME or USERPROFILE is set to the
-  // empty string (set, not undefined), skip telemetry entirely. Do NOT fall
-  // back to os.homedir() in that case — empty-string is a deliberate signal
-  // (used by tests and by operators who want telemetry disabled without
-  // editing settings.json).
+  // Explicit operator opt-out: only when BOTH HOME and USERPROFILE are set
+  // to the empty string (set, not undefined) do we skip telemetry entirely.
+  // Empty-string-on-both is a deliberate signal (used by tests and by
+  // operators who want telemetry disabled without editing settings.json).
+  // If only one var is empty and the other points at a valid path, fall
+  // back to the valid one — otherwise telemetry would silently disable
+  // whenever a shell happens to clear one variable.
   const home = process.env.HOME;
   const userProfile = process.env.USERPROFILE;
-  if (home === "" || userProfile === "") return "";
+  if (home === "" && userProfile === "") return "";
   if (home) return home;
   if (userProfile) return userProfile;
-  // Both undefined: legitimately fall back to os.homedir() so normal
-  // non-test usage keeps working when env vars are merely missing.
+  // Neither set to a truthy path: legitimately fall back to os.homedir()
+  // so normal non-test usage keeps working when env vars are merely missing.
   try {
     const fromOs = homedir();
     if (fromOs) return fromOs;

--- a/plugins/continuous-improvement/hooks/three-section-close.mjs
+++ b/plugins/continuous-improvement/hooks/three-section-close.mjs
@@ -15,8 +15,16 @@
 // Heuristic: skip messages shorter than 600 chars. Pure clarifying replies
 // don't need the close; only substantive technical responses (work
 // summaries, plan responses, post-execution reports) get gated.
+//
+// Telemetry: best-effort JSONL line per gated invocation written to
+// ~/.claude/hook-telemetry/<project-hash>.jsonl. Never throws, never
+// blocks the response. No network. No transcript content recorded.
 
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { performance } from "node:perf_hooks";
 
 const MIN_LENGTH_TO_GATE = 600;
 
@@ -85,7 +93,48 @@ function emitBlock(missing) {
   process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
 }
 
+function resolveHomeDir() {
+  const fromEnv = process.env.HOME || process.env.USERPROFILE;
+  if (fromEnv) return fromEnv;
+  try {
+    const fromOs = homedir();
+    if (fromOs) return fromOs;
+  } catch {
+    // os.homedir() can throw in pathological env conditions
+  }
+  return "";
+}
+
+function projectHashFor(transcriptPath) {
+  const dir = dirname(transcriptPath);
+  let normalized = dir.split("\\").join("/");
+  if (platform() === "win32") normalized = normalized.toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+}
+
+function recordTelemetry(entry, transcriptPath) {
+  try {
+    const home = resolveHomeDir();
+    if (!home) return;
+    const telemetryDir = join(home, ".claude", "hook-telemetry");
+    try {
+      mkdirSync(telemetryDir, { recursive: true });
+    } catch {
+      return;
+    }
+    const file = join(telemetryDir, `${projectHashFor(transcriptPath)}.jsonl`);
+    try {
+      appendFileSync(file, JSON.stringify(entry) + "\n", "utf8");
+    } catch {
+      return;
+    }
+  } catch {
+    // belt-and-suspenders: telemetry must never throw
+  }
+}
+
 function main() {
+  const startedAt = performance.now();
   const stdin = readStdinSync();
   if (!stdin) return;
 
@@ -100,12 +149,32 @@ function main() {
     return; // fail open on read error
   }
   if (!lastText) return;
-  if (lastText.length < MIN_LENGTH_TO_GATE) return;
 
-  const missing = REQUIRED_SECTIONS.filter((s) => !s.pattern.test(lastText));
-  if (missing.length === 0) return;
+  const textLength = lastText.length;
+  let action;
+  let missing = [];
 
-  emitBlock(missing);
+  if (textLength < MIN_LENGTH_TO_GATE) {
+    action = "skip-short";
+  } else {
+    missing = REQUIRED_SECTIONS.filter((s) => !s.pattern.test(lastText));
+    if (missing.length === 0) {
+      action = "pass";
+    } else {
+      action = "block";
+      emitBlock(missing);
+    }
+  }
+
+  const entry = {
+    ts: new Date().toISOString(),
+    hook: "three-section-close",
+    action,
+    textLength,
+    missing: missing.map((s) => s.heading),
+    durationMs: Math.round((performance.now() - startedAt) * 1000) / 1000,
+  };
+  recordTelemetry(entry, payload.transcript_path);
 }
 
 try {

--- a/plugins/continuous-improvement/hooks/three-section-close.mjs
+++ b/plugins/continuous-improvement/hooks/three-section-close.mjs
@@ -22,9 +22,11 @@
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 
 const MIN_LENGTH_TO_GATE = 600;
 
@@ -91,30 +93,6 @@ function emitBlock(missing) {
   const reason =
     `Your reply is missing the required 3-section close. Add these sections at the end of the reply with these exact headings:\n${bullets}`;
   process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
-}
-
-function resolveHomeDir() {
-  // Explicit operator opt-out: only when BOTH HOME and USERPROFILE are set
-  // to the empty string (set, not undefined) do we skip telemetry entirely.
-  // Empty-string-on-both is a deliberate signal (used by tests and by
-  // operators who want telemetry disabled without editing settings.json).
-  // If only one var is empty and the other points at a valid path, fall
-  // back to the valid one — otherwise telemetry would silently disable
-  // whenever a shell happens to clear one variable.
-  const home = process.env.HOME;
-  const userProfile = process.env.USERPROFILE;
-  if (home === "" && userProfile === "") return "";
-  if (home) return home;
-  if (userProfile) return userProfile;
-  // Neither set to a truthy path: legitimately fall back to os.homedir()
-  // so normal non-test usage keeps working when env vars are merely missing.
-  try {
-    const fromOs = homedir();
-    if (fromOs) return fromOs;
-  } catch {
-    // os.homedir() can throw in pathological env conditions
-  }
-  return "";
 }
 
 function projectHashFor(transcriptPath) {

--- a/plugins/continuous-improvement/hooks/three-section-close.mjs
+++ b/plugins/continuous-improvement/hooks/three-section-close.mjs
@@ -94,8 +94,18 @@ function emitBlock(missing) {
 }
 
 function resolveHomeDir() {
-  const fromEnv = process.env.HOME || process.env.USERPROFILE;
-  if (fromEnv) return fromEnv;
+  // Explicit operator opt-out: if EITHER HOME or USERPROFILE is set to the
+  // empty string (set, not undefined), skip telemetry entirely. Do NOT fall
+  // back to os.homedir() in that case — empty-string is a deliberate signal
+  // (used by tests and by operators who want telemetry disabled without
+  // editing settings.json).
+  const home = process.env.HOME;
+  const userProfile = process.env.USERPROFILE;
+  if (home === "" || userProfile === "") return "";
+  if (home) return home;
+  if (userProfile) return userProfile;
+  // Both undefined: legitimately fall back to os.homedir() so normal
+  // non-test usage keeps working when env vars are merely missing.
   try {
     const fromOs = homedir();
     if (fromOs) return fromOs;

--- a/plugins/continuous-improvement/lib/resolve-home-dir.mjs
+++ b/plugins/continuous-improvement/lib/resolve-home-dir.mjs
@@ -1,0 +1,43 @@
+// resolve-home-dir.mts — Single source of truth for the telemetry home dir
+// resolution rule shared by hooks/three-section-close.mjs and bin/hook-stats.mjs.
+//
+// Previously this 20-line function lived in three byte-equivalent copies; this
+// module collapses them. Behavior is unchanged.
+import { homedir } from "node:os";
+/**
+ * Resolve the home directory used to locate `.claude/hook-telemetry/`.
+ *
+ * Contract (AND-semantic opt-out):
+ *   - If BOTH `HOME` and `USERPROFILE` are explicitly set to the empty string
+ *     (set, not merely undefined), return `""`. This is the operator/test
+ *     opt-out signal: telemetry is intentionally disabled.
+ *   - Otherwise return the first truthy value from, in order:
+ *     `process.env.HOME`, `process.env.USERPROFILE`, `os.homedir()`.
+ *   - If none yields a truthy path, return `""`.
+ *
+ * The AND-semantic is deliberate: an OR-semantic would silently disable
+ * telemetry whenever a shell happened to clear one variable while the other
+ * still pointed at a valid path.
+ *
+ * Never throws. `os.homedir()` is wrapped in try/catch because it can throw
+ * in pathological env conditions.
+ */
+export function resolveHomeDir() {
+    const home = process.env.HOME;
+    const userProfile = process.env.USERPROFILE;
+    if (home === "" && userProfile === "")
+        return "";
+    if (home)
+        return home;
+    if (userProfile)
+        return userProfile;
+    try {
+        const fromOs = homedir();
+        if (fromOs)
+            return fromOs;
+    }
+    catch {
+        // os.homedir() can throw in pathological env conditions
+    }
+    return "";
+}

--- a/src/bin/generate-plugin-manifests.mts
+++ b/src/bin/generate-plugin-manifests.mts
@@ -165,6 +165,10 @@ async function writePluginBundle(): Promise<void> {
       join(REPO_ROOT, "lib", "plugin-metadata.mjs"),
       join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs"),
     ),
+    copyFileTo(
+      join(REPO_ROOT, "lib", "resolve-home-dir.mjs"),
+      join(PLUGIN_BUNDLE_DIR, "lib", "resolve-home-dir.mjs"),
+    ),
     copyFileTo(join(REPO_ROOT, "LICENSE"), join(PLUGIN_BUNDLE_DIR, "LICENSE")),
     writePluginBundleReadme(),
   ]);

--- a/src/bin/hook-stats.mts
+++ b/src/bin/hook-stats.mts
@@ -132,9 +132,12 @@ function parseArgs(rawArgs: readonly string[]): CliOptions {
 }
 
 function resolveHomeDir(): string {
+  // Mirrors the hook: explicit opt-out requires BOTH env vars empty.
+  // OR-semantic would silently disable the CLI when a shell happened to
+  // clear one variable while the other still pointed at a valid path.
   const home = env.HOME;
   const userProfile = env.USERPROFILE;
-  if (home === "" || userProfile === "") return "";
+  if (home === "" && userProfile === "") return "";
   if (home) return home;
   if (userProfile) return userProfile;
   try {

--- a/src/bin/hook-stats.mts
+++ b/src/bin/hook-stats.mts
@@ -1,0 +1,310 @@
+#!/usr/bin/env node
+
+/**
+ * Hook Stats Reader
+ *
+ * Reads JSONL telemetry written by Claude Code Stop hooks (e.g. the
+ * three-section-close hook) from `<HOME>/.claude/hook-telemetry/*.jsonl`
+ * and prints per-hook aggregate counts over a recent time window.
+ *
+ * Each input line is JSON of the shape:
+ *   {
+ *     "ts": "<ISO timestamp>",
+ *     "hook": "<hook-name>",
+ *     "action": "pass" | "block" | "skip-short",
+ *     "textLength": <number>,
+ *     "missing": <string[]>,
+ *     "durationMs": <number>
+ *   }
+ *
+ * The reader is parse-tolerant: malformed lines are skipped silently so
+ * the CLI keeps working even when the hook has been crash-restarted mid
+ * append. The hook itself is fail-open; the reader matches that posture.
+ *
+ * Project hash:
+ *   The hook keys telemetry files by a 12-char sha256 prefix of the
+ *   *project* directory (the dir containing the transcript). For the CLI,
+ *   the "project" is the current working directory: we normalize path
+ *   separators to forward slash, lowercase on win32, then sha256 and
+ *   slice the first 12 hex chars. Pass `--hash=<value>` to override.
+ *
+ * Usage:
+ *   node bin/hook-stats.mjs [--hours=<n>] [--hash=<hash>] [--telemetry-dir=<path>]
+ *   node bin/hook-stats.mjs --help
+ *
+ * Defaults:
+ *   --hours          24
+ *   --hash           sha256(normalize(process.cwd())).slice(0, 12)
+ *   --telemetry-dir  <HOME>/.claude/hook-telemetry
+ *
+ * Exit codes:
+ *   0 — printed aggregate (or "no records" message)
+ *   1 — unexpected error
+ */
+
+import { createHash } from "node:crypto";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { join } from "node:path";
+import { argv, cwd, env, exit, stderr, stdout } from "node:process";
+
+interface CliOptions {
+  hours: number;
+  hash: string | null;
+  telemetryDir: string | null;
+  help: boolean;
+}
+
+interface TelemetryRecord {
+  ts: string;
+  hook: string;
+  action: string;
+  textLength?: number;
+  missing?: string[];
+  durationMs?: number;
+}
+
+interface HookAggregate {
+  hook: string;
+  pass: number;
+  block: number;
+  skipShort: number;
+  total: number;
+  durationSum: number;
+  durationCount: number;
+}
+
+const USAGE = `Usage: node bin/hook-stats.mjs [options]
+
+Reads JSONL telemetry from <HOME>/.claude/hook-telemetry/*.jsonl and
+prints per-hook aggregate counts over a recent time window.
+
+Options:
+  --hours=<n>            Time window in hours (default: 24)
+  --hash=<hash>          Only read this single <hash>.jsonl file
+                         (default: sha256 of the current working directory,
+                         normalized to forward slashes and lowercased on
+                         Windows, then first 12 hex chars)
+  --telemetry-dir=<path> Override telemetry dir
+                         (default: <HOME>/.claude/hook-telemetry)
+  --help                 Show this help and exit 0
+
+Output:
+  One line per hook: "<hook> last <hours>h: pass=<n> block=<n>
+  skip-short=<n> total=<n> avg-duration=<X>ms".
+  If there are no records in the window: "no records in last <hours>h".
+
+The reader is parse-tolerant: malformed JSONL lines are skipped silently.
+`;
+
+function parseArgs(rawArgs: readonly string[]): CliOptions {
+  const opts: CliOptions = {
+    hours: 24,
+    hash: null,
+    telemetryDir: null,
+    help: false,
+  };
+  for (const arg of rawArgs) {
+    if (arg === "--help" || arg === "-h") {
+      opts.help = true;
+      continue;
+    }
+    if (arg.startsWith("--hours=")) {
+      const raw = arg.slice("--hours=".length);
+      const n = Number(raw);
+      if (!Number.isFinite(n) || n <= 0) {
+        throw new Error(`invalid --hours value: ${raw}`);
+      }
+      opts.hours = n;
+      continue;
+    }
+    if (arg.startsWith("--hash=")) {
+      opts.hash = arg.slice("--hash=".length);
+      continue;
+    }
+    if (arg.startsWith("--telemetry-dir=")) {
+      opts.telemetryDir = arg.slice("--telemetry-dir=".length);
+      continue;
+    }
+    throw new Error(`unknown argument: ${arg}`);
+  }
+  return opts;
+}
+
+function resolveHomeDir(): string {
+  const home = env.HOME;
+  const userProfile = env.USERPROFILE;
+  if (home === "" || userProfile === "") return "";
+  if (home) return home;
+  if (userProfile) return userProfile;
+  try {
+    const fromOs = homedir();
+    if (fromOs) return fromOs;
+  } catch {
+    // ignore
+  }
+  return "";
+}
+
+export function projectHashForCwd(workingDir: string): string {
+  let normalized = workingDir.split("\\").join("/");
+  if (platform() === "win32") normalized = normalized.toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+}
+
+function listJsonlFiles(dir: string, hashFilter: string | null): string[] {
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    if (hashFilter !== null) {
+      if (name !== `${hashFilter}.jsonl`) continue;
+    }
+    const full = join(dir, name);
+    try {
+      const stat = statSync(full);
+      if (!stat.isFile()) continue;
+    } catch {
+      continue;
+    }
+    out.push(full);
+  }
+  return out;
+}
+
+function safeJsonParse(line: string): TelemetryRecord | null {
+  try {
+    const parsed = JSON.parse(line) as unknown;
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as { hook?: unknown }).hook === "string" &&
+      typeof (parsed as { ts?: unknown }).ts === "string" &&
+      typeof (parsed as { action?: unknown }).action === "string"
+    ) {
+      return parsed as TelemetryRecord;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function aggregate(
+  records: readonly TelemetryRecord[],
+  cutoffMs: number,
+): HookAggregate[] {
+  const byHook = new Map<string, HookAggregate>();
+  for (const rec of records) {
+    const tsMs = Date.parse(rec.ts);
+    if (!Number.isFinite(tsMs)) continue;
+    if (tsMs < cutoffMs) continue;
+    let agg = byHook.get(rec.hook);
+    if (!agg) {
+      agg = {
+        hook: rec.hook,
+        pass: 0,
+        block: 0,
+        skipShort: 0,
+        total: 0,
+        durationSum: 0,
+        durationCount: 0,
+      };
+      byHook.set(rec.hook, agg);
+    }
+    agg.total += 1;
+    if (rec.action === "pass") agg.pass += 1;
+    else if (rec.action === "block") agg.block += 1;
+    else if (rec.action === "skip-short") agg.skipShort += 1;
+    if (typeof rec.durationMs === "number" && Number.isFinite(rec.durationMs)) {
+      agg.durationSum += rec.durationMs;
+      agg.durationCount += 1;
+    }
+  }
+  return Array.from(byHook.values()).sort((a, b) =>
+    a.hook.localeCompare(b.hook),
+  );
+}
+
+function formatAggregate(agg: HookAggregate, hours: number): string {
+  const avg =
+    agg.durationCount > 0
+      ? Math.round(agg.durationSum / agg.durationCount)
+      : 0;
+  return `${agg.hook} last ${hours}h: pass=${agg.pass} block=${agg.block} skip-short=${agg.skipShort} total=${agg.total} avg-duration=${avg}ms`;
+}
+
+function main(): void {
+  const opts = parseArgs(argv.slice(2));
+  if (opts.help) {
+    stdout.write(USAGE);
+    exit(0);
+  }
+
+  let telemetryDir: string;
+  if (opts.telemetryDir !== null) {
+    telemetryDir = opts.telemetryDir;
+  } else {
+    const home = resolveHomeDir();
+    if (!home) {
+      stderr.write("no telemetry dir resolved\n");
+      exit(0);
+    }
+    telemetryDir = join(home, ".claude", "hook-telemetry");
+  }
+
+  const hashFilter = opts.hash ?? projectHashForCwd(cwd());
+  // When the user did not pass --hash, we still read all files (per spec).
+  // Only restrict to a single file when --hash is explicitly set.
+  const useHashFilter = opts.hash !== null;
+  const files = listJsonlFiles(
+    telemetryDir,
+    useHashFilter ? hashFilter : null,
+  );
+
+  const records: TelemetryRecord[] = [];
+  for (const file of files) {
+    let content: string;
+    try {
+      content = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const rawLine of content.split(/\r?\n/)) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      const rec = safeJsonParse(line);
+      if (rec) records.push(rec);
+    }
+  }
+
+  const cutoffMs = Date.now() - opts.hours * 3600 * 1000;
+  const aggregates = aggregate(records, cutoffMs);
+
+  if (aggregates.length === 0) {
+    stdout.write(`no records in last ${opts.hours}h\n`);
+    exit(0);
+  }
+
+  for (const agg of aggregates) {
+    stdout.write(formatAggregate(agg, opts.hours) + "\n");
+  }
+  exit(0);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].split("\\").join("/"));
+if (invokedDirectly || argv[1]?.endsWith("hook-stats.mjs")) {
+  try {
+    main();
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    stderr.write(`${message}\n`);
+    exit(1);
+  }
+}

--- a/src/bin/hook-stats.mts
+++ b/src/bin/hook-stats.mts
@@ -44,9 +44,11 @@
 
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { join } from "node:path";
-import { argv, cwd, env, exit, stderr, stdout } from "node:process";
+import { argv, cwd, exit, stderr, stdout } from "node:process";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 
 interface CliOptions {
   hours: number;
@@ -129,24 +131,6 @@ function parseArgs(rawArgs: readonly string[]): CliOptions {
     throw new Error(`unknown argument: ${arg}`);
   }
   return opts;
-}
-
-function resolveHomeDir(): string {
-  // Mirrors the hook: explicit opt-out requires BOTH env vars empty.
-  // OR-semantic would silently disable the CLI when a shell happened to
-  // clear one variable while the other still pointed at a valid path.
-  const home = env.HOME;
-  const userProfile = env.USERPROFILE;
-  if (home === "" && userProfile === "") return "";
-  if (home) return home;
-  if (userProfile) return userProfile;
-  try {
-    const fromOs = homedir();
-    if (fromOs) return fromOs;
-  } catch {
-    // ignore
-  }
-  return "";
 }
 
 export function projectHashForCwd(workingDir: string): string {

--- a/src/lib/resolve-home-dir.mts
+++ b/src/lib/resolve-home-dir.mts
@@ -1,0 +1,40 @@
+// resolve-home-dir.mts — Single source of truth for the telemetry home dir
+// resolution rule shared by hooks/three-section-close.mjs and bin/hook-stats.mjs.
+//
+// Previously this 20-line function lived in three byte-equivalent copies; this
+// module collapses them. Behavior is unchanged.
+
+import { homedir } from "node:os";
+
+/**
+ * Resolve the home directory used to locate `.claude/hook-telemetry/`.
+ *
+ * Contract (AND-semantic opt-out):
+ *   - If BOTH `HOME` and `USERPROFILE` are explicitly set to the empty string
+ *     (set, not merely undefined), return `""`. This is the operator/test
+ *     opt-out signal: telemetry is intentionally disabled.
+ *   - Otherwise return the first truthy value from, in order:
+ *     `process.env.HOME`, `process.env.USERPROFILE`, `os.homedir()`.
+ *   - If none yields a truthy path, return `""`.
+ *
+ * The AND-semantic is deliberate: an OR-semantic would silently disable
+ * telemetry whenever a shell happened to clear one variable while the other
+ * still pointed at a valid path.
+ *
+ * Never throws. `os.homedir()` is wrapped in try/catch because it can throw
+ * in pathological env conditions.
+ */
+export function resolveHomeDir(): string {
+  const home = process.env.HOME;
+  const userProfile = process.env.USERPROFILE;
+  if (home === "" && userProfile === "") return "";
+  if (home) return home;
+  if (userProfile) return userProfile;
+  try {
+    const fromOs = homedir();
+    if (fromOs) return fromOs;
+  } catch {
+    // os.homedir() can throw in pathological env conditions
+  }
+  return "";
+}

--- a/src/test/cross-skill-contract.test.mts
+++ b/src/test/cross-skill-contract.test.mts
@@ -1,0 +1,168 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+// ----- Asserted contract literals (single source of truth) ----------------
+//
+// Half 1: proceed-with-the-recommendation must reference wild-risa-balance
+// in its Phase 1 section, naming both the upstream skill and the block-shape
+// contract phrasing.
+const PROCEED_WILD_RISA_REF_LITERAL = "wild-risa-balance";
+const PROCEED_PHASE1_BLOCK_SHAPE_LITERAL = "2 WILD + at least 5 RISA";
+// The exact "composed under" phrase as written in the SKILL.md (with the
+// embedded backticks around the skill name).
+const PROCEED_COMPOSED_UNDER_LITERAL = "composed under `wild-risa-balance`";
+
+// Half 2: wild-risa-balance must reference proceed-with-the-recommendation
+// as its execution arm, plus the auto-trigger discipline literal.
+const WILD_PROCEED_REF_LITERAL = "proceed-with-the-recommendation";
+const WILD_EXECUTION_ARM_LITERAL = "execution arm";
+const WILD_NEVER_AUTO_TRIGGER_LITERAL = "Never auto-trigger";
+
+// ----- Mirror tables -------------------------------------------------------
+
+const PROCEED_MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
+  {
+    path: "skills/proceed-with-the-recommendation.md",
+    label: "source skill",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+    label: "plugin mirror",
+  },
+];
+
+const WILD_MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
+  {
+    path: "skills/wild-risa-balance.md",
+    label: "source skill",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md",
+    label: "plugin mirror",
+  },
+];
+
+// ----- Heading regexes (m flag — heading casing is stable) ----------------
+
+const PHASE_1_HEADING_RE = /^##\s+Phase\s+1:/m;
+const NEXT_H2_RE = /^##\s+/m;
+
+// ----- Section extraction --------------------------------------------------
+
+function extractPhase1(content: string, mirrorPath: string): string {
+  const startMatch = content.match(PHASE_1_HEADING_RE);
+  assert.ok(
+    startMatch && typeof startMatch.index === "number",
+    `${mirrorPath}: missing "## Phase 1:" heading — Phase 1 section is gone or renamed.`,
+  );
+  const start = startMatch!.index!;
+  const headingLineEnd = content.indexOf("\n", start);
+  const tailFromBody = content.slice(headingLineEnd + 1);
+  const endRel = tailFromBody.search(NEXT_H2_RE);
+  const body = endRel === -1 ? tailFromBody : tailFromBody.slice(0, endRel);
+  assert.ok(
+    body.trim().length > 0,
+    `${mirrorPath}: "## Phase 1:" section is empty.`,
+  );
+  return body;
+}
+
+function assertContains(
+  haystack: string,
+  needle: string,
+  mirrorPath: string,
+  half: string,
+  clauseLabel: string,
+): void {
+  assert.ok(
+    haystack.includes(needle),
+    `${mirrorPath} :: ${half} :: ${clauseLabel} :: missing required literal: ${needle}`,
+  );
+}
+
+// ----- Half 1 — proceed-with-the-recommendation references wild-risa-balance
+
+describe("cross-skill contract — proceed-with-the-recommendation references wild-risa-balance", () => {
+  for (const mirror of PROCEED_MIRRORS) {
+    describe(`${mirror.label} (${mirror.path})`, () => {
+      const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+      const phase1 = extractPhase1(content, mirror.path);
+
+      it("Phase 1 names wild-risa-balance as the upstream skill", () => {
+        assertContains(
+          phase1,
+          PROCEED_WILD_RISA_REF_LITERAL,
+          mirror.path,
+          "Half 1",
+          "Phase 1 cross-reference to wild-risa-balance",
+        );
+      });
+
+      it("Phase 1 contains the block-shape contract literal '2 WILD + at least 5 RISA'", () => {
+        assertContains(
+          phase1,
+          PROCEED_PHASE1_BLOCK_SHAPE_LITERAL,
+          mirror.path,
+          "Half 1",
+          "Phase 1 block-shape contract literal",
+        );
+      });
+
+      it("file declares the list was 'composed under `wild-risa-balance`'", () => {
+        assertContains(
+          content,
+          PROCEED_COMPOSED_UNDER_LITERAL,
+          mirror.path,
+          "Half 1",
+          "composed-under upstream-skill phrase",
+        );
+      });
+    });
+  }
+});
+
+// ----- Half 2 — wild-risa-balance references proceed-with-the-recommendation
+
+describe("cross-skill contract — wild-risa-balance references proceed-with-the-recommendation", () => {
+  for (const mirror of WILD_MIRRORS) {
+    describe(`${mirror.label} (${mirror.path})`, () => {
+      const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+
+      it("file names proceed-with-the-recommendation as a related skill", () => {
+        assertContains(
+          content,
+          WILD_PROCEED_REF_LITERAL,
+          mirror.path,
+          "Half 2",
+          "cross-reference to proceed-with-the-recommendation",
+        );
+      });
+
+      it("file describes proceed-with-the-recommendation as the 'execution arm'", () => {
+        assertContains(
+          content,
+          WILD_EXECUTION_ARM_LITERAL,
+          mirror.path,
+          "Half 2",
+          "execution-arm role description",
+        );
+      });
+
+      it("file anchors the auto-trigger discipline with literal 'Never auto-trigger'", () => {
+        assertContains(
+          content,
+          WILD_NEVER_AUTO_TRIGGER_LITERAL,
+          mirror.path,
+          "Half 2",
+          "auto-trigger discipline literal",
+        );
+      });
+    });
+  }
+});

--- a/src/test/hook-stats.test.mts
+++ b/src/test/hook-stats.test.mts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  appendFileSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CLI = join(REPO_ROOT, "bin", "hook-stats.mjs");
+
+interface TelemetryEntry {
+  ts: string;
+  hook: string;
+  action: "pass" | "block" | "skip-short";
+  textLength: number;
+  missing: string[];
+  durationMs: number;
+}
+
+function makeEntry(overrides: Partial<TelemetryEntry> = {}): TelemetryEntry {
+  return {
+    ts: new Date().toISOString(),
+    hook: "three-section-close",
+    action: "pass",
+    textLength: 1200,
+    missing: [],
+    durationMs: 5,
+    ...overrides,
+  };
+}
+
+function writeJsonl(file: string, entries: readonly TelemetryEntry[]): void {
+  const body = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  writeFileSync(file, body, "utf8");
+}
+
+interface RunResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: readonly string[]): RunResult {
+  const result = spawnSync(process.execPath, [CLI, ...args], {
+    encoding: "utf8",
+    timeout: 10000,
+  });
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("hook-stats CLI", () => {
+  const tempDirs: string[] = [];
+
+  function freshTelemetryDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), "hook-stats-test-"));
+    tempDirs.push(dir);
+    return dir;
+  }
+
+  after(() => {
+    for (const dir of tempDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--help exits 0 and prints usage on stdout", () => {
+    const res = runCli(["--help"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.match(res.stdout, /Usage: node bin\/hook-stats\.mjs/);
+    assert.match(res.stdout, /--hours=<n>/);
+    assert.match(res.stdout, /--hash=<hash>/);
+    assert.match(res.stdout, /--telemetry-dir=<path>/);
+  });
+
+  it("happy path: aggregates pass/block/skip-short counts and avg duration", () => {
+    const dir = freshTelemetryDir();
+    const file = join(dir, "abcdef012345.jsonl");
+    const now = Date.now();
+    const entries: TelemetryEntry[] = [];
+    // 5 pass with durationMs 10
+    for (let i = 0; i < 5; i++) {
+      entries.push(
+        makeEntry({
+          ts: new Date(now - i * 60_000).toISOString(),
+          action: "pass",
+          durationMs: 10,
+        }),
+      );
+    }
+    // 3 block with durationMs 20
+    for (let i = 0; i < 3; i++) {
+      entries.push(
+        makeEntry({
+          ts: new Date(now - (i + 5) * 60_000).toISOString(),
+          action: "block",
+          durationMs: 20,
+        }),
+      );
+    }
+    // 2 skip-short with durationMs 30
+    for (let i = 0; i < 2; i++) {
+      entries.push(
+        makeEntry({
+          ts: new Date(now - (i + 8) * 60_000).toISOString(),
+          action: "skip-short",
+          durationMs: 30,
+        }),
+      );
+    }
+    writeJsonl(file, entries);
+
+    const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    // avg = (5*10 + 3*20 + 2*30) / 10 = (50 + 60 + 60) / 10 = 17 (rounded)
+    assert.match(
+      res.stdout,
+      /three-section-close last 24h: pass=5 block=3 skip-short=2 total=10 avg-duration=17ms/,
+    );
+  });
+
+  it("filters out records older than the --hours window", () => {
+    const dir = freshTelemetryDir();
+    const file = join(dir, "deadbeef0001.jsonl");
+    const now = Date.now();
+    const fresh1 = makeEntry({
+      ts: new Date(now - 60_000).toISOString(),
+      action: "pass",
+      durationMs: 4,
+    });
+    const fresh2 = makeEntry({
+      ts: new Date(now - 120_000).toISOString(),
+      action: "block",
+      durationMs: 6,
+    });
+    const stale = makeEntry({
+      ts: new Date(now - 48 * 3600 * 1000).toISOString(),
+      action: "pass",
+      durationMs: 999,
+    });
+    writeJsonl(file, [fresh1, fresh2, stale]);
+
+    const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    // Only the 2 fresh records counted; avg = (4 + 6)/2 = 5
+    assert.match(
+      res.stdout,
+      /three-section-close last 24h: pass=1 block=1 skip-short=0 total=2 avg-duration=5ms/,
+    );
+  });
+
+  it("tolerates malformed JSONL lines and counts only valid records", () => {
+    const dir = freshTelemetryDir();
+    const file = join(dir, "ffffffffffff.jsonl");
+    const now = Date.now();
+    const valid1 = JSON.stringify(
+      makeEntry({
+        ts: new Date(now - 60_000).toISOString(),
+        action: "pass",
+        durationMs: 8,
+      }),
+    );
+    const valid2 = JSON.stringify(
+      makeEntry({
+        ts: new Date(now - 120_000).toISOString(),
+        action: "block",
+        durationMs: 12,
+      }),
+    );
+    // Garbage between valid lines and at the end.
+    const body = [valid1, "{not-json", "", valid2, "trailing garbage"].join(
+      "\n",
+    );
+    writeFileSync(file, body + "\n", "utf8");
+
+    const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.match(
+      res.stdout,
+      /three-section-close last 24h: pass=1 block=1 skip-short=0 total=2 avg-duration=10ms/,
+    );
+  });
+
+  it("prints 'no records' when telemetry dir exists but has no JSONL files", () => {
+    const dir = freshTelemetryDir();
+    const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.match(res.stdout, /no records in last 24h/);
+  });
+
+  it("--hash filter restricts reading to a single <hash>.jsonl file", () => {
+    const dir = freshTelemetryDir();
+    const fileA = join(dir, "aaaaaaaaaaaa.jsonl");
+    const fileB = join(dir, "bbbbbbbbbbbb.jsonl");
+    const now = Date.now();
+    writeJsonl(fileA, [
+      makeEntry({
+        ts: new Date(now - 60_000).toISOString(),
+        action: "pass",
+        durationMs: 7,
+        hook: "three-section-close",
+      }),
+    ]);
+    writeJsonl(fileB, [
+      makeEntry({
+        ts: new Date(now - 60_000).toISOString(),
+        action: "block",
+        durationMs: 999,
+        hook: "three-section-close",
+      }),
+      makeEntry({
+        ts: new Date(now - 90_000).toISOString(),
+        action: "block",
+        durationMs: 999,
+        hook: "three-section-close",
+      }),
+    ]);
+
+    const res = runCli([
+      `--telemetry-dir=${dir}`,
+      "--hours=24",
+      "--hash=aaaaaaaaaaaa",
+    ]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.match(
+      res.stdout,
+      /three-section-close last 24h: pass=1 block=0 skip-short=0 total=1 avg-duration=7ms/,
+    );
+    // Should NOT include the bbbb file's records.
+    assert.doesNotMatch(res.stdout, /total=2/);
+    assert.doesNotMatch(res.stdout, /total=3/);
+  });
+
+  it("groups multiple hooks separately in output", () => {
+    const dir = freshTelemetryDir();
+    const file = join(dir, "112233445566.jsonl");
+    const now = Date.now();
+    const entries: TelemetryEntry[] = [
+      makeEntry({
+        ts: new Date(now - 30_000).toISOString(),
+        hook: "alpha-hook",
+        action: "pass",
+        durationMs: 2,
+      }),
+      makeEntry({
+        ts: new Date(now - 30_000).toISOString(),
+        hook: "alpha-hook",
+        action: "pass",
+        durationMs: 4,
+      }),
+      makeEntry({
+        ts: new Date(now - 30_000).toISOString(),
+        hook: "beta-hook",
+        action: "block",
+        durationMs: 100,
+      }),
+    ];
+    writeJsonl(file, entries);
+
+    const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+    assert.match(
+      res.stdout,
+      /alpha-hook last 24h: pass=2 block=0 skip-short=0 total=2 avg-duration=3ms/,
+    );
+    assert.match(
+      res.stdout,
+      /beta-hook last 24h: pass=0 block=1 skip-short=0 total=1 avg-duration=100ms/,
+    );
+  });
+
+  it("appends are visible: re-running picks up newly added lines", () => {
+    const dir = freshTelemetryDir();
+    const file = join(dir, "0011223344aa.jsonl");
+    const now = Date.now();
+    writeJsonl(file, [
+      makeEntry({
+        ts: new Date(now - 30_000).toISOString(),
+        action: "pass",
+        durationMs: 5,
+      }),
+    ]);
+    let res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.match(res.stdout, /total=1/);
+
+    appendFileSync(
+      file,
+      JSON.stringify(
+        makeEntry({
+          ts: new Date().toISOString(),
+          action: "block",
+          durationMs: 9,
+        }),
+      ) + "\n",
+      "utf8",
+    );
+    res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+    assert.match(
+      res.stdout,
+      /three-section-close last 24h: pass=1 block=1 skip-short=0 total=2 avg-duration=7ms/,
+    );
+  });
+});

--- a/src/test/hook.test.mts
+++ b/src/test/hook.test.mts
@@ -192,10 +192,15 @@ function runThreeSectionClose(
   payload: string,
   extraEnv: Record<string, string> = {},
 ) {
+  // Empty-string HOME/USERPROFILE = explicit opt-out signal recognized by
+  // three-section-close.mjs. This blocks the hook from writing telemetry into
+  // the developer's real ~/.claude/hook-telemetry/ during every `npm test` run.
+  // None of the cases in this file assert on telemetry presence; they only
+  // check stdout/status. Callers can still override via extraEnv if needed.
   const result = spawnSync(process.execPath, ["./three-section-close.mjs"], {
     input: payload,
     cwd: HOOKS_DIR,
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, HOME: "", USERPROFILE: "", ...extraEnv },
     encoding: "utf8",
     timeout: 5000,
   });

--- a/src/test/phase7-close-spec.test.mts
+++ b/src/test/phase7-close-spec.test.mts
@@ -1,0 +1,199 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+const MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
+  {
+    path: "skills/proceed-with-the-recommendation.md",
+    label: "source skill",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+    label: "plugin mirror",
+  },
+];
+
+// Asserted contract literals — every magic string used in `.includes(...)` is
+// hoisted here so a single source of truth governs what the skill must say.
+const HEADING_DONE_LITERAL = "### 1. What has been done";
+const HEADING_NEXT_LITERAL = "### 2. What is next";
+const HEADING_RECOMMENDATION_LITERAL = "### 3. Recommendation";
+
+const TIER_1_LITERAL = "Tier 1 — strong fit";
+const TIER_2_LITERAL = "Tier 2 — high-fit complements";
+const SKIP_TIER_LITERAL = "Skip these — already covered";
+const TIER_1_CITATION_LITERAL = "concrete file/line/rule citation";
+
+const WANT_ME_TO_LITERAL = "Want me to:";
+const EXACTLY_TWO_OPTIONS_LITERAL = "exactly two options";
+
+const TINY_LIST_EXEMPTION_LITERAL = "Tiny-list exemption:";
+const TINY_LIST_THRESHOLD_LITERAL = "≤1 item";
+
+const PHASE_7_HEADING_RE = /^##\s+Phase\s+7:\s+End-of-Run Summary[^\n]*$/m;
+const NEXT_H2_RE = /^##\s+/m;
+
+function extractPhase7(content: string, mirrorPath: string): string {
+  const startMatch = content.match(PHASE_7_HEADING_RE);
+  assert.ok(
+    startMatch && typeof startMatch.index === "number",
+    `${mirrorPath}: missing "## Phase 7: End-of-Run Summary" heading — Phase 7 section is gone or renamed.`,
+  );
+  const start = startMatch!.index!;
+  const headingLineEnd = content.indexOf("\n", start);
+  const tailFromBody = content.slice(headingLineEnd + 1);
+  const endRel = tailFromBody.search(NEXT_H2_RE);
+  const body = endRel === -1 ? tailFromBody : tailFromBody.slice(0, endRel);
+  assert.ok(
+    body.trim().length > 0,
+    `${mirrorPath}: "## Phase 7" section is empty.`,
+  );
+  return body;
+}
+
+function assertContains(
+  haystack: string,
+  needle: string,
+  mirrorPath: string,
+  clauseLabel: string,
+): void {
+  assert.ok(
+    haystack.includes(needle),
+    `${mirrorPath} :: Phase 7 :: ${clauseLabel} :: missing required literal: ${needle}`,
+  );
+}
+
+describe("proceed-with-the-recommendation Phase 7 close behavioral spec", () => {
+  for (const mirror of MIRRORS) {
+    describe(`${mirror.label} (${mirror.path})`, () => {
+      const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+      const phase7 = extractPhase7(content, mirror.path);
+
+      describe("3-section close shape", () => {
+        it(`contains literal "${HEADING_DONE_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            HEADING_DONE_LITERAL,
+            mirror.path,
+            "3-section close — section 1 heading",
+          );
+        });
+
+        it(`contains literal "${HEADING_NEXT_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            HEADING_NEXT_LITERAL,
+            mirror.path,
+            "3-section close — section 2 heading",
+          );
+        });
+
+        it(`contains literal "${HEADING_RECOMMENDATION_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            HEADING_RECOMMENDATION_LITERAL,
+            mirror.path,
+            "3-section close — section 3 heading",
+          );
+        });
+
+        it("the three section headings appear in strict order 1 → 2 → 3", () => {
+          const idxDone = phase7.indexOf(HEADING_DONE_LITERAL);
+          const idxNext = phase7.indexOf(HEADING_NEXT_LITERAL);
+          const idxRec = phase7.indexOf(HEADING_RECOMMENDATION_LITERAL);
+          assert.ok(
+            idxDone >= 0 && idxNext >= 0 && idxRec >= 0,
+            `${mirror.path} :: Phase 7 :: 3-section close :: one or more section headings missing — cannot verify ordering. Indexes: done=${idxDone}, next=${idxNext}, rec=${idxRec}.`,
+          );
+          assert.ok(
+            idxDone < idxNext && idxNext < idxRec,
+            `${mirror.path} :: Phase 7 :: 3-section close :: section headings out of order — expected 1 → 2 → 3, got indexes done=${idxDone}, next=${idxNext}, rec=${idxRec}.`,
+          );
+        });
+      });
+
+      describe("Tiered Recommendation block", () => {
+        it(`contains literal "${TIER_1_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            TIER_1_LITERAL,
+            mirror.path,
+            "Tiered Recommendation — Tier 1 row label",
+          );
+        });
+
+        it(`contains literal "${TIER_2_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            TIER_2_LITERAL,
+            mirror.path,
+            "Tiered Recommendation — Tier 2 row label",
+          );
+        });
+
+        it(`contains literal "${SKIP_TIER_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            SKIP_TIER_LITERAL,
+            mirror.path,
+            "Tiered Recommendation — Skip row label",
+          );
+        });
+
+        it(`Tier 1 evidence rule mentions literal "${TIER_1_CITATION_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            TIER_1_CITATION_LITERAL,
+            mirror.path,
+            "Tiered Recommendation — Tier 1 concrete-citation requirement",
+          );
+        });
+      });
+
+      describe("Want me to: block", () => {
+        it(`contains literal "${WANT_ME_TO_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            WANT_ME_TO_LITERAL,
+            mirror.path,
+            "Want me to: block — prompt prefix",
+          );
+        });
+
+        it(`contains literal "${EXACTLY_TWO_OPTIONS_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            EXACTLY_TWO_OPTIONS_LITERAL,
+            mirror.path,
+            "Want me to: block — exactly-two-options rule",
+          );
+        });
+      });
+
+      describe("Tiny-list exemption", () => {
+        it(`contains literal "${TINY_LIST_EXEMPTION_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            TINY_LIST_EXEMPTION_LITERAL,
+            mirror.path,
+            "Tiny-list exemption — clause prefix",
+          );
+        });
+
+        it(`contains literal "${TINY_LIST_THRESHOLD_LITERAL}"`, () => {
+          assertContains(
+            phase7,
+            TINY_LIST_THRESHOLD_LITERAL,
+            mirror.path,
+            "Tiny-list exemption — ≤1 item threshold",
+          );
+        });
+      });
+    });
+  }
+});

--- a/src/test/pmag-spec.test.mts
+++ b/src/test/pmag-spec.test.mts
@@ -1,0 +1,242 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+const MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
+  {
+    path: "skills/proceed-with-the-recommendation.md",
+    label: "source skill",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+    label: "plugin mirror",
+  },
+];
+
+const PHASE_0_HEADING_RE = /^##\s+Phase\s+0:\s+Acknowledge.*P-MAG.*$/im;
+const PHASE_1_HEADING_RE = /^##\s+Phase\s+1:/im;
+const RULE_HEADING_RE = /^###\s+Rule\s+([123])\b[^\n]*$/gim;
+
+type RuleSection = { rule: 1 | 2 | 3; heading: string; body: string };
+
+function extractPhase0(content: string, mirrorPath: string): string {
+  const startMatch = content.match(PHASE_0_HEADING_RE);
+  assert.ok(
+    startMatch && typeof startMatch.index === "number",
+    `${mirrorPath}: missing "## Phase 0: Acknowledge ... P-MAG" heading — Phase 0 section is gone.`
+  );
+  const start = startMatch!.index!;
+  const tail = content.slice(start);
+  const endRel = tail.search(PHASE_1_HEADING_RE);
+  assert.ok(
+    endRel > 0,
+    `${mirrorPath}: missing "## Phase 1:" heading after Phase 0 — cannot bound the Phase 0 section.`
+  );
+  return tail.slice(0, endRel);
+}
+
+function extractRules(phase0: string, mirrorPath: string): Map<1 | 2 | 3, RuleSection> {
+  const rules = new Map<1 | 2 | 3, RuleSection>();
+  const matches: Array<{ rule: 1 | 2 | 3; heading: string; index: number }> = [];
+  RULE_HEADING_RE.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = RULE_HEADING_RE.exec(phase0)) !== null) {
+    const ruleNum = Number(m[1]) as 1 | 2 | 3;
+    matches.push({ rule: ruleNum, heading: m[0], index: m.index });
+  }
+  RULE_HEADING_RE.lastIndex = 0;
+
+  assert.ok(
+    matches.length >= 3,
+    `${mirrorPath}: expected at least 3 "### Rule N" subsections inside Phase 0, found ${matches.length}.`
+  );
+
+  for (let i = 0; i < matches.length; i++) {
+    const cur = matches[i]!;
+    const next = matches[i + 1];
+    const body = phase0.slice(cur.index, next ? next.index : phase0.length);
+    rules.set(cur.rule, { rule: cur.rule, heading: cur.heading, body });
+  }
+
+  for (const n of [1, 2, 3] as const) {
+    assert.ok(
+      rules.has(n),
+      `${mirrorPath}: Phase 0 is missing "### Rule ${n}" subsection.`
+    );
+  }
+  return rules;
+}
+
+function assertContains(
+  haystack: string,
+  needle: string,
+  mirrorPath: string,
+  ruleLabel: string,
+  clauseLabel: string
+): void {
+  assert.ok(
+    haystack.includes(needle),
+    `${mirrorPath} :: ${ruleLabel} :: missing required clause [${clauseLabel}] — expected literal:\n  ${needle}`
+  );
+}
+
+function assertMatches(
+  haystack: string,
+  pattern: RegExp,
+  mirrorPath: string,
+  ruleLabel: string,
+  clauseLabel: string
+): void {
+  assert.ok(
+    pattern.test(haystack),
+    `${mirrorPath} :: ${ruleLabel} :: missing required clause [${clauseLabel}] — expected pattern:\n  ${pattern}`
+  );
+}
+
+describe("proceed-with-the-recommendation P-MAG Phase 0 behavioral spec", () => {
+  for (const mirror of MIRRORS) {
+    describe(`${mirror.label} (${mirror.path})`, () => {
+      const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+      const phase0 = extractPhase0(content, mirror.path);
+      const rules = extractRules(phase0, mirror.path);
+
+      describe("Rule 1 — acknowledge before context", () => {
+        const rule1 = rules.get(1)!.body;
+
+        it("references observations.jsonl literally", () => {
+          assertContains(
+            rule1,
+            "observations.jsonl",
+            mirror.path,
+            "Rule 1",
+            "observations.jsonl reference"
+          );
+        });
+
+        it("defines the quote-line format with literal 'Past mistake observed:'", () => {
+          assertContains(
+            rule1,
+            "Past mistake observed:",
+            mirror.path,
+            "Rule 1",
+            "quote-line format prefix 'Past mistake observed:'"
+          );
+        });
+
+        it("defines the empty-surfaces fallback line", () => {
+          assertContains(
+            rule1,
+            "No prior mistakes recorded — proceed.",
+            mirror.path,
+            "Rule 1",
+            "empty-surfaces fallback line"
+          );
+        });
+      });
+
+      describe("Rule 2 — clearance gate", () => {
+        const rule2 = rules.get(2)!.body;
+
+        it("contains the literal halt prefix 'BLOCKED on prior mistake:'", () => {
+          assertContains(
+            rule2,
+            "BLOCKED on prior mistake:",
+            mirror.path,
+            "Rule 2",
+            "halt prefix 'BLOCKED on prior mistake:'"
+          );
+        });
+
+        it("enumerates residue-still-present trigger", () => {
+          assertContains(
+            rule2,
+            "residue",
+            mirror.path,
+            "Rule 2",
+            "residue trigger keyword"
+          );
+          assertMatches(
+            rule2,
+            /unrotated|stale|unreverted/i,
+            mirror.path,
+            "Rule 2",
+            "residue concrete examples (unrotated|stale|unreverted)"
+          );
+        });
+
+        it("enumerates unrun-verification trigger", () => {
+          assertContains(
+            rule2,
+            "verification step",
+            mirror.path,
+            "Rule 2",
+            "verification-step trigger keyword"
+          );
+          assertMatches(
+            rule2,
+            /never run|was never run/i,
+            mirror.path,
+            "Rule 2",
+            "verification-step never-run phrasing"
+          );
+        });
+
+        it("enumerates unresolved needs-approval trigger", () => {
+          assertContains(
+            rule2,
+            "needs-approval",
+            mirror.path,
+            "Rule 2",
+            "unresolved 'needs-approval' trigger keyword"
+          );
+        });
+      });
+
+      describe("Rule 3 — negative prompt", () => {
+        const rule3 = rules.get(3)!.body;
+
+        it("contains the literal 'Will NOT repeat:'", () => {
+          assertContains(
+            rule3,
+            "Will NOT repeat:",
+            mirror.path,
+            "Rule 3",
+            "negative-prompt prefix 'Will NOT repeat:'"
+          );
+        });
+
+        it("requires a specific prior session citation", () => {
+          assertContains(
+            rule3,
+            "cite a specific prior session",
+            mirror.path,
+            "Rule 3",
+            "specific-prior-session citation requirement"
+          );
+        });
+
+        it("explicitly disqualifies generic anti-patterns near a generic example", () => {
+          assertContains(
+            rule3,
+            "do not qualify",
+            mirror.path,
+            "Rule 3",
+            "generic anti-pattern disqualifier 'do not qualify'"
+          );
+          assertMatches(
+            rule3,
+            /\([^)]*will not[^)]*\)[^\n]{0,80}do not qualify/i,
+            mirror.path,
+            "Rule 3",
+            "generic example shown in parens immediately before 'do not qualify'"
+          );
+        });
+      });
+    });
+  }
+});

--- a/src/test/resolve-home-dir.test.mts
+++ b/src/test/resolve-home-dir.test.mts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { after, before, describe, it } from "node:test";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
+
+// Each test sets HOME / USERPROFILE on the live env, asserts, and the
+// outer before/after captures + restores the original values exactly.
+// We don't spawn subprocesses: this is a unit test of a pure function
+// that reads process.env synchronously.
+
+describe("resolveHomeDir", () => {
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+  let homeWasSet = false;
+  let userProfileWasSet = false;
+
+  before(() => {
+    homeWasSet = "HOME" in process.env;
+    userProfileWasSet = "USERPROFILE" in process.env;
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+  });
+
+  after(() => {
+    if (homeWasSet) {
+      process.env.HOME = savedHome;
+    } else {
+      delete process.env.HOME;
+    }
+    if (userProfileWasSet) {
+      process.env.USERPROFILE = savedUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
+  });
+
+  it("returns HOME when HOME is set and USERPROFILE is undefined", () => {
+    process.env.HOME = "/foo";
+    delete process.env.USERPROFILE;
+    assert.equal(resolveHomeDir(), "/foo");
+  });
+
+  it("returns USERPROFILE when HOME is undefined and USERPROFILE is set", () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = "C:\\Users\\X";
+    assert.equal(resolveHomeDir(), "C:\\Users\\X");
+  });
+
+  it("returns empty string when BOTH HOME and USERPROFILE are explicitly empty (opt-out)", () => {
+    process.env.HOME = "";
+    process.env.USERPROFILE = "";
+    assert.equal(resolveHomeDir(), "");
+  });
+
+  it("falls back to USERPROFILE when only HOME is empty (single empty does NOT opt out)", () => {
+    process.env.HOME = "";
+    process.env.USERPROFILE = "/bar";
+    assert.equal(resolveHomeDir(), "/bar");
+  });
+
+  it("falls back to os.homedir() when both HOME and USERPROFILE are undefined", () => {
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    const expected = homedir() || "";
+    assert.equal(resolveHomeDir(), expected);
+  });
+});

--- a/src/test/three-section-close.test.mts
+++ b/src/test/three-section-close.test.mts
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, before, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname resolves to <repo>/test/ at runtime (compiled .mjs lives under
+// test/ per tsconfig outDir). Hook lives under <repo>/hooks/.
+const HOOK_PATH = join(__dirname, "..", "hooks", "three-section-close.mjs");
+
+const REQUIRED_HEADINGS = [
+  "What has been done",
+  "What is next",
+  "Recommendation",
+];
+
+interface TelemetryEntry {
+  ts: string;
+  hook: string;
+  action: "pass" | "block" | "skip-short";
+  textLength: number;
+  missing: string[];
+  durationMs: number;
+}
+
+function projectHashFor(transcriptPath: string): string {
+  const dir = dirname(transcriptPath);
+  let normalized = dir.split("\\").join("/");
+  if (platform() === "win32") normalized = normalized.toLowerCase();
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+}
+
+function writeAssistantTranscript(path: string, text: string): void {
+  const line = JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "text", text }] },
+  });
+  writeFileSync(path, `${line}\n`);
+}
+
+function buildIsolatedEnv(home: string): NodeJS.ProcessEnv {
+  // Strip the real HOME/USERPROFILE so the hook only sees our temp dir.
+  // Process.env spread loses the inheritance, so we re-add PATH explicitly.
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.HOME;
+  delete env.USERPROFILE;
+  env.HOME = home;
+  // Windows resolves homedir from USERPROFILE; set it too so platform code
+  // paths agree regardless of which is consulted first.
+  env.USERPROFILE = home;
+  return env;
+}
+
+function runHook(
+  payload: string,
+  env: NodeJS.ProcessEnv,
+): { status: number | null; stdout: string; stderr: string } {
+  const result = spawnSync(process.execPath, [HOOK_PATH], {
+    input: payload,
+    env,
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function readTelemetryLines(home: string, transcriptPath: string): TelemetryEntry[] {
+  const file = join(
+    home,
+    ".claude",
+    "hook-telemetry",
+    `${projectHashFor(transcriptPath)}.jsonl`,
+  );
+  if (!existsSync(file)) return [];
+  const raw = readFileSync(file, "utf8");
+  return raw
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as TelemetryEntry);
+}
+
+describe("three-section-close.mjs telemetry", () => {
+  let rootTemp = "";
+
+  before(() => {
+    rootTemp = mkdtempSync(join(tmpdir(), "three-sec-root-"));
+  });
+
+  after(() => {
+    rmSync(rootTemp, { recursive: true, force: true });
+  });
+
+  // Each test gets its own HOME so telemetry writes can't leak between cases.
+  let home = "";
+  let transcriptDir = "";
+
+  beforeEach(() => {
+    home = mkdtempSync(join(rootTemp, "home-"));
+    transcriptDir = mkdtempSync(join(rootTemp, "transcripts-"));
+  });
+
+  it("records a pass entry for a compliant long reply", () => {
+    const transcript = join(transcriptDir, "pass.jsonl");
+    const body = [
+      "Lots of substantive work prose. ".repeat(20),
+      "## What has been done",
+      "- changed things",
+      "## What is next",
+      "1. a\n2. b\n3. c\n4. d\n5. e",
+      "## Recommendation",
+      "1. ship it",
+    ].join("\n\n");
+    writeAssistantTranscript(transcript, body);
+
+    const env = buildIsolatedEnv(home);
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0, "hook should exit 0");
+    assert.equal(result.stdout, "", "no stdout on pass path");
+
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(entries.length, 1, "exactly one telemetry line written");
+    const [entry] = entries;
+    assert.equal(entry.hook, "three-section-close");
+    assert.equal(entry.action, "pass");
+    assert.deepEqual(entry.missing, [], "missing array empty on pass");
+    assert.ok(entry.textLength >= 600, "textLength gates above threshold");
+    assert.equal(typeof entry.durationMs, "number");
+    assert.ok(!Number.isNaN(Date.parse(entry.ts)), "ts is ISO timestamp");
+  });
+
+  it("records a block entry naming the absent heading(s)", () => {
+    const transcript = join(transcriptDir, "block.jsonl");
+    // ≥ 600 chars but missing all three sections.
+    const body = "Long technical narrative without the required close. ".repeat(20);
+    writeAssistantTranscript(transcript, body);
+
+    const env = buildIsolatedEnv(home);
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0, "hook still exits 0; block goes via stdout");
+    const parsed = JSON.parse(result.stdout) as { decision?: string; reason?: string };
+    assert.equal(parsed.decision, "block");
+    for (const heading of REQUIRED_HEADINGS) {
+      assert.match(parsed.reason ?? "", new RegExp(heading));
+    }
+
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(entries.length, 1, "exactly one telemetry line written");
+    const [entry] = entries;
+    assert.equal(entry.action, "block");
+    assert.deepEqual(entry.missing, REQUIRED_HEADINGS, "missing lists every absent heading");
+    assert.ok(entry.textLength >= 600);
+  });
+
+  it("records a skip-short entry for a short reply", () => {
+    const transcript = join(transcriptDir, "short.jsonl");
+    writeAssistantTranscript(transcript, "ok done");
+
+    const env = buildIsolatedEnv(home);
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "");
+
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(entries.length, 1);
+    const [entry] = entries;
+    assert.equal(entry.action, "skip-short");
+    assert.deepEqual(entry.missing, []);
+    assert.ok(entry.textLength < 600, "textLength below gate threshold");
+  });
+
+  it("fails open when the telemetry directory cannot be created", () => {
+    // Point HOME at a regular file so mkdirSync(.../.claude/hook-telemetry)
+    // must fail (cannot create a child of a file). The hook must still
+    // pass/block correctly via stdout.
+    const blockerFile = join(rootTemp, `home-as-file-${Date.now()}.txt`);
+    writeFileSync(blockerFile, "not a directory");
+
+    const transcript = join(transcriptDir, "fail-open.jsonl");
+    const body = "Long body without sections. ".repeat(25);
+    writeAssistantTranscript(transcript, body);
+
+    const env = buildIsolatedEnv(blockerFile);
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0, "hook still exits 0 even with unwritable HOME");
+    const parsed = JSON.parse(result.stdout) as { decision?: string };
+    assert.equal(parsed.decision, "block", "block emit still works");
+    assert.equal(result.stderr, "", "no stderr on fail-open telemetry");
+  });
+
+  it("works when HOME and USERPROFILE are both unset (no telemetry, no error)", () => {
+    const transcript = join(transcriptDir, "no-home.jsonl");
+    const body = [
+      "Filler. ".repeat(30),
+      "## What has been done",
+      "x",
+      "## What is next",
+      "1. a\n2. b\n3. c\n4. d\n5. e",
+      "## Recommendation",
+      "no",
+    ].join("\n\n");
+    writeAssistantTranscript(transcript, body);
+
+    // Build env with neither HOME nor USERPROFILE.
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    delete env.HOME;
+    delete env.USERPROFILE;
+
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0, "hook exits 0 without HOME/USERPROFILE");
+    assert.equal(result.stdout, "", "compliant reply still passes");
+    assert.equal(result.stderr, "", "no error escapes to stderr");
+
+    // Confirm no telemetry was written under our isolated `home` either —
+    // the hook had no place to write it.
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(entries.length, 0, "no telemetry written when HOME/USERPROFILE absent");
+  });
+
+  it("uses a project hash that differs across distinct transcript directories", () => {
+    const transcriptA = join(transcriptDir, "a.jsonl");
+    const otherDir = mkdtempSync(join(rootTemp, "transcripts-other-"));
+    const transcriptB = join(otherDir, "b.jsonl");
+    const body = "Short ok"; // skip-short keeps the test fast and deterministic
+    writeAssistantTranscript(transcriptA, body);
+    writeAssistantTranscript(transcriptB, body);
+
+    const env = buildIsolatedEnv(home);
+    runHook(JSON.stringify({ transcript_path: transcriptA }), env);
+    runHook(JSON.stringify({ transcript_path: transcriptB }), env);
+
+    const hashA = projectHashFor(transcriptA);
+    const hashB = projectHashFor(transcriptB);
+    assert.notEqual(hashA, hashB, "different transcript dirs hash differently");
+
+    const fileA = join(home, ".claude", "hook-telemetry", `${hashA}.jsonl`);
+    const fileB = join(home, ".claude", "hook-telemetry", `${hashB}.jsonl`);
+    assert.ok(existsSync(fileA), "telemetry file for project A exists");
+    assert.ok(existsSync(fileB), "telemetry file for project B exists");
+  });
+
+  it("does not write telemetry when transcript file does not exist", () => {
+    const transcript = join(transcriptDir, "missing.jsonl");
+    const env = buildIsolatedEnv(home);
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "");
+    // The hook returns before reaching telemetry; expect no file.
+    const dirAfter = join(home, ".claude", "hook-telemetry");
+    assert.equal(existsSync(dirAfter), false, "telemetry dir not created");
+  });
+
+  it("appends a second telemetry line on a second invocation in the same project", () => {
+    const transcript = join(transcriptDir, "repeat.jsonl");
+    writeAssistantTranscript(transcript, "short body");
+
+    const env = buildIsolatedEnv(home);
+    runHook(JSON.stringify({ transcript_path: transcript }), env);
+    runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(entries.length, 2, "two appended telemetry lines");
+    for (const entry of entries) {
+      assert.equal(entry.action, "skip-short");
+    }
+  });
+});
+
+// Sanity: the production hook file we are testing actually exists and is
+// executable as a Node script. Catches setup mistakes early.
+describe("three-section-close.mjs presence", () => {
+  it("has the expected hook file on disk", () => {
+    assert.ok(existsSync(HOOK_PATH), `hook file should exist at ${HOOK_PATH}`);
+  });
+
+  it("can be imported without throwing parse errors", () => {
+    const dummyHome = mkdtempSync(join(tmpdir(), "three-sec-noop-"));
+    try {
+      const env = buildIsolatedEnv(dummyHome);
+      const result = runHook("", env);
+      assert.equal(result.status, 0, "hook handles empty stdin cleanly");
+      assert.equal(result.stdout, "");
+      assert.equal(result.stderr, "");
+    } finally {
+      rmSync(dummyHome, { recursive: true, force: true });
+      // Also ensure parent fragments cleaned (mkdtempSync may leave bones)
+      const parentLeftover = dirname(dummyHome);
+      if (parentLeftover === tmpdir()) {
+        // tmpdir() — never delete
+      }
+    }
+  });
+});

--- a/src/test/three-section-close.test.mts
+++ b/src/test/three-section-close.test.mts
@@ -5,11 +5,12 @@ import {
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
-import { platform, tmpdir } from "node:os";
+import { homedir, platform, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { after, before, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -93,6 +94,29 @@ function readTelemetryLines(home: string, transcriptPath: string): TelemetryEntr
     .split(/\r?\n/)
     .filter((line) => line.trim().length > 0)
     .map((line) => JSON.parse(line) as TelemetryEntry);
+}
+
+// Snapshot the real ~/.claude/hook-telemetry/ directory so tests can prove
+// they did not leak telemetry into the developer's actual home dir while
+// HOME/USERPROFILE were manipulated. Returns a Set of file basenames; an
+// empty Set is returned if the directory does not exist.
+function snapshotRealTelemetryDir(): Set<string> {
+  const dir = join(homedir(), ".claude", "hook-telemetry");
+  if (!existsSync(dir)) return new Set();
+  return new Set(readdirSync(dir));
+}
+
+function assertNoRealTelemetryLeak(before: Set<string>, label: string): void {
+  const after = snapshotRealTelemetryDir();
+  const newFiles: string[] = [];
+  for (const f of after) {
+    if (!before.has(f)) newFiles.push(f);
+  }
+  assert.deepEqual(
+    newFiles,
+    [],
+    `${label}: hook leaked telemetry into real ~/.claude/hook-telemetry/: ${newFiles.join(", ")}`,
+  );
 }
 
 describe("three-section-close.mjs telemetry", () => {
@@ -190,13 +214,16 @@ describe("three-section-close.mjs telemetry", () => {
   it("fails open when the telemetry directory cannot be created", () => {
     // Point HOME at a regular file so mkdirSync(.../.claude/hook-telemetry)
     // must fail (cannot create a child of a file). The hook must still
-    // pass/block correctly via stdout.
+    // pass/block correctly via stdout, and must NOT silently re-route the
+    // write to the real ~/.claude/hook-telemetry/ directory.
     const blockerFile = join(rootTemp, `home-as-file-${Date.now()}.txt`);
     writeFileSync(blockerFile, "not a directory");
 
     const transcript = join(transcriptDir, "fail-open.jsonl");
     const body = "Long body without sections. ".repeat(25);
     writeAssistantTranscript(transcript, body);
+
+    const realBefore = snapshotRealTelemetryDir();
 
     const env = buildIsolatedEnv(blockerFile);
     const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
@@ -205,9 +232,13 @@ describe("three-section-close.mjs telemetry", () => {
     const parsed = JSON.parse(result.stdout) as { decision?: string };
     assert.equal(parsed.decision, "block", "block emit still works");
     assert.equal(result.stderr, "", "no stderr on fail-open telemetry");
+
+    // Drift-catch: the mkdir failure path must not silently bypass to the
+    // operator's real home dir. Snapshot before/after; no new files.
+    assertNoRealTelemetryLeak(realBefore, "unwritable-telemetry-dir test");
   });
 
-  it("works when HOME and USERPROFILE are both unset (no telemetry, no error)", () => {
+  it("explicit opt-out via empty HOME/USERPROFILE skips telemetry without falling back to os.homedir()", () => {
     const transcript = join(transcriptDir, "no-home.jsonl");
     const body = [
       "Filler. ".repeat(30),
@@ -220,21 +251,32 @@ describe("three-section-close.mjs telemetry", () => {
     ].join("\n\n");
     writeAssistantTranscript(transcript, body);
 
-    // Build env with neither HOME nor USERPROFILE.
+    // Empty-string HOME and USERPROFILE = explicit operator opt-out signal.
+    // The hook must short-circuit and write nothing. Critically, it must
+    // NOT fall back to os.homedir() (which would pollute the real
+    // ~/.claude/hook-telemetry/ during every `npm test` run — the bug this
+    // test was previously a false positive for).
     const env: NodeJS.ProcessEnv = { ...process.env };
-    delete env.HOME;
-    delete env.USERPROFILE;
+    env.HOME = "";
+    env.USERPROFILE = "";
+
+    const realBefore = snapshotRealTelemetryDir();
 
     const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
 
-    assert.equal(result.status, 0, "hook exits 0 without HOME/USERPROFILE");
+    assert.equal(result.status, 0, "hook exits 0 with empty HOME/USERPROFILE");
     assert.equal(result.stdout, "", "compliant reply still passes");
     assert.equal(result.stderr, "", "no error escapes to stderr");
 
     // Confirm no telemetry was written under our isolated `home` either —
     // the hook had no place to write it.
     const entries = readTelemetryLines(home, transcript);
-    assert.equal(entries.length, 0, "no telemetry written when HOME/USERPROFILE absent");
+    assert.equal(entries.length, 0, "no telemetry written under isolated HOME");
+
+    // Drift-catch: the real ~/.claude/hook-telemetry/ must be untouched.
+    // Without the empty-string opt-out, resolveHomeDir() would call
+    // os.homedir() and write a JSONL line into the developer's real home.
+    assertNoRealTelemetryLeak(realBefore, "empty-HOME opt-out test");
   });
 
   it("uses a project hash that differs across distinct transcript directories", () => {

--- a/src/test/three-section-close.test.mts
+++ b/src/test/three-section-close.test.mts
@@ -279,6 +279,63 @@ describe("three-section-close.mjs telemetry", () => {
     assertNoRealTelemetryLeak(realBefore, "empty-HOME opt-out test");
   });
 
+  it("falls back to USERPROFILE when only HOME is empty (AND-semantic opt-out)", () => {
+    // Regression net for the AND-semantic fix: the opt-out only fires when
+    // BOTH env vars are explicitly empty. With HOME="" and USERPROFILE
+    // pointing at a valid path, the hook must still resolve a home and
+    // write telemetry there — not silently disable itself.
+    const transcript = join(transcriptDir, "home-empty.jsonl");
+    writeAssistantTranscript(transcript, "short body");
+
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    env.HOME = "";
+    env.USERPROFILE = home;
+
+    const realBefore = snapshotRealTelemetryDir();
+
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "");
+
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(
+      entries.length,
+      1,
+      "telemetry must land under USERPROFILE when HOME is empty",
+    );
+    assert.equal(entries[0].action, "skip-short");
+
+    assertNoRealTelemetryLeak(realBefore, "HOME-empty/USERPROFILE-valid test");
+  });
+
+  it("falls back to HOME when only USERPROFILE is empty (AND-semantic opt-out)", () => {
+    // Mirror of the above for the other direction.
+    const transcript = join(transcriptDir, "userprofile-empty.jsonl");
+    writeAssistantTranscript(transcript, "short body");
+
+    const env: NodeJS.ProcessEnv = { ...process.env };
+    env.HOME = home;
+    env.USERPROFILE = "";
+
+    const realBefore = snapshotRealTelemetryDir();
+
+    const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+
+    assert.equal(result.status, 0);
+    assert.equal(result.stdout, "");
+
+    const entries = readTelemetryLines(home, transcript);
+    assert.equal(
+      entries.length,
+      1,
+      "telemetry must land under HOME when USERPROFILE is empty",
+    );
+    assert.equal(entries[0].action, "skip-short");
+
+    assertNoRealTelemetryLeak(realBefore, "HOME-valid/USERPROFILE-empty test");
+  });
+
   it("uses a project hash that differs across distinct transcript directories", () => {
     const transcriptA = join(transcriptDir, "a.jsonl");
     const otherDir = mkdtempSync(join(rootTemp, "transcripts-other-"));

--- a/src/test/wild-risa-spec.test.mts
+++ b/src/test/wild-risa-spec.test.mts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+
+const MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
+  {
+    path: "skills/wild-risa-balance.md",
+    label: "source skill",
+  },
+  {
+    path: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md",
+    label: "plugin mirror",
+  },
+];
+
+// Asserted contract literals — every magic string used in `.includes(...)` is
+// hoisted here so a single source of truth governs what the skill must say.
+const WILD_EXACT_COUNT_LITERAL = "exactly 2";
+const RISA_FLOOR_LITERAL = "at least 5";
+const RANK_LITERAL = "rank descending by impact";
+const NEVER_AUTO_TRIGGER_LITERAL = "Never auto-trigger";
+const EXAMPLE_TOTAL_LITERAL = "Total: 7 items (2 WILD + 5 RISA)";
+const WILD_EXAMPLE_COUNT = 2;
+const RISA_EXAMPLE_COUNT = 5;
+
+const HOW_TO_APPLY_HEADING_RE = /^##\s+How to Apply in a Recommendation List\s*$/im;
+const NEXT_H2_RE = /^##\s+/m;
+const EXAMPLE_HEADING_RE = /^##\s+Example\s*$/im;
+const NUMBERED_TOP_LEVEL_RE = /^(\d+)\.\s+/gm;
+const WILD_PILOTS_BLOCK_HEADER_RE = /^[^\n]*WILD pilots[^\n]*$/im;
+const RISA_BASELINE_BLOCK_HEADER_RE = /^[^\n]*RISA baseline[^\n]*$/im;
+const NUMBERED_LINE_RE = /^(\d+)\.\s+/gm;
+
+function extractSection(
+  content: string,
+  startRe: RegExp,
+  mirrorPath: string,
+  sectionLabel: string,
+): string {
+  const startMatch = content.match(startRe);
+  assert.ok(
+    startMatch && typeof startMatch.index === "number",
+    `${mirrorPath}: missing "${sectionLabel}" heading — section is gone or renamed.`,
+  );
+  const start = startMatch!.index!;
+  const headingLineEnd = content.indexOf("\n", start);
+  const tailFromBody = content.slice(headingLineEnd + 1);
+  const endRel = tailFromBody.search(NEXT_H2_RE);
+  const body = endRel === -1 ? tailFromBody : tailFromBody.slice(0, endRel);
+  assert.ok(
+    body.trim().length > 0,
+    `${mirrorPath}: "${sectionLabel}" section is empty.`,
+  );
+  return body;
+}
+
+function countTopLevelNumbered(section: string): number {
+  NUMBERED_TOP_LEVEL_RE.lastIndex = 0;
+  let count = 0;
+  while (NUMBERED_TOP_LEVEL_RE.exec(section) !== null) {
+    count++;
+  }
+  NUMBERED_TOP_LEVEL_RE.lastIndex = 0;
+  return count;
+}
+
+function extractBlockAfterHeader(
+  exampleSection: string,
+  headerRe: RegExp,
+  mirrorPath: string,
+  blockLabel: string,
+): string {
+  const headerMatch = exampleSection.match(headerRe);
+  assert.ok(
+    headerMatch && typeof headerMatch.index === "number",
+    `${mirrorPath}: Example block is missing the "${blockLabel}" header line.`,
+  );
+  const start = headerMatch!.index!;
+  const headerLineEnd = exampleSection.indexOf("\n", start);
+  const after = exampleSection.slice(headerLineEnd + 1);
+  // The block runs until the next blank line OR the next non-numbered, non-empty line.
+  const lines = after.split("\n");
+  const collected: string[] = [];
+  for (const line of lines) {
+    if (line.trim() === "") {
+      if (collected.length > 0) break;
+      continue;
+    }
+    if (/^\d+\.\s+/.test(line)) {
+      collected.push(line);
+      continue;
+    }
+    // First non-numbered non-blank line ends the block.
+    break;
+  }
+  return collected.join("\n");
+}
+
+function countNumberedLines(block: string): number {
+  NUMBERED_LINE_RE.lastIndex = 0;
+  let count = 0;
+  while (NUMBERED_LINE_RE.exec(block) !== null) {
+    count++;
+  }
+  NUMBERED_LINE_RE.lastIndex = 0;
+  return count;
+}
+
+function assertContains(
+  haystack: string,
+  needle: string,
+  mirrorPath: string,
+  sectionLabel: string,
+  clauseLabel: string,
+): void {
+  assert.ok(
+    haystack.includes(needle),
+    `${mirrorPath} :: ${sectionLabel} :: missing required clause [${clauseLabel}] — expected literal:\n  ${needle}`,
+  );
+}
+
+describe("wild-risa-balance How to Apply behavioral spec", () => {
+  for (const mirror of MIRRORS) {
+    describe(`${mirror.label} (${mirror.path})`, () => {
+      const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+      const howToApply = extractSection(
+        content,
+        HOW_TO_APPLY_HEADING_RE,
+        mirror.path,
+        "## How to Apply in a Recommendation List",
+      );
+
+      describe("section structure — 4 numbered top-level sub-rules", () => {
+        it(`contains exactly 4 top-level numbered items (1.–4.)`, () => {
+          const count = countTopLevelNumbered(howToApply);
+          assert.equal(
+            count,
+            4,
+            `${mirror.path}: How to Apply section must contain 4 numbered top-level sub-rules; found ${count}. Each rule encodes a normative behavior — losing one silently degrades the contract.`,
+          );
+        });
+
+        it(`Rule 1 (WILD pilots line) contains literal "${WILD_EXACT_COUNT_LITERAL}"`, () => {
+          // Rule 1 is the line beginning with "1." that mentions WILD.
+          const rule1Line = howToApply
+            .split("\n")
+            .find((l) => /^1\.\s+/.test(l) && /WILD/i.test(l));
+          assert.ok(
+            rule1Line,
+            `${mirror.path}: could not locate "1." rule line referencing WILD — Rule 1 may have been renumbered or rephrased.`,
+          );
+          assertContains(
+            rule1Line!,
+            WILD_EXACT_COUNT_LITERAL,
+            mirror.path,
+            "Rule 1 (WILD pilots)",
+            `WILD count literal "${WILD_EXACT_COUNT_LITERAL}"`,
+          );
+        });
+
+        it(`Rule 2 (RISA baseline line) contains literal "${RISA_FLOOR_LITERAL}"`, () => {
+          const rule2Line = howToApply
+            .split("\n")
+            .find((l) => /^2\.\s+/.test(l) && /RISA/i.test(l));
+          assert.ok(
+            rule2Line,
+            `${mirror.path}: could not locate "2." rule line referencing RISA — Rule 2 may have been renumbered or rephrased.`,
+          );
+          assertContains(
+            rule2Line!,
+            RISA_FLOOR_LITERAL,
+            mirror.path,
+            "Rule 2 (RISA baseline)",
+            `RISA floor literal "${RISA_FLOOR_LITERAL}"`,
+          );
+        });
+
+        it(`section contains literal "${RANK_LITERAL}"`, () => {
+          assertContains(
+            howToApply,
+            RANK_LITERAL,
+            mirror.path,
+            "How to Apply",
+            `ranking clause "${RANK_LITERAL}"`,
+          );
+        });
+
+        it(`section contains never-auto-trigger clause literal "${NEVER_AUTO_TRIGGER_LITERAL}"`, () => {
+          assertContains(
+            howToApply,
+            NEVER_AUTO_TRIGGER_LITERAL,
+            mirror.path,
+            "How to Apply",
+            `never-auto-trigger clause "${NEVER_AUTO_TRIGGER_LITERAL}"`,
+          );
+        });
+      });
+
+      describe("Example block — counts and closing line", () => {
+        const exampleSection = extractSection(
+          content,
+          EXAMPLE_HEADING_RE,
+          mirror.path,
+          "## Example",
+        );
+
+        it(`WILD pilots example block contains exactly ${WILD_EXAMPLE_COUNT} numbered items`, () => {
+          const wildBlock = extractBlockAfterHeader(
+            exampleSection,
+            WILD_PILOTS_BLOCK_HEADER_RE,
+            mirror.path,
+            "WILD pilots",
+          );
+          const found = countNumberedLines(wildBlock);
+          assert.equal(
+            found,
+            WILD_EXAMPLE_COUNT,
+            `${mirror.path}: Example block "WILD pilots" must show exactly ${WILD_EXAMPLE_COUNT} numbered items, found ${found}. The example must mirror the rule "exactly 2".`,
+          );
+        });
+
+        it(`RISA baseline example block contains exactly ${RISA_EXAMPLE_COUNT} numbered items`, () => {
+          const risaBlock = extractBlockAfterHeader(
+            exampleSection,
+            RISA_BASELINE_BLOCK_HEADER_RE,
+            mirror.path,
+            "RISA baseline",
+          );
+          const found = countNumberedLines(risaBlock);
+          assert.equal(
+            found,
+            RISA_EXAMPLE_COUNT,
+            `${mirror.path}: Example block "RISA baseline" must show exactly ${RISA_EXAMPLE_COUNT} numbered items, found ${found}. The example must mirror the rule "at least 5" floor.`,
+          );
+        });
+
+        it(`Example section contains closing total literal "${EXAMPLE_TOTAL_LITERAL}"`, () => {
+          assertContains(
+            exampleSection,
+            EXAMPLE_TOTAL_LITERAL,
+            mirror.path,
+            "Example",
+            `closing total "${EXAMPLE_TOTAL_LITERAL}"`,
+          );
+        });
+      });
+    });
+  }
+});

--- a/test/cross-skill-contract.test.mjs
+++ b/test/cross-skill-contract.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+// ----- Asserted contract literals (single source of truth) ----------------
+//
+// Half 1: proceed-with-the-recommendation must reference wild-risa-balance
+// in its Phase 1 section, naming both the upstream skill and the block-shape
+// contract phrasing.
+const PROCEED_WILD_RISA_REF_LITERAL = "wild-risa-balance";
+const PROCEED_PHASE1_BLOCK_SHAPE_LITERAL = "2 WILD + at least 5 RISA";
+// The exact "composed under" phrase as written in the SKILL.md (with the
+// embedded backticks around the skill name).
+const PROCEED_COMPOSED_UNDER_LITERAL = "composed under `wild-risa-balance`";
+// Half 2: wild-risa-balance must reference proceed-with-the-recommendation
+// as its execution arm, plus the auto-trigger discipline literal.
+const WILD_PROCEED_REF_LITERAL = "proceed-with-the-recommendation";
+const WILD_EXECUTION_ARM_LITERAL = "execution arm";
+const WILD_NEVER_AUTO_TRIGGER_LITERAL = "Never auto-trigger";
+// ----- Mirror tables -------------------------------------------------------
+const PROCEED_MIRRORS = [
+    {
+        path: "skills/proceed-with-the-recommendation.md",
+        label: "source skill",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+        label: "plugin mirror",
+    },
+];
+const WILD_MIRRORS = [
+    {
+        path: "skills/wild-risa-balance.md",
+        label: "source skill",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md",
+        label: "plugin mirror",
+    },
+];
+// ----- Heading regexes (m flag — heading casing is stable) ----------------
+const PHASE_1_HEADING_RE = /^##\s+Phase\s+1:/m;
+const NEXT_H2_RE = /^##\s+/m;
+// ----- Section extraction --------------------------------------------------
+function extractPhase1(content, mirrorPath) {
+    const startMatch = content.match(PHASE_1_HEADING_RE);
+    assert.ok(startMatch && typeof startMatch.index === "number", `${mirrorPath}: missing "## Phase 1:" heading — Phase 1 section is gone or renamed.`);
+    const start = startMatch.index;
+    const headingLineEnd = content.indexOf("\n", start);
+    const tailFromBody = content.slice(headingLineEnd + 1);
+    const endRel = tailFromBody.search(NEXT_H2_RE);
+    const body = endRel === -1 ? tailFromBody : tailFromBody.slice(0, endRel);
+    assert.ok(body.trim().length > 0, `${mirrorPath}: "## Phase 1:" section is empty.`);
+    return body;
+}
+function assertContains(haystack, needle, mirrorPath, half, clauseLabel) {
+    assert.ok(haystack.includes(needle), `${mirrorPath} :: ${half} :: ${clauseLabel} :: missing required literal: ${needle}`);
+}
+// ----- Half 1 — proceed-with-the-recommendation references wild-risa-balance
+describe("cross-skill contract — proceed-with-the-recommendation references wild-risa-balance", () => {
+    for (const mirror of PROCEED_MIRRORS) {
+        describe(`${mirror.label} (${mirror.path})`, () => {
+            const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+            const phase1 = extractPhase1(content, mirror.path);
+            it("Phase 1 names wild-risa-balance as the upstream skill", () => {
+                assertContains(phase1, PROCEED_WILD_RISA_REF_LITERAL, mirror.path, "Half 1", "Phase 1 cross-reference to wild-risa-balance");
+            });
+            it("Phase 1 contains the block-shape contract literal '2 WILD + at least 5 RISA'", () => {
+                assertContains(phase1, PROCEED_PHASE1_BLOCK_SHAPE_LITERAL, mirror.path, "Half 1", "Phase 1 block-shape contract literal");
+            });
+            it("file declares the list was 'composed under `wild-risa-balance`'", () => {
+                assertContains(content, PROCEED_COMPOSED_UNDER_LITERAL, mirror.path, "Half 1", "composed-under upstream-skill phrase");
+            });
+        });
+    }
+});
+// ----- Half 2 — wild-risa-balance references proceed-with-the-recommendation
+describe("cross-skill contract — wild-risa-balance references proceed-with-the-recommendation", () => {
+    for (const mirror of WILD_MIRRORS) {
+        describe(`${mirror.label} (${mirror.path})`, () => {
+            const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+            it("file names proceed-with-the-recommendation as a related skill", () => {
+                assertContains(content, WILD_PROCEED_REF_LITERAL, mirror.path, "Half 2", "cross-reference to proceed-with-the-recommendation");
+            });
+            it("file describes proceed-with-the-recommendation as the 'execution arm'", () => {
+                assertContains(content, WILD_EXECUTION_ARM_LITERAL, mirror.path, "Half 2", "execution-arm role description");
+            });
+            it("file anchors the auto-trigger discipline with literal 'Never auto-trigger'", () => {
+                assertContains(content, WILD_NEVER_AUTO_TRIGGER_LITERAL, mirror.path, "Half 2", "auto-trigger discipline literal");
+            });
+        });
+    }
+});

--- a/test/hook-stats.test.mjs
+++ b/test/hook-stats.test.mjs
@@ -1,0 +1,235 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { appendFileSync, mkdtempSync, rmSync, writeFileSync, } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CLI = join(REPO_ROOT, "bin", "hook-stats.mjs");
+function makeEntry(overrides = {}) {
+    return {
+        ts: new Date().toISOString(),
+        hook: "three-section-close",
+        action: "pass",
+        textLength: 1200,
+        missing: [],
+        durationMs: 5,
+        ...overrides,
+    };
+}
+function writeJsonl(file, entries) {
+    const body = entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+    writeFileSync(file, body, "utf8");
+}
+function runCli(args) {
+    const result = spawnSync(process.execPath, [CLI, ...args], {
+        encoding: "utf8",
+        timeout: 10000,
+    });
+    if (result.error)
+        throw result.error;
+    return {
+        status: result.status,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+describe("hook-stats CLI", () => {
+    const tempDirs = [];
+    function freshTelemetryDir() {
+        const dir = mkdtempSync(join(tmpdir(), "hook-stats-test-"));
+        tempDirs.push(dir);
+        return dir;
+    }
+    after(() => {
+        for (const dir of tempDirs) {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("--help exits 0 and prints usage on stdout", () => {
+        const res = runCli(["--help"]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        assert.match(res.stdout, /Usage: node bin\/hook-stats\.mjs/);
+        assert.match(res.stdout, /--hours=<n>/);
+        assert.match(res.stdout, /--hash=<hash>/);
+        assert.match(res.stdout, /--telemetry-dir=<path>/);
+    });
+    it("happy path: aggregates pass/block/skip-short counts and avg duration", () => {
+        const dir = freshTelemetryDir();
+        const file = join(dir, "abcdef012345.jsonl");
+        const now = Date.now();
+        const entries = [];
+        // 5 pass with durationMs 10
+        for (let i = 0; i < 5; i++) {
+            entries.push(makeEntry({
+                ts: new Date(now - i * 60_000).toISOString(),
+                action: "pass",
+                durationMs: 10,
+            }));
+        }
+        // 3 block with durationMs 20
+        for (let i = 0; i < 3; i++) {
+            entries.push(makeEntry({
+                ts: new Date(now - (i + 5) * 60_000).toISOString(),
+                action: "block",
+                durationMs: 20,
+            }));
+        }
+        // 2 skip-short with durationMs 30
+        for (let i = 0; i < 2; i++) {
+            entries.push(makeEntry({
+                ts: new Date(now - (i + 8) * 60_000).toISOString(),
+                action: "skip-short",
+                durationMs: 30,
+            }));
+        }
+        writeJsonl(file, entries);
+        const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        // avg = (5*10 + 3*20 + 2*30) / 10 = (50 + 60 + 60) / 10 = 17 (rounded)
+        assert.match(res.stdout, /three-section-close last 24h: pass=5 block=3 skip-short=2 total=10 avg-duration=17ms/);
+    });
+    it("filters out records older than the --hours window", () => {
+        const dir = freshTelemetryDir();
+        const file = join(dir, "deadbeef0001.jsonl");
+        const now = Date.now();
+        const fresh1 = makeEntry({
+            ts: new Date(now - 60_000).toISOString(),
+            action: "pass",
+            durationMs: 4,
+        });
+        const fresh2 = makeEntry({
+            ts: new Date(now - 120_000).toISOString(),
+            action: "block",
+            durationMs: 6,
+        });
+        const stale = makeEntry({
+            ts: new Date(now - 48 * 3600 * 1000).toISOString(),
+            action: "pass",
+            durationMs: 999,
+        });
+        writeJsonl(file, [fresh1, fresh2, stale]);
+        const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        // Only the 2 fresh records counted; avg = (4 + 6)/2 = 5
+        assert.match(res.stdout, /three-section-close last 24h: pass=1 block=1 skip-short=0 total=2 avg-duration=5ms/);
+    });
+    it("tolerates malformed JSONL lines and counts only valid records", () => {
+        const dir = freshTelemetryDir();
+        const file = join(dir, "ffffffffffff.jsonl");
+        const now = Date.now();
+        const valid1 = JSON.stringify(makeEntry({
+            ts: new Date(now - 60_000).toISOString(),
+            action: "pass",
+            durationMs: 8,
+        }));
+        const valid2 = JSON.stringify(makeEntry({
+            ts: new Date(now - 120_000).toISOString(),
+            action: "block",
+            durationMs: 12,
+        }));
+        // Garbage between valid lines and at the end.
+        const body = [valid1, "{not-json", "", valid2, "trailing garbage"].join("\n");
+        writeFileSync(file, body + "\n", "utf8");
+        const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        assert.match(res.stdout, /three-section-close last 24h: pass=1 block=1 skip-short=0 total=2 avg-duration=10ms/);
+    });
+    it("prints 'no records' when telemetry dir exists but has no JSONL files", () => {
+        const dir = freshTelemetryDir();
+        const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        assert.match(res.stdout, /no records in last 24h/);
+    });
+    it("--hash filter restricts reading to a single <hash>.jsonl file", () => {
+        const dir = freshTelemetryDir();
+        const fileA = join(dir, "aaaaaaaaaaaa.jsonl");
+        const fileB = join(dir, "bbbbbbbbbbbb.jsonl");
+        const now = Date.now();
+        writeJsonl(fileA, [
+            makeEntry({
+                ts: new Date(now - 60_000).toISOString(),
+                action: "pass",
+                durationMs: 7,
+                hook: "three-section-close",
+            }),
+        ]);
+        writeJsonl(fileB, [
+            makeEntry({
+                ts: new Date(now - 60_000).toISOString(),
+                action: "block",
+                durationMs: 999,
+                hook: "three-section-close",
+            }),
+            makeEntry({
+                ts: new Date(now - 90_000).toISOString(),
+                action: "block",
+                durationMs: 999,
+                hook: "three-section-close",
+            }),
+        ]);
+        const res = runCli([
+            `--telemetry-dir=${dir}`,
+            "--hours=24",
+            "--hash=aaaaaaaaaaaa",
+        ]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        assert.match(res.stdout, /three-section-close last 24h: pass=1 block=0 skip-short=0 total=1 avg-duration=7ms/);
+        // Should NOT include the bbbb file's records.
+        assert.doesNotMatch(res.stdout, /total=2/);
+        assert.doesNotMatch(res.stdout, /total=3/);
+    });
+    it("groups multiple hooks separately in output", () => {
+        const dir = freshTelemetryDir();
+        const file = join(dir, "112233445566.jsonl");
+        const now = Date.now();
+        const entries = [
+            makeEntry({
+                ts: new Date(now - 30_000).toISOString(),
+                hook: "alpha-hook",
+                action: "pass",
+                durationMs: 2,
+            }),
+            makeEntry({
+                ts: new Date(now - 30_000).toISOString(),
+                hook: "alpha-hook",
+                action: "pass",
+                durationMs: 4,
+            }),
+            makeEntry({
+                ts: new Date(now - 30_000).toISOString(),
+                hook: "beta-hook",
+                action: "block",
+                durationMs: 100,
+            }),
+        ];
+        writeJsonl(file, entries);
+        const res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.equal(res.status, 0, `stderr: ${res.stderr}`);
+        assert.match(res.stdout, /alpha-hook last 24h: pass=2 block=0 skip-short=0 total=2 avg-duration=3ms/);
+        assert.match(res.stdout, /beta-hook last 24h: pass=0 block=1 skip-short=0 total=1 avg-duration=100ms/);
+    });
+    it("appends are visible: re-running picks up newly added lines", () => {
+        const dir = freshTelemetryDir();
+        const file = join(dir, "0011223344aa.jsonl");
+        const now = Date.now();
+        writeJsonl(file, [
+            makeEntry({
+                ts: new Date(now - 30_000).toISOString(),
+                action: "pass",
+                durationMs: 5,
+            }),
+        ]);
+        let res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.match(res.stdout, /total=1/);
+        appendFileSync(file, JSON.stringify(makeEntry({
+            ts: new Date().toISOString(),
+            action: "block",
+            durationMs: 9,
+        })) + "\n", "utf8");
+        res = runCli([`--telemetry-dir=${dir}`, "--hours=24"]);
+        assert.match(res.stdout, /three-section-close last 24h: pass=1 block=1 skip-short=0 total=2 avg-duration=7ms/);
+    });
+});

--- a/test/hook.test.mjs
+++ b/test/hook.test.mjs
@@ -147,10 +147,15 @@ describe("observe.sh hook", { skip: SKIP_REASON }, () => {
 // reply to close with What has been done / What is next / Recommendation.
 // ===========================================================================
 function runThreeSectionClose(payload, extraEnv = {}) {
+    // Empty-string HOME/USERPROFILE = explicit opt-out signal recognized by
+    // three-section-close.mjs. This blocks the hook from writing telemetry into
+    // the developer's real ~/.claude/hook-telemetry/ during every `npm test` run.
+    // None of the cases in this file assert on telemetry presence; they only
+    // check stdout/status. Callers can still override via extraEnv if needed.
     const result = spawnSync(process.execPath, ["./three-section-close.mjs"], {
         input: payload,
         cwd: HOOKS_DIR,
-        env: { ...process.env, ...extraEnv },
+        env: { ...process.env, HOME: "", USERPROFILE: "", ...extraEnv },
         encoding: "utf8",
         timeout: 5000,
     });

--- a/test/phase7-close-spec.test.mjs
+++ b/test/phase7-close-spec.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const MIRRORS = [
+    {
+        path: "skills/proceed-with-the-recommendation.md",
+        label: "source skill",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+        label: "plugin mirror",
+    },
+];
+// Asserted contract literals — every magic string used in `.includes(...)` is
+// hoisted here so a single source of truth governs what the skill must say.
+const HEADING_DONE_LITERAL = "### 1. What has been done";
+const HEADING_NEXT_LITERAL = "### 2. What is next";
+const HEADING_RECOMMENDATION_LITERAL = "### 3. Recommendation";
+const TIER_1_LITERAL = "Tier 1 — strong fit";
+const TIER_2_LITERAL = "Tier 2 — high-fit complements";
+const SKIP_TIER_LITERAL = "Skip these — already covered";
+const TIER_1_CITATION_LITERAL = "concrete file/line/rule citation";
+const WANT_ME_TO_LITERAL = "Want me to:";
+const EXACTLY_TWO_OPTIONS_LITERAL = "exactly two options";
+const TINY_LIST_EXEMPTION_LITERAL = "Tiny-list exemption:";
+const TINY_LIST_THRESHOLD_LITERAL = "≤1 item";
+const PHASE_7_HEADING_RE = /^##\s+Phase\s+7:\s+End-of-Run Summary[^\n]*$/m;
+const NEXT_H2_RE = /^##\s+/m;
+function extractPhase7(content, mirrorPath) {
+    const startMatch = content.match(PHASE_7_HEADING_RE);
+    assert.ok(startMatch && typeof startMatch.index === "number", `${mirrorPath}: missing "## Phase 7: End-of-Run Summary" heading — Phase 7 section is gone or renamed.`);
+    const start = startMatch.index;
+    const headingLineEnd = content.indexOf("\n", start);
+    const tailFromBody = content.slice(headingLineEnd + 1);
+    const endRel = tailFromBody.search(NEXT_H2_RE);
+    const body = endRel === -1 ? tailFromBody : tailFromBody.slice(0, endRel);
+    assert.ok(body.trim().length > 0, `${mirrorPath}: "## Phase 7" section is empty.`);
+    return body;
+}
+function assertContains(haystack, needle, mirrorPath, clauseLabel) {
+    assert.ok(haystack.includes(needle), `${mirrorPath} :: Phase 7 :: ${clauseLabel} :: missing required literal: ${needle}`);
+}
+describe("proceed-with-the-recommendation Phase 7 close behavioral spec", () => {
+    for (const mirror of MIRRORS) {
+        describe(`${mirror.label} (${mirror.path})`, () => {
+            const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+            const phase7 = extractPhase7(content, mirror.path);
+            describe("3-section close shape", () => {
+                it(`contains literal "${HEADING_DONE_LITERAL}"`, () => {
+                    assertContains(phase7, HEADING_DONE_LITERAL, mirror.path, "3-section close — section 1 heading");
+                });
+                it(`contains literal "${HEADING_NEXT_LITERAL}"`, () => {
+                    assertContains(phase7, HEADING_NEXT_LITERAL, mirror.path, "3-section close — section 2 heading");
+                });
+                it(`contains literal "${HEADING_RECOMMENDATION_LITERAL}"`, () => {
+                    assertContains(phase7, HEADING_RECOMMENDATION_LITERAL, mirror.path, "3-section close — section 3 heading");
+                });
+                it("the three section headings appear in strict order 1 → 2 → 3", () => {
+                    const idxDone = phase7.indexOf(HEADING_DONE_LITERAL);
+                    const idxNext = phase7.indexOf(HEADING_NEXT_LITERAL);
+                    const idxRec = phase7.indexOf(HEADING_RECOMMENDATION_LITERAL);
+                    assert.ok(idxDone >= 0 && idxNext >= 0 && idxRec >= 0, `${mirror.path} :: Phase 7 :: 3-section close :: one or more section headings missing — cannot verify ordering. Indexes: done=${idxDone}, next=${idxNext}, rec=${idxRec}.`);
+                    assert.ok(idxDone < idxNext && idxNext < idxRec, `${mirror.path} :: Phase 7 :: 3-section close :: section headings out of order — expected 1 → 2 → 3, got indexes done=${idxDone}, next=${idxNext}, rec=${idxRec}.`);
+                });
+            });
+            describe("Tiered Recommendation block", () => {
+                it(`contains literal "${TIER_1_LITERAL}"`, () => {
+                    assertContains(phase7, TIER_1_LITERAL, mirror.path, "Tiered Recommendation — Tier 1 row label");
+                });
+                it(`contains literal "${TIER_2_LITERAL}"`, () => {
+                    assertContains(phase7, TIER_2_LITERAL, mirror.path, "Tiered Recommendation — Tier 2 row label");
+                });
+                it(`contains literal "${SKIP_TIER_LITERAL}"`, () => {
+                    assertContains(phase7, SKIP_TIER_LITERAL, mirror.path, "Tiered Recommendation — Skip row label");
+                });
+                it(`Tier 1 evidence rule mentions literal "${TIER_1_CITATION_LITERAL}"`, () => {
+                    assertContains(phase7, TIER_1_CITATION_LITERAL, mirror.path, "Tiered Recommendation — Tier 1 concrete-citation requirement");
+                });
+            });
+            describe("Want me to: block", () => {
+                it(`contains literal "${WANT_ME_TO_LITERAL}"`, () => {
+                    assertContains(phase7, WANT_ME_TO_LITERAL, mirror.path, "Want me to: block — prompt prefix");
+                });
+                it(`contains literal "${EXACTLY_TWO_OPTIONS_LITERAL}"`, () => {
+                    assertContains(phase7, EXACTLY_TWO_OPTIONS_LITERAL, mirror.path, "Want me to: block — exactly-two-options rule");
+                });
+            });
+            describe("Tiny-list exemption", () => {
+                it(`contains literal "${TINY_LIST_EXEMPTION_LITERAL}"`, () => {
+                    assertContains(phase7, TINY_LIST_EXEMPTION_LITERAL, mirror.path, "Tiny-list exemption — clause prefix");
+                });
+                it(`contains literal "${TINY_LIST_THRESHOLD_LITERAL}"`, () => {
+                    assertContains(phase7, TINY_LIST_THRESHOLD_LITERAL, mirror.path, "Tiny-list exemption — ≤1 item threshold");
+                });
+            });
+        });
+    }
+});

--- a/test/pmag-spec.test.mjs
+++ b/test/pmag-spec.test.mjs
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const MIRRORS = [
+    {
+        path: "skills/proceed-with-the-recommendation.md",
+        label: "source skill",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md",
+        label: "plugin mirror",
+    },
+];
+const PHASE_0_HEADING_RE = /^##\s+Phase\s+0:\s+Acknowledge.*P-MAG.*$/im;
+const PHASE_1_HEADING_RE = /^##\s+Phase\s+1:/im;
+const RULE_HEADING_RE = /^###\s+Rule\s+([123])\b[^\n]*$/gim;
+function extractPhase0(content, mirrorPath) {
+    const startMatch = content.match(PHASE_0_HEADING_RE);
+    assert.ok(startMatch && typeof startMatch.index === "number", `${mirrorPath}: missing "## Phase 0: Acknowledge ... P-MAG" heading — Phase 0 section is gone.`);
+    const start = startMatch.index;
+    const tail = content.slice(start);
+    const endRel = tail.search(PHASE_1_HEADING_RE);
+    assert.ok(endRel > 0, `${mirrorPath}: missing "## Phase 1:" heading after Phase 0 — cannot bound the Phase 0 section.`);
+    return tail.slice(0, endRel);
+}
+function extractRules(phase0, mirrorPath) {
+    const rules = new Map();
+    const matches = [];
+    RULE_HEADING_RE.lastIndex = 0;
+    let m;
+    while ((m = RULE_HEADING_RE.exec(phase0)) !== null) {
+        const ruleNum = Number(m[1]);
+        matches.push({ rule: ruleNum, heading: m[0], index: m.index });
+    }
+    RULE_HEADING_RE.lastIndex = 0;
+    assert.ok(matches.length >= 3, `${mirrorPath}: expected at least 3 "### Rule N" subsections inside Phase 0, found ${matches.length}.`);
+    for (let i = 0; i < matches.length; i++) {
+        const cur = matches[i];
+        const next = matches[i + 1];
+        const body = phase0.slice(cur.index, next ? next.index : phase0.length);
+        rules.set(cur.rule, { rule: cur.rule, heading: cur.heading, body });
+    }
+    for (const n of [1, 2, 3]) {
+        assert.ok(rules.has(n), `${mirrorPath}: Phase 0 is missing "### Rule ${n}" subsection.`);
+    }
+    return rules;
+}
+function assertContains(haystack, needle, mirrorPath, ruleLabel, clauseLabel) {
+    assert.ok(haystack.includes(needle), `${mirrorPath} :: ${ruleLabel} :: missing required clause [${clauseLabel}] — expected literal:\n  ${needle}`);
+}
+function assertMatches(haystack, pattern, mirrorPath, ruleLabel, clauseLabel) {
+    assert.ok(pattern.test(haystack), `${mirrorPath} :: ${ruleLabel} :: missing required clause [${clauseLabel}] — expected pattern:\n  ${pattern}`);
+}
+describe("proceed-with-the-recommendation P-MAG Phase 0 behavioral spec", () => {
+    for (const mirror of MIRRORS) {
+        describe(`${mirror.label} (${mirror.path})`, () => {
+            const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+            const phase0 = extractPhase0(content, mirror.path);
+            const rules = extractRules(phase0, mirror.path);
+            describe("Rule 1 — acknowledge before context", () => {
+                const rule1 = rules.get(1).body;
+                it("references observations.jsonl literally", () => {
+                    assertContains(rule1, "observations.jsonl", mirror.path, "Rule 1", "observations.jsonl reference");
+                });
+                it("defines the quote-line format with literal 'Past mistake observed:'", () => {
+                    assertContains(rule1, "Past mistake observed:", mirror.path, "Rule 1", "quote-line format prefix 'Past mistake observed:'");
+                });
+                it("defines the empty-surfaces fallback line", () => {
+                    assertContains(rule1, "No prior mistakes recorded — proceed.", mirror.path, "Rule 1", "empty-surfaces fallback line");
+                });
+            });
+            describe("Rule 2 — clearance gate", () => {
+                const rule2 = rules.get(2).body;
+                it("contains the literal halt prefix 'BLOCKED on prior mistake:'", () => {
+                    assertContains(rule2, "BLOCKED on prior mistake:", mirror.path, "Rule 2", "halt prefix 'BLOCKED on prior mistake:'");
+                });
+                it("enumerates residue-still-present trigger", () => {
+                    assertContains(rule2, "residue", mirror.path, "Rule 2", "residue trigger keyword");
+                    assertMatches(rule2, /unrotated|stale|unreverted/i, mirror.path, "Rule 2", "residue concrete examples (unrotated|stale|unreverted)");
+                });
+                it("enumerates unrun-verification trigger", () => {
+                    assertContains(rule2, "verification step", mirror.path, "Rule 2", "verification-step trigger keyword");
+                    assertMatches(rule2, /never run|was never run/i, mirror.path, "Rule 2", "verification-step never-run phrasing");
+                });
+                it("enumerates unresolved needs-approval trigger", () => {
+                    assertContains(rule2, "needs-approval", mirror.path, "Rule 2", "unresolved 'needs-approval' trigger keyword");
+                });
+            });
+            describe("Rule 3 — negative prompt", () => {
+                const rule3 = rules.get(3).body;
+                it("contains the literal 'Will NOT repeat:'", () => {
+                    assertContains(rule3, "Will NOT repeat:", mirror.path, "Rule 3", "negative-prompt prefix 'Will NOT repeat:'");
+                });
+                it("requires a specific prior session citation", () => {
+                    assertContains(rule3, "cite a specific prior session", mirror.path, "Rule 3", "specific-prior-session citation requirement");
+                });
+                it("explicitly disqualifies generic anti-patterns near a generic example", () => {
+                    assertContains(rule3, "do not qualify", mirror.path, "Rule 3", "generic anti-pattern disqualifier 'do not qualify'");
+                    assertMatches(rule3, /\([^)]*will not[^)]*\)[^\n]{0,80}do not qualify/i, mirror.path, "Rule 3", "generic example shown in parens immediately before 'do not qualify'");
+                });
+            });
+        });
+    }
+});

--- a/test/resolve-home-dir.test.mjs
+++ b/test/resolve-home-dir.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { after, before, describe, it } from "node:test";
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
+// Each test sets HOME / USERPROFILE on the live env, asserts, and the
+// outer before/after captures + restores the original values exactly.
+// We don't spawn subprocesses: this is a unit test of a pure function
+// that reads process.env synchronously.
+describe("resolveHomeDir", () => {
+    let savedHome;
+    let savedUserProfile;
+    let homeWasSet = false;
+    let userProfileWasSet = false;
+    before(() => {
+        homeWasSet = "HOME" in process.env;
+        userProfileWasSet = "USERPROFILE" in process.env;
+        savedHome = process.env.HOME;
+        savedUserProfile = process.env.USERPROFILE;
+    });
+    after(() => {
+        if (homeWasSet) {
+            process.env.HOME = savedHome;
+        }
+        else {
+            delete process.env.HOME;
+        }
+        if (userProfileWasSet) {
+            process.env.USERPROFILE = savedUserProfile;
+        }
+        else {
+            delete process.env.USERPROFILE;
+        }
+    });
+    it("returns HOME when HOME is set and USERPROFILE is undefined", () => {
+        process.env.HOME = "/foo";
+        delete process.env.USERPROFILE;
+        assert.equal(resolveHomeDir(), "/foo");
+    });
+    it("returns USERPROFILE when HOME is undefined and USERPROFILE is set", () => {
+        delete process.env.HOME;
+        process.env.USERPROFILE = "C:\\Users\\X";
+        assert.equal(resolveHomeDir(), "C:\\Users\\X");
+    });
+    it("returns empty string when BOTH HOME and USERPROFILE are explicitly empty (opt-out)", () => {
+        process.env.HOME = "";
+        process.env.USERPROFILE = "";
+        assert.equal(resolveHomeDir(), "");
+    });
+    it("falls back to USERPROFILE when only HOME is empty (single empty does NOT opt out)", () => {
+        process.env.HOME = "";
+        process.env.USERPROFILE = "/bar";
+        assert.equal(resolveHomeDir(), "/bar");
+    });
+    it("falls back to os.homedir() when both HOME and USERPROFILE are undefined", () => {
+        delete process.env.HOME;
+        delete process.env.USERPROFILE;
+        const expected = homedir() || "";
+        assert.equal(resolveHomeDir(), expected);
+    });
+});

--- a/test/three-section-close.test.mjs
+++ b/test/three-section-close.test.mjs
@@ -215,6 +215,41 @@ describe("three-section-close.mjs telemetry", () => {
         // os.homedir() and write a JSONL line into the developer's real home.
         assertNoRealTelemetryLeak(realBefore, "empty-HOME opt-out test");
     });
+    it("falls back to USERPROFILE when only HOME is empty (AND-semantic opt-out)", () => {
+        // Regression net for the AND-semantic fix: the opt-out only fires when
+        // BOTH env vars are explicitly empty. With HOME="" and USERPROFILE
+        // pointing at a valid path, the hook must still resolve a home and
+        // write telemetry there — not silently disable itself.
+        const transcript = join(transcriptDir, "home-empty.jsonl");
+        writeAssistantTranscript(transcript, "short body");
+        const env = { ...process.env };
+        env.HOME = "";
+        env.USERPROFILE = home;
+        const realBefore = snapshotRealTelemetryDir();
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, "");
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 1, "telemetry must land under USERPROFILE when HOME is empty");
+        assert.equal(entries[0].action, "skip-short");
+        assertNoRealTelemetryLeak(realBefore, "HOME-empty/USERPROFILE-valid test");
+    });
+    it("falls back to HOME when only USERPROFILE is empty (AND-semantic opt-out)", () => {
+        // Mirror of the above for the other direction.
+        const transcript = join(transcriptDir, "userprofile-empty.jsonl");
+        writeAssistantTranscript(transcript, "short body");
+        const env = { ...process.env };
+        env.HOME = home;
+        env.USERPROFILE = "";
+        const realBefore = snapshotRealTelemetryDir();
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, "");
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 1, "telemetry must land under HOME when USERPROFILE is empty");
+        assert.equal(entries[0].action, "skip-short");
+        assertNoRealTelemetryLeak(realBefore, "HOME-valid/USERPROFILE-empty test");
+    });
     it("uses a project hash that differs across distinct transcript directories", () => {
         const transcriptA = join(transcriptDir, "a.jsonl");
         const otherDir = mkdtempSync(join(rootTemp, "transcripts-other-"));

--- a/test/three-section-close.test.mjs
+++ b/test/three-section-close.test.mjs
@@ -1,8 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, } from "node:fs";
-import { platform, tmpdir } from "node:os";
+import { existsSync, mkdtempSync, readdirSync, readFileSync, rmSync, writeFileSync, } from "node:fs";
+import { homedir, platform, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { after, before, beforeEach, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -65,6 +65,25 @@ function readTelemetryLines(home, transcriptPath) {
         .split(/\r?\n/)
         .filter((line) => line.trim().length > 0)
         .map((line) => JSON.parse(line));
+}
+// Snapshot the real ~/.claude/hook-telemetry/ directory so tests can prove
+// they did not leak telemetry into the developer's actual home dir while
+// HOME/USERPROFILE were manipulated. Returns a Set of file basenames; an
+// empty Set is returned if the directory does not exist.
+function snapshotRealTelemetryDir() {
+    const dir = join(homedir(), ".claude", "hook-telemetry");
+    if (!existsSync(dir))
+        return new Set();
+    return new Set(readdirSync(dir));
+}
+function assertNoRealTelemetryLeak(before, label) {
+    const after = snapshotRealTelemetryDir();
+    const newFiles = [];
+    for (const f of after) {
+        if (!before.has(f))
+            newFiles.push(f);
+    }
+    assert.deepEqual(newFiles, [], `${label}: hook leaked telemetry into real ~/.claude/hook-telemetry/: ${newFiles.join(", ")}`);
 }
 describe("three-section-close.mjs telemetry", () => {
     let rootTemp = "";
@@ -144,20 +163,25 @@ describe("three-section-close.mjs telemetry", () => {
     it("fails open when the telemetry directory cannot be created", () => {
         // Point HOME at a regular file so mkdirSync(.../.claude/hook-telemetry)
         // must fail (cannot create a child of a file). The hook must still
-        // pass/block correctly via stdout.
+        // pass/block correctly via stdout, and must NOT silently re-route the
+        // write to the real ~/.claude/hook-telemetry/ directory.
         const blockerFile = join(rootTemp, `home-as-file-${Date.now()}.txt`);
         writeFileSync(blockerFile, "not a directory");
         const transcript = join(transcriptDir, "fail-open.jsonl");
         const body = "Long body without sections. ".repeat(25);
         writeAssistantTranscript(transcript, body);
+        const realBefore = snapshotRealTelemetryDir();
         const env = buildIsolatedEnv(blockerFile);
         const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
         assert.equal(result.status, 0, "hook still exits 0 even with unwritable HOME");
         const parsed = JSON.parse(result.stdout);
         assert.equal(parsed.decision, "block", "block emit still works");
         assert.equal(result.stderr, "", "no stderr on fail-open telemetry");
+        // Drift-catch: the mkdir failure path must not silently bypass to the
+        // operator's real home dir. Snapshot before/after; no new files.
+        assertNoRealTelemetryLeak(realBefore, "unwritable-telemetry-dir test");
     });
-    it("works when HOME and USERPROFILE are both unset (no telemetry, no error)", () => {
+    it("explicit opt-out via empty HOME/USERPROFILE skips telemetry without falling back to os.homedir()", () => {
         const transcript = join(transcriptDir, "no-home.jsonl");
         const body = [
             "Filler. ".repeat(30),
@@ -169,18 +193,27 @@ describe("three-section-close.mjs telemetry", () => {
             "no",
         ].join("\n\n");
         writeAssistantTranscript(transcript, body);
-        // Build env with neither HOME nor USERPROFILE.
+        // Empty-string HOME and USERPROFILE = explicit operator opt-out signal.
+        // The hook must short-circuit and write nothing. Critically, it must
+        // NOT fall back to os.homedir() (which would pollute the real
+        // ~/.claude/hook-telemetry/ during every `npm test` run — the bug this
+        // test was previously a false positive for).
         const env = { ...process.env };
-        delete env.HOME;
-        delete env.USERPROFILE;
+        env.HOME = "";
+        env.USERPROFILE = "";
+        const realBefore = snapshotRealTelemetryDir();
         const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
-        assert.equal(result.status, 0, "hook exits 0 without HOME/USERPROFILE");
+        assert.equal(result.status, 0, "hook exits 0 with empty HOME/USERPROFILE");
         assert.equal(result.stdout, "", "compliant reply still passes");
         assert.equal(result.stderr, "", "no error escapes to stderr");
         // Confirm no telemetry was written under our isolated `home` either —
         // the hook had no place to write it.
         const entries = readTelemetryLines(home, transcript);
-        assert.equal(entries.length, 0, "no telemetry written when HOME/USERPROFILE absent");
+        assert.equal(entries.length, 0, "no telemetry written under isolated HOME");
+        // Drift-catch: the real ~/.claude/hook-telemetry/ must be untouched.
+        // Without the empty-string opt-out, resolveHomeDir() would call
+        // os.homedir() and write a JSONL line into the developer's real home.
+        assertNoRealTelemetryLeak(realBefore, "empty-HOME opt-out test");
     });
     it("uses a project hash that differs across distinct transcript directories", () => {
         const transcriptA = join(transcriptDir, "a.jsonl");

--- a/test/three-section-close.test.mjs
+++ b/test/three-section-close.test.mjs
@@ -1,0 +1,250 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync, } from "node:fs";
+import { platform, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { after, before, beforeEach, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname resolves to <repo>/test/ at runtime (compiled .mjs lives under
+// test/ per tsconfig outDir). Hook lives under <repo>/hooks/.
+const HOOK_PATH = join(__dirname, "..", "hooks", "three-section-close.mjs");
+const REQUIRED_HEADINGS = [
+    "What has been done",
+    "What is next",
+    "Recommendation",
+];
+function projectHashFor(transcriptPath) {
+    const dir = dirname(transcriptPath);
+    let normalized = dir.split("\\").join("/");
+    if (platform() === "win32")
+        normalized = normalized.toLowerCase();
+    return createHash("sha256").update(normalized).digest("hex").slice(0, 12);
+}
+function writeAssistantTranscript(path, text) {
+    const line = JSON.stringify({
+        type: "assistant",
+        message: { content: [{ type: "text", text }] },
+    });
+    writeFileSync(path, `${line}\n`);
+}
+function buildIsolatedEnv(home) {
+    // Strip the real HOME/USERPROFILE so the hook only sees our temp dir.
+    // Process.env spread loses the inheritance, so we re-add PATH explicitly.
+    const env = { ...process.env };
+    delete env.HOME;
+    delete env.USERPROFILE;
+    env.HOME = home;
+    // Windows resolves homedir from USERPROFILE; set it too so platform code
+    // paths agree regardless of which is consulted first.
+    env.USERPROFILE = home;
+    return env;
+}
+function runHook(payload, env) {
+    const result = spawnSync(process.execPath, [HOOK_PATH], {
+        input: payload,
+        env,
+        encoding: "utf8",
+        timeout: 5000,
+    });
+    if (result.error)
+        throw result.error;
+    return {
+        status: result.status,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+function readTelemetryLines(home, transcriptPath) {
+    const file = join(home, ".claude", "hook-telemetry", `${projectHashFor(transcriptPath)}.jsonl`);
+    if (!existsSync(file))
+        return [];
+    const raw = readFileSync(file, "utf8");
+    return raw
+        .split(/\r?\n/)
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line));
+}
+describe("three-section-close.mjs telemetry", () => {
+    let rootTemp = "";
+    before(() => {
+        rootTemp = mkdtempSync(join(tmpdir(), "three-sec-root-"));
+    });
+    after(() => {
+        rmSync(rootTemp, { recursive: true, force: true });
+    });
+    // Each test gets its own HOME so telemetry writes can't leak between cases.
+    let home = "";
+    let transcriptDir = "";
+    beforeEach(() => {
+        home = mkdtempSync(join(rootTemp, "home-"));
+        transcriptDir = mkdtempSync(join(rootTemp, "transcripts-"));
+    });
+    it("records a pass entry for a compliant long reply", () => {
+        const transcript = join(transcriptDir, "pass.jsonl");
+        const body = [
+            "Lots of substantive work prose. ".repeat(20),
+            "## What has been done",
+            "- changed things",
+            "## What is next",
+            "1. a\n2. b\n3. c\n4. d\n5. e",
+            "## Recommendation",
+            "1. ship it",
+        ].join("\n\n");
+        writeAssistantTranscript(transcript, body);
+        const env = buildIsolatedEnv(home);
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0, "hook should exit 0");
+        assert.equal(result.stdout, "", "no stdout on pass path");
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 1, "exactly one telemetry line written");
+        const [entry] = entries;
+        assert.equal(entry.hook, "three-section-close");
+        assert.equal(entry.action, "pass");
+        assert.deepEqual(entry.missing, [], "missing array empty on pass");
+        assert.ok(entry.textLength >= 600, "textLength gates above threshold");
+        assert.equal(typeof entry.durationMs, "number");
+        assert.ok(!Number.isNaN(Date.parse(entry.ts)), "ts is ISO timestamp");
+    });
+    it("records a block entry naming the absent heading(s)", () => {
+        const transcript = join(transcriptDir, "block.jsonl");
+        // ≥ 600 chars but missing all three sections.
+        const body = "Long technical narrative without the required close. ".repeat(20);
+        writeAssistantTranscript(transcript, body);
+        const env = buildIsolatedEnv(home);
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0, "hook still exits 0; block goes via stdout");
+        const parsed = JSON.parse(result.stdout);
+        assert.equal(parsed.decision, "block");
+        for (const heading of REQUIRED_HEADINGS) {
+            assert.match(parsed.reason ?? "", new RegExp(heading));
+        }
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 1, "exactly one telemetry line written");
+        const [entry] = entries;
+        assert.equal(entry.action, "block");
+        assert.deepEqual(entry.missing, REQUIRED_HEADINGS, "missing lists every absent heading");
+        assert.ok(entry.textLength >= 600);
+    });
+    it("records a skip-short entry for a short reply", () => {
+        const transcript = join(transcriptDir, "short.jsonl");
+        writeAssistantTranscript(transcript, "ok done");
+        const env = buildIsolatedEnv(home);
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, "");
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 1);
+        const [entry] = entries;
+        assert.equal(entry.action, "skip-short");
+        assert.deepEqual(entry.missing, []);
+        assert.ok(entry.textLength < 600, "textLength below gate threshold");
+    });
+    it("fails open when the telemetry directory cannot be created", () => {
+        // Point HOME at a regular file so mkdirSync(.../.claude/hook-telemetry)
+        // must fail (cannot create a child of a file). The hook must still
+        // pass/block correctly via stdout.
+        const blockerFile = join(rootTemp, `home-as-file-${Date.now()}.txt`);
+        writeFileSync(blockerFile, "not a directory");
+        const transcript = join(transcriptDir, "fail-open.jsonl");
+        const body = "Long body without sections. ".repeat(25);
+        writeAssistantTranscript(transcript, body);
+        const env = buildIsolatedEnv(blockerFile);
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0, "hook still exits 0 even with unwritable HOME");
+        const parsed = JSON.parse(result.stdout);
+        assert.equal(parsed.decision, "block", "block emit still works");
+        assert.equal(result.stderr, "", "no stderr on fail-open telemetry");
+    });
+    it("works when HOME and USERPROFILE are both unset (no telemetry, no error)", () => {
+        const transcript = join(transcriptDir, "no-home.jsonl");
+        const body = [
+            "Filler. ".repeat(30),
+            "## What has been done",
+            "x",
+            "## What is next",
+            "1. a\n2. b\n3. c\n4. d\n5. e",
+            "## Recommendation",
+            "no",
+        ].join("\n\n");
+        writeAssistantTranscript(transcript, body);
+        // Build env with neither HOME nor USERPROFILE.
+        const env = { ...process.env };
+        delete env.HOME;
+        delete env.USERPROFILE;
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0, "hook exits 0 without HOME/USERPROFILE");
+        assert.equal(result.stdout, "", "compliant reply still passes");
+        assert.equal(result.stderr, "", "no error escapes to stderr");
+        // Confirm no telemetry was written under our isolated `home` either —
+        // the hook had no place to write it.
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 0, "no telemetry written when HOME/USERPROFILE absent");
+    });
+    it("uses a project hash that differs across distinct transcript directories", () => {
+        const transcriptA = join(transcriptDir, "a.jsonl");
+        const otherDir = mkdtempSync(join(rootTemp, "transcripts-other-"));
+        const transcriptB = join(otherDir, "b.jsonl");
+        const body = "Short ok"; // skip-short keeps the test fast and deterministic
+        writeAssistantTranscript(transcriptA, body);
+        writeAssistantTranscript(transcriptB, body);
+        const env = buildIsolatedEnv(home);
+        runHook(JSON.stringify({ transcript_path: transcriptA }), env);
+        runHook(JSON.stringify({ transcript_path: transcriptB }), env);
+        const hashA = projectHashFor(transcriptA);
+        const hashB = projectHashFor(transcriptB);
+        assert.notEqual(hashA, hashB, "different transcript dirs hash differently");
+        const fileA = join(home, ".claude", "hook-telemetry", `${hashA}.jsonl`);
+        const fileB = join(home, ".claude", "hook-telemetry", `${hashB}.jsonl`);
+        assert.ok(existsSync(fileA), "telemetry file for project A exists");
+        assert.ok(existsSync(fileB), "telemetry file for project B exists");
+    });
+    it("does not write telemetry when transcript file does not exist", () => {
+        const transcript = join(transcriptDir, "missing.jsonl");
+        const env = buildIsolatedEnv(home);
+        const result = runHook(JSON.stringify({ transcript_path: transcript }), env);
+        assert.equal(result.status, 0);
+        assert.equal(result.stdout, "");
+        // The hook returns before reaching telemetry; expect no file.
+        const dirAfter = join(home, ".claude", "hook-telemetry");
+        assert.equal(existsSync(dirAfter), false, "telemetry dir not created");
+    });
+    it("appends a second telemetry line on a second invocation in the same project", () => {
+        const transcript = join(transcriptDir, "repeat.jsonl");
+        writeAssistantTranscript(transcript, "short body");
+        const env = buildIsolatedEnv(home);
+        runHook(JSON.stringify({ transcript_path: transcript }), env);
+        runHook(JSON.stringify({ transcript_path: transcript }), env);
+        const entries = readTelemetryLines(home, transcript);
+        assert.equal(entries.length, 2, "two appended telemetry lines");
+        for (const entry of entries) {
+            assert.equal(entry.action, "skip-short");
+        }
+    });
+});
+// Sanity: the production hook file we are testing actually exists and is
+// executable as a Node script. Catches setup mistakes early.
+describe("three-section-close.mjs presence", () => {
+    it("has the expected hook file on disk", () => {
+        assert.ok(existsSync(HOOK_PATH), `hook file should exist at ${HOOK_PATH}`);
+    });
+    it("can be imported without throwing parse errors", () => {
+        const dummyHome = mkdtempSync(join(tmpdir(), "three-sec-noop-"));
+        try {
+            const env = buildIsolatedEnv(dummyHome);
+            const result = runHook("", env);
+            assert.equal(result.status, 0, "hook handles empty stdin cleanly");
+            assert.equal(result.stdout, "");
+            assert.equal(result.stderr, "");
+        }
+        finally {
+            rmSync(dummyHome, { recursive: true, force: true });
+            // Also ensure parent fragments cleaned (mkdtempSync may leave bones)
+            const parentLeftover = dirname(dummyHome);
+            if (parentLeftover === tmpdir()) {
+                // tmpdir() — never delete
+            }
+        }
+    });
+});

--- a/test/wild-risa-spec.test.mjs
+++ b/test/wild-risa-spec.test.mjs
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const MIRRORS = [
+    {
+        path: "skills/wild-risa-balance.md",
+        label: "source skill",
+    },
+    {
+        path: "plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md",
+        label: "plugin mirror",
+    },
+];
+// Asserted contract literals — every magic string used in `.includes(...)` is
+// hoisted here so a single source of truth governs what the skill must say.
+const WILD_EXACT_COUNT_LITERAL = "exactly 2";
+const RISA_FLOOR_LITERAL = "at least 5";
+const RANK_LITERAL = "rank descending by impact";
+const NEVER_AUTO_TRIGGER_LITERAL = "Never auto-trigger";
+const EXAMPLE_TOTAL_LITERAL = "Total: 7 items (2 WILD + 5 RISA)";
+const WILD_EXAMPLE_COUNT = 2;
+const RISA_EXAMPLE_COUNT = 5;
+const HOW_TO_APPLY_HEADING_RE = /^##\s+How to Apply in a Recommendation List\s*$/im;
+const NEXT_H2_RE = /^##\s+/m;
+const EXAMPLE_HEADING_RE = /^##\s+Example\s*$/im;
+const NUMBERED_TOP_LEVEL_RE = /^(\d+)\.\s+/gm;
+const WILD_PILOTS_BLOCK_HEADER_RE = /^[^\n]*WILD pilots[^\n]*$/im;
+const RISA_BASELINE_BLOCK_HEADER_RE = /^[^\n]*RISA baseline[^\n]*$/im;
+const NUMBERED_LINE_RE = /^(\d+)\.\s+/gm;
+function extractSection(content, startRe, mirrorPath, sectionLabel) {
+    const startMatch = content.match(startRe);
+    assert.ok(startMatch && typeof startMatch.index === "number", `${mirrorPath}: missing "${sectionLabel}" heading — section is gone or renamed.`);
+    const start = startMatch.index;
+    const headingLineEnd = content.indexOf("\n", start);
+    const tailFromBody = content.slice(headingLineEnd + 1);
+    const endRel = tailFromBody.search(NEXT_H2_RE);
+    const body = endRel === -1 ? tailFromBody : tailFromBody.slice(0, endRel);
+    assert.ok(body.trim().length > 0, `${mirrorPath}: "${sectionLabel}" section is empty.`);
+    return body;
+}
+function countTopLevelNumbered(section) {
+    NUMBERED_TOP_LEVEL_RE.lastIndex = 0;
+    let count = 0;
+    while (NUMBERED_TOP_LEVEL_RE.exec(section) !== null) {
+        count++;
+    }
+    NUMBERED_TOP_LEVEL_RE.lastIndex = 0;
+    return count;
+}
+function extractBlockAfterHeader(exampleSection, headerRe, mirrorPath, blockLabel) {
+    const headerMatch = exampleSection.match(headerRe);
+    assert.ok(headerMatch && typeof headerMatch.index === "number", `${mirrorPath}: Example block is missing the "${blockLabel}" header line.`);
+    const start = headerMatch.index;
+    const headerLineEnd = exampleSection.indexOf("\n", start);
+    const after = exampleSection.slice(headerLineEnd + 1);
+    // The block runs until the next blank line OR the next non-numbered, non-empty line.
+    const lines = after.split("\n");
+    const collected = [];
+    for (const line of lines) {
+        if (line.trim() === "") {
+            if (collected.length > 0)
+                break;
+            continue;
+        }
+        if (/^\d+\.\s+/.test(line)) {
+            collected.push(line);
+            continue;
+        }
+        // First non-numbered non-blank line ends the block.
+        break;
+    }
+    return collected.join("\n");
+}
+function countNumberedLines(block) {
+    NUMBERED_LINE_RE.lastIndex = 0;
+    let count = 0;
+    while (NUMBERED_LINE_RE.exec(block) !== null) {
+        count++;
+    }
+    NUMBERED_LINE_RE.lastIndex = 0;
+    return count;
+}
+function assertContains(haystack, needle, mirrorPath, sectionLabel, clauseLabel) {
+    assert.ok(haystack.includes(needle), `${mirrorPath} :: ${sectionLabel} :: missing required clause [${clauseLabel}] — expected literal:\n  ${needle}`);
+}
+describe("wild-risa-balance How to Apply behavioral spec", () => {
+    for (const mirror of MIRRORS) {
+        describe(`${mirror.label} (${mirror.path})`, () => {
+            const content = readFileSync(join(REPO_ROOT, mirror.path), "utf8");
+            const howToApply = extractSection(content, HOW_TO_APPLY_HEADING_RE, mirror.path, "## How to Apply in a Recommendation List");
+            describe("section structure — 4 numbered top-level sub-rules", () => {
+                it(`contains exactly 4 top-level numbered items (1.–4.)`, () => {
+                    const count = countTopLevelNumbered(howToApply);
+                    assert.equal(count, 4, `${mirror.path}: How to Apply section must contain 4 numbered top-level sub-rules; found ${count}. Each rule encodes a normative behavior — losing one silently degrades the contract.`);
+                });
+                it(`Rule 1 (WILD pilots line) contains literal "${WILD_EXACT_COUNT_LITERAL}"`, () => {
+                    // Rule 1 is the line beginning with "1." that mentions WILD.
+                    const rule1Line = howToApply
+                        .split("\n")
+                        .find((l) => /^1\.\s+/.test(l) && /WILD/i.test(l));
+                    assert.ok(rule1Line, `${mirror.path}: could not locate "1." rule line referencing WILD — Rule 1 may have been renumbered or rephrased.`);
+                    assertContains(rule1Line, WILD_EXACT_COUNT_LITERAL, mirror.path, "Rule 1 (WILD pilots)", `WILD count literal "${WILD_EXACT_COUNT_LITERAL}"`);
+                });
+                it(`Rule 2 (RISA baseline line) contains literal "${RISA_FLOOR_LITERAL}"`, () => {
+                    const rule2Line = howToApply
+                        .split("\n")
+                        .find((l) => /^2\.\s+/.test(l) && /RISA/i.test(l));
+                    assert.ok(rule2Line, `${mirror.path}: could not locate "2." rule line referencing RISA — Rule 2 may have been renumbered or rephrased.`);
+                    assertContains(rule2Line, RISA_FLOOR_LITERAL, mirror.path, "Rule 2 (RISA baseline)", `RISA floor literal "${RISA_FLOOR_LITERAL}"`);
+                });
+                it(`section contains literal "${RANK_LITERAL}"`, () => {
+                    assertContains(howToApply, RANK_LITERAL, mirror.path, "How to Apply", `ranking clause "${RANK_LITERAL}"`);
+                });
+                it(`section contains never-auto-trigger clause literal "${NEVER_AUTO_TRIGGER_LITERAL}"`, () => {
+                    assertContains(howToApply, NEVER_AUTO_TRIGGER_LITERAL, mirror.path, "How to Apply", `never-auto-trigger clause "${NEVER_AUTO_TRIGGER_LITERAL}"`);
+                });
+            });
+            describe("Example block — counts and closing line", () => {
+                const exampleSection = extractSection(content, EXAMPLE_HEADING_RE, mirror.path, "## Example");
+                it(`WILD pilots example block contains exactly ${WILD_EXAMPLE_COUNT} numbered items`, () => {
+                    const wildBlock = extractBlockAfterHeader(exampleSection, WILD_PILOTS_BLOCK_HEADER_RE, mirror.path, "WILD pilots");
+                    const found = countNumberedLines(wildBlock);
+                    assert.equal(found, WILD_EXAMPLE_COUNT, `${mirror.path}: Example block "WILD pilots" must show exactly ${WILD_EXAMPLE_COUNT} numbered items, found ${found}. The example must mirror the rule "exactly 2".`);
+                });
+                it(`RISA baseline example block contains exactly ${RISA_EXAMPLE_COUNT} numbered items`, () => {
+                    const risaBlock = extractBlockAfterHeader(exampleSection, RISA_BASELINE_BLOCK_HEADER_RE, mirror.path, "RISA baseline");
+                    const found = countNumberedLines(risaBlock);
+                    assert.equal(found, RISA_EXAMPLE_COUNT, `${mirror.path}: Example block "RISA baseline" must show exactly ${RISA_EXAMPLE_COUNT} numbered items, found ${found}. The example must mirror the rule "at least 5" floor.`);
+                });
+                it(`Example section contains closing total literal "${EXAMPLE_TOTAL_LITERAL}"`, () => {
+                    assertContains(exampleSection, EXAMPLE_TOTAL_LITERAL, mirror.path, "Example", `closing total "${EXAMPLE_TOTAL_LITERAL}"`);
+                });
+            });
+        });
+    }
+});


### PR DESCRIPTION
## Summary

Locks down three recently shipped skills against silent SKILL.md drift, adds JSONL telemetry to the `three-section-close` Stop hook, and ships a `hook-stats` reader. 10 commits, 342 tests passing, zero new runtime deps.

- **Behavioral spec tests** (4 new files) for `proceed-with-the-recommendation` Phase 0 P-MAG, `wild-risa-balance` 5+2 floor + How-to-Apply, `proceed-with-the-recommendation` Phase 7 close shape, and the cross-skill contract that links the two skills. Existing tests checked literal substrings; these parse the relevant sections and assert on structural rules so a softened verb or removed clause fails CI.
- **Hook telemetry** in `hooks/three-section-close.mjs`: every invocation appends one JSONL line to `~/.claude/hook-telemetry/<project-hash>.jsonl` with `action` (pass/block/skip-short), `textLength`, `missing` headings, `durationMs`. Fail-open under all error paths. Triple try/catch on the telemetry writer; block-emit happens before telemetry write so a hung append cannot suppress the decision.
- **`npm run hooks:stats`** CLI for ad-hoc inspection of the JSONL — supports `--hours`, `--hash`, `--telemetry-dir`, parse-tolerant of malformed lines.
- **Two follow-up fix commits** address code-review findings on B1/B2: a false-positive no-HOME test (was silently writing to the developer's real `~/.claude/hook-telemetry/` on every `npm test` run) and an over-aggressive OR semantic in the empty-HOME opt-out (now AND).

Plan doc: [docs/plans/2026-04-29-skill-hardening-design.md](docs/plans/2026-04-29-skill-hardening-design.md). Includes execution-notes section logging the C1 Part 1 scope cut (fixture replay was redundant with B1's expanded tests).

## Test plan

- [x] `npm test` — 342/342 pass on local (Node 24).
- [ ] CI multi-Node matrix (18/20/22) green.
- [ ] CI gate `git diff --exit-code -- bin test` green (all `.mts`/`.mjs` pairs committed).
- [ ] CI gate `verify:zero-runtime-deps` — no entries in `dependencies`.
- [x] Drift-catch verified locally on `pmag-spec.test.mts`: flipping `No prior mistakes recorded — proceed.` produced `AssertionError: skills/proceed-with-the-recommendation.md :: Rule 1 :: missing required clause [empty-surfaces fallback line]` on both mirrors. Reverted clean.
- [x] Test-time telemetry pollution check: real `~/.claude/hook-telemetry/` file count unchanged across `npm test` run.
- [x] Hook fail-open trace: every error path returns rather than throws; outer `try { main() } catch {}` preserved; telemetry writer triple-wrapped.
- [ ] Smoke: trigger one real Stop-hook fire post-merge, confirm JSONL line shape matches test fixtures, run `npm run hooks:stats`.

## Commits (oldest first)

```
e048d28 docs(plans): skill-hardening design
518eb24 test(skills): behavioral spec for P-MAG Phase 0 rules
b4d1d12 test(skills): behavioral spec for wild-risa-balance How to Apply rules
3418e22 test(skills): behavioral spec for proceed-with-the-recommendation Phase 7 close
81b04c6 feat(hooks): JSONL telemetry sink for three-section-close hook
1241671 fix(hooks): empty-HOME opt-out + eliminate test-time telemetry leak
8f2d5a2 feat(hooks): hook-stats reader + npm run hooks:stats
c42d06b fix(hooks): require BOTH env vars empty for telemetry opt-out
335622d test(skills): cross-skill contract — proceed-with-the-recommendation ↔ wild-risa-balance
d0c1f86 docs(plans): log skill-hardening execution notes
```

## Deferred follow-ups (logged in plan doc)

- Extract `resolveHomeDir` into shared `lib/` module — three byte-equivalent copies across the hook + plugin mirror + CLI is the highest future-drift surface in this branch.
- JSONL log rotation/retention before this lands on busy dev machines.
- Live-agent eval harness (Claude API budget required).
- Behavioral specs for skills outside the three-skill scope.