### PR TITLE
refactor(hooks): extract resolveHomeDir into shared lib

### DIFF
--- a/bin/generate-plugin-manifests.mjs
+++ b/bin/generate-plugin-manifests.mjs
@@ -102,6 +102,7 @@ async function writePluginBundle() {
         copyDirectory(join(REPO_ROOT, "templates", "planning-with-files"), join(PLUGIN_BUNDLE_DIR, "templates", "planning-with-files")),
         copyFileTo(join(REPO_ROOT, "bin", "mcp-server.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "mcp-server.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "plugin-metadata.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs")),
+        copyFileTo(join(REPO_ROOT, "lib", "resolve-home-dir.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "resolve-home-dir.mjs")),
         copyFileTo(join(REPO_ROOT, "LICENSE"), join(PLUGIN_BUNDLE_DIR, "LICENSE")),
         writePluginBundleReadme(),
     ]);

--- a/bin/hook-stats.mjs
+++ b/bin/hook-stats.mjs
@@ -42,9 +42,10 @@
  */
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { join } from "node:path";
-import { argv, cwd, env, exit, stderr, stdout } from "node:process";
+import { argv, cwd, exit, stderr, stdout } from "node:process";
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 const USAGE = `Usage: node bin/hook-stats.mjs [options]
 
 Reads JSONL telemetry from <HOME>/.claude/hook-telemetry/*.jsonl and
@@ -99,28 +100,6 @@ function parseArgs(rawArgs) {
         throw new Error(`unknown argument: ${arg}`);
     }
     return opts;
-}
-function resolveHomeDir() {
-    // Mirrors the hook: explicit opt-out requires BOTH env vars empty.
-    // OR-semantic would silently disable the CLI when a shell happened to
-    // clear one variable while the other still pointed at a valid path.
-    const home = env.HOME;
-    const userProfile = env.USERPROFILE;
-    if (home === "" && userProfile === "")
-        return "";
-    if (home)
-        return home;
-    if (userProfile)
-        return userProfile;
-    try {
-        const fromOs = homedir();
-        if (fromOs)
-            return fromOs;
-    }
-    catch {
-        // ignore
-    }
-    return "";
 }
 export function projectHashForCwd(workingDir) {
     let normalized = workingDir.split("\\").join("/");

--- a/hooks/three-section-close.mjs
+++ b/hooks/three-section-close.mjs
@@ -22,9 +22,11 @@
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 
 const MIN_LENGTH_TO_GATE = 600;
 
@@ -91,30 +93,6 @@ function emitBlock(missing) {
   const reason =
     `Your reply is missing the required 3-section close. Add these sections at the end of the reply with these exact headings:\n${bullets}`;
   process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
-}
-
-function resolveHomeDir() {
-  // Explicit operator opt-out: only when BOTH HOME and USERPROFILE are set
-  // to the empty string (set, not undefined) do we skip telemetry entirely.
-  // Empty-string-on-both is a deliberate signal (used by tests and by
-  // operators who want telemetry disabled without editing settings.json).
-  // If only one var is empty and the other points at a valid path, fall
-  // back to the valid one — otherwise telemetry would silently disable
-  // whenever a shell happens to clear one variable.
-  const home = process.env.HOME;
-  const userProfile = process.env.USERPROFILE;
-  if (home === "" && userProfile === "") return "";
-  if (home) return home;
-  if (userProfile) return userProfile;
-  // Neither set to a truthy path: legitimately fall back to os.homedir()
-  // so normal non-test usage keeps working when env vars are merely missing.
-  try {
-    const fromOs = homedir();
-    if (fromOs) return fromOs;
-  } catch {
-    // os.homedir() can throw in pathological env conditions
-  }
-  return "";
 }
 
 function projectHashFor(transcriptPath) {

--- a/lib/resolve-home-dir.mjs
+++ b/lib/resolve-home-dir.mjs
@@ -1,0 +1,43 @@
+// resolve-home-dir.mts — Single source of truth for the telemetry home dir
+// resolution rule shared by hooks/three-section-close.mjs and bin/hook-stats.mjs.
+//
+// Previously this 20-line function lived in three byte-equivalent copies; this
+// module collapses them. Behavior is unchanged.
+import { homedir } from "node:os";
+/**
+ * Resolve the home directory used to locate `.claude/hook-telemetry/`.
+ *
+ * Contract (AND-semantic opt-out):
+ *   - If BOTH `HOME` and `USERPROFILE` are explicitly set to the empty string
+ *     (set, not merely undefined), return `""`. This is the operator/test
+ *     opt-out signal: telemetry is intentionally disabled.
+ *   - Otherwise return the first truthy value from, in order:
+ *     `process.env.HOME`, `process.env.USERPROFILE`, `os.homedir()`.
+ *   - If none yields a truthy path, return `""`.
+ *
+ * The AND-semantic is deliberate: an OR-semantic would silently disable
+ * telemetry whenever a shell happened to clear one variable while the other
+ * still pointed at a valid path.
+ *
+ * Never throws. `os.homedir()` is wrapped in try/catch because it can throw
+ * in pathological env conditions.
+ */
+export function resolveHomeDir() {
+    const home = process.env.HOME;
+    const userProfile = process.env.USERPROFILE;
+    if (home === "" && userProfile === "")
+        return "";
+    if (home)
+        return home;
+    if (userProfile)
+        return userProfile;
+    try {
+        const fromOs = homedir();
+        if (fromOs)
+            return fromOs;
+    }
+    catch {
+        // os.homedir() can throw in pathological env conditions
+    }
+    return "";
+}

--- a/plugins/continuous-improvement/hooks/three-section-close.mjs
+++ b/plugins/continuous-improvement/hooks/three-section-close.mjs
@@ -22,9 +22,11 @@
 
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { createHash } from "node:crypto";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { dirname, join } from "node:path";
 import { performance } from "node:perf_hooks";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 
 const MIN_LENGTH_TO_GATE = 600;
 
@@ -91,30 +93,6 @@ function emitBlock(missing) {
   const reason =
     `Your reply is missing the required 3-section close. Add these sections at the end of the reply with these exact headings:\n${bullets}`;
   process.stdout.write(JSON.stringify({ decision: "block", reason }) + "\n");
-}
-
-function resolveHomeDir() {
-  // Explicit operator opt-out: only when BOTH HOME and USERPROFILE are set
-  // to the empty string (set, not undefined) do we skip telemetry entirely.
-  // Empty-string-on-both is a deliberate signal (used by tests and by
-  // operators who want telemetry disabled without editing settings.json).
-  // If only one var is empty and the other points at a valid path, fall
-  // back to the valid one — otherwise telemetry would silently disable
-  // whenever a shell happens to clear one variable.
-  const home = process.env.HOME;
-  const userProfile = process.env.USERPROFILE;
-  if (home === "" && userProfile === "") return "";
-  if (home) return home;
-  if (userProfile) return userProfile;
-  // Neither set to a truthy path: legitimately fall back to os.homedir()
-  // so normal non-test usage keeps working when env vars are merely missing.
-  try {
-    const fromOs = homedir();
-    if (fromOs) return fromOs;
-  } catch {
-    // os.homedir() can throw in pathological env conditions
-  }
-  return "";
 }
 
 function projectHashFor(transcriptPath) {

--- a/plugins/continuous-improvement/lib/resolve-home-dir.mjs
+++ b/plugins/continuous-improvement/lib/resolve-home-dir.mjs
@@ -1,0 +1,43 @@
+// resolve-home-dir.mts — Single source of truth for the telemetry home dir
+// resolution rule shared by hooks/three-section-close.mjs and bin/hook-stats.mjs.
+//
+// Previously this 20-line function lived in three byte-equivalent copies; this
+// module collapses them. Behavior is unchanged.
+import { homedir } from "node:os";
+/**
+ * Resolve the home directory used to locate `.claude/hook-telemetry/`.
+ *
+ * Contract (AND-semantic opt-out):
+ *   - If BOTH `HOME` and `USERPROFILE` are explicitly set to the empty string
+ *     (set, not merely undefined), return `""`. This is the operator/test
+ *     opt-out signal: telemetry is intentionally disabled.
+ *   - Otherwise return the first truthy value from, in order:
+ *     `process.env.HOME`, `process.env.USERPROFILE`, `os.homedir()`.
+ *   - If none yields a truthy path, return `""`.
+ *
+ * The AND-semantic is deliberate: an OR-semantic would silently disable
+ * telemetry whenever a shell happened to clear one variable while the other
+ * still pointed at a valid path.
+ *
+ * Never throws. `os.homedir()` is wrapped in try/catch because it can throw
+ * in pathological env conditions.
+ */
+export function resolveHomeDir() {
+    const home = process.env.HOME;
+    const userProfile = process.env.USERPROFILE;
+    if (home === "" && userProfile === "")
+        return "";
+    if (home)
+        return home;
+    if (userProfile)
+        return userProfile;
+    try {
+        const fromOs = homedir();
+        if (fromOs)
+            return fromOs;
+    }
+    catch {
+        // os.homedir() can throw in pathological env conditions
+    }
+    return "";
+}

--- a/src/bin/generate-plugin-manifests.mts
+++ b/src/bin/generate-plugin-manifests.mts
@@ -165,6 +165,10 @@ async function writePluginBundle(): Promise<void> {
       join(REPO_ROOT, "lib", "plugin-metadata.mjs"),
       join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs"),
     ),
+    copyFileTo(
+      join(REPO_ROOT, "lib", "resolve-home-dir.mjs"),
+      join(PLUGIN_BUNDLE_DIR, "lib", "resolve-home-dir.mjs"),
+    ),
     copyFileTo(join(REPO_ROOT, "LICENSE"), join(PLUGIN_BUNDLE_DIR, "LICENSE")),
     writePluginBundleReadme(),
   ]);

--- a/src/bin/hook-stats.mts
+++ b/src/bin/hook-stats.mts
@@ -44,9 +44,11 @@
 
 import { createHash } from "node:crypto";
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { homedir, platform } from "node:os";
+import { platform } from "node:os";
 import { join } from "node:path";
-import { argv, cwd, env, exit, stderr, stdout } from "node:process";
+import { argv, cwd, exit, stderr, stdout } from "node:process";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
 
 interface CliOptions {
   hours: number;
@@ -129,24 +131,6 @@ function parseArgs(rawArgs: readonly string[]): CliOptions {
     throw new Error(`unknown argument: ${arg}`);
   }
   return opts;
-}
-
-function resolveHomeDir(): string {
-  // Mirrors the hook: explicit opt-out requires BOTH env vars empty.
-  // OR-semantic would silently disable the CLI when a shell happened to
-  // clear one variable while the other still pointed at a valid path.
-  const home = env.HOME;
-  const userProfile = env.USERPROFILE;
-  if (home === "" && userProfile === "") return "";
-  if (home) return home;
-  if (userProfile) return userProfile;
-  try {
-    const fromOs = homedir();
-    if (fromOs) return fromOs;
-  } catch {
-    // ignore
-  }
-  return "";
 }
 
 export function projectHashForCwd(workingDir: string): string {

--- a/src/lib/resolve-home-dir.mts
+++ b/src/lib/resolve-home-dir.mts
@@ -1,0 +1,40 @@
+// resolve-home-dir.mts — Single source of truth for the telemetry home dir
+// resolution rule shared by hooks/three-section-close.mjs and bin/hook-stats.mjs.
+//
+// Previously this 20-line function lived in three byte-equivalent copies; this
+// module collapses them. Behavior is unchanged.
+
+import { homedir } from "node:os";
+
+/**
+ * Resolve the home directory used to locate `.claude/hook-telemetry/`.
+ *
+ * Contract (AND-semantic opt-out):
+ *   - If BOTH `HOME` and `USERPROFILE` are explicitly set to the empty string
+ *     (set, not merely undefined), return `""`. This is the operator/test
+ *     opt-out signal: telemetry is intentionally disabled.
+ *   - Otherwise return the first truthy value from, in order:
+ *     `process.env.HOME`, `process.env.USERPROFILE`, `os.homedir()`.
+ *   - If none yields a truthy path, return `""`.
+ *
+ * The AND-semantic is deliberate: an OR-semantic would silently disable
+ * telemetry whenever a shell happened to clear one variable while the other
+ * still pointed at a valid path.
+ *
+ * Never throws. `os.homedir()` is wrapped in try/catch because it can throw
+ * in pathological env conditions.
+ */
+export function resolveHomeDir(): string {
+  const home = process.env.HOME;
+  const userProfile = process.env.USERPROFILE;
+  if (home === "" && userProfile === "") return "";
+  if (home) return home;
+  if (userProfile) return userProfile;
+  try {
+    const fromOs = homedir();
+    if (fromOs) return fromOs;
+  } catch {
+    // os.homedir() can throw in pathological env conditions
+  }
+  return "";
+}

--- a/src/test/resolve-home-dir.test.mts
+++ b/src/test/resolve-home-dir.test.mts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { after, before, describe, it } from "node:test";
+
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
+
+// Each test sets HOME / USERPROFILE on the live env, asserts, and the
+// outer before/after captures + restores the original values exactly.
+// We don't spawn subprocesses: this is a unit test of a pure function
+// that reads process.env synchronously.
+
+describe("resolveHomeDir", () => {
+  let savedHome: string | undefined;
+  let savedUserProfile: string | undefined;
+  let homeWasSet = false;
+  let userProfileWasSet = false;
+
+  before(() => {
+    homeWasSet = "HOME" in process.env;
+    userProfileWasSet = "USERPROFILE" in process.env;
+    savedHome = process.env.HOME;
+    savedUserProfile = process.env.USERPROFILE;
+  });
+
+  after(() => {
+    if (homeWasSet) {
+      process.env.HOME = savedHome;
+    } else {
+      delete process.env.HOME;
+    }
+    if (userProfileWasSet) {
+      process.env.USERPROFILE = savedUserProfile;
+    } else {
+      delete process.env.USERPROFILE;
+    }
+  });
+
+  it("returns HOME when HOME is set and USERPROFILE is undefined", () => {
+    process.env.HOME = "/foo";
+    delete process.env.USERPROFILE;
+    assert.equal(resolveHomeDir(), "/foo");
+  });
+
+  it("returns USERPROFILE when HOME is undefined and USERPROFILE is set", () => {
+    delete process.env.HOME;
+    process.env.USERPROFILE = "C:\\Users\\X";
+    assert.equal(resolveHomeDir(), "C:\\Users\\X");
+  });
+
+  it("returns empty string when BOTH HOME and USERPROFILE are explicitly empty (opt-out)", () => {
+    process.env.HOME = "";
+    process.env.USERPROFILE = "";
+    assert.equal(resolveHomeDir(), "");
+  });
+
+  it("falls back to USERPROFILE when only HOME is empty (single empty does NOT opt out)", () => {
+    process.env.HOME = "";
+    process.env.USERPROFILE = "/bar";
+    assert.equal(resolveHomeDir(), "/bar");
+  });
+
+  it("falls back to os.homedir() when both HOME and USERPROFILE are undefined", () => {
+    delete process.env.HOME;
+    delete process.env.USERPROFILE;
+    const expected = homedir() || "";
+    assert.equal(resolveHomeDir(), expected);
+  });
+});

--- a/test/resolve-home-dir.test.mjs
+++ b/test/resolve-home-dir.test.mjs
@@ -1,0 +1,60 @@
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { after, before, describe, it } from "node:test";
+import { resolveHomeDir } from "../lib/resolve-home-dir.mjs";
+// Each test sets HOME / USERPROFILE on the live env, asserts, and the
+// outer before/after captures + restores the original values exactly.
+// We don't spawn subprocesses: this is a unit test of a pure function
+// that reads process.env synchronously.
+describe("resolveHomeDir", () => {
+    let savedHome;
+    let savedUserProfile;
+    let homeWasSet = false;
+    let userProfileWasSet = false;
+    before(() => {
+        homeWasSet = "HOME" in process.env;
+        userProfileWasSet = "USERPROFILE" in process.env;
+        savedHome = process.env.HOME;
+        savedUserProfile = process.env.USERPROFILE;
+    });
+    after(() => {
+        if (homeWasSet) {
+            process.env.HOME = savedHome;
+        }
+        else {
+            delete process.env.HOME;
+        }
+        if (userProfileWasSet) {
+            process.env.USERPROFILE = savedUserProfile;
+        }
+        else {
+            delete process.env.USERPROFILE;
+        }
+    });
+    it("returns HOME when HOME is set and USERPROFILE is undefined", () => {
+        process.env.HOME = "/foo";
+        delete process.env.USERPROFILE;
+        assert.equal(resolveHomeDir(), "/foo");
+    });
+    it("returns USERPROFILE when HOME is undefined and USERPROFILE is set", () => {
+        delete process.env.HOME;
+        process.env.USERPROFILE = "C:\\Users\\X";
+        assert.equal(resolveHomeDir(), "C:\\Users\\X");
+    });
+    it("returns empty string when BOTH HOME and USERPROFILE are explicitly empty (opt-out)", () => {
+        process.env.HOME = "";
+        process.env.USERPROFILE = "";
+        assert.equal(resolveHomeDir(), "");
+    });
+    it("falls back to USERPROFILE when only HOME is empty (single empty does NOT opt out)", () => {
+        process.env.HOME = "";
+        process.env.USERPROFILE = "/bar";
+        assert.equal(resolveHomeDir(), "/bar");
+    });
+    it("falls back to os.homedir() when both HOME and USERPROFILE are undefined", () => {
+        delete process.env.HOME;
+        delete process.env.USERPROFILE;
+        const expected = homedir() || "";
+        assert.equal(resolveHomeDir(), expected);
+    });
+});


### PR DESCRIPTION
## Summary

Stacked on top of #41. Single source of truth for `resolveHomeDir` — the AND-semantic empty-HOME opt-out logic that previously lived in three byte-equivalent copies.

- Before: `resolveHomeDir` inlined identically in `hooks/three-section-close.mjs`, `plugins/continuous-improvement/hooks/three-section-close.mjs`, and `src/bin/hook-stats.mts`. Highest future-drift surface in the harden-skills branch.
- After: one file at `src/lib/resolve-home-dir.mts` (compiled to `lib/resolve-home-dir.mjs` and copied into the plugin tree by the build script), three import sites.

Behavior unchanged. Hook mirror still byte-identical.

## Test plan

- [x] `npm test` — 347/347 pass on local (Node 24). Baseline was 342 on harden-skills; the +5 are unit tests for the extracted lib covering all five cases (HOME-only, USERPROFILE-only, both empty opt-out, single empty falls through, both unset → os.homedir()).
- [ ] CI multi-Node matrix (18/20/22) green.
- [x] `verify:generated` clean — `git diff --exit-code -- .claude-plugin bin test lib plugins` exits 0.
- [x] `verify:skill-mirror` clean (13 pairs match).
- [x] Hook mirror byte-equality: `diff hooks/three-section-close.mjs plugins/continuous-improvement/hooks/three-section-close.mjs` is empty.
- [x] Telemetry pollution snapshot: real `~/.claude/hook-telemetry/` file count unchanged across `npm test` run.
- [x] Smoke: `node hooks/three-section-close.mjs <<< '{}'` exits 0 silently (fail-open path); `node bin/hook-stats.mjs --help` exits 0 with usage.

## Files

11 files in the commit:

- `src/lib/resolve-home-dir.mts` (new — single named export)
- `lib/resolve-home-dir.mjs` (new — generated)
- `plugins/continuous-improvement/lib/resolve-home-dir.mjs` (new — generated by build script for plugin install)
- `src/test/resolve-home-dir.test.mts` (new — 5-case unit test)
- `test/resolve-home-dir.test.mjs` (new — generated)
- `src/bin/generate-plugin-manifests.mts` + `bin/generate-plugin-manifests.mjs` (modified — added one copy line to mirror the new lib file into the plugin tree)
- `hooks/three-section-close.mjs` + `plugins/continuous-improvement/hooks/three-section-close.mjs` (modified — replace inline function with import; mirrors stay byte-identical)
- `src/bin/hook-stats.mts` + `bin/hook-stats.mjs` (modified — same import substitution)

## Merge order

Merge after #41. This branch is based on `harden-skills`; once #41 lands, this PR auto-rebases onto `main`.

## Deferred follow-ups

- Plugin-bundle README in `writePluginBundleReadme()` should list `lib/resolve-home-dir.mjs` under "Included surfaces" — cosmetic, defer.
- `projectHashFor(transcriptPath)` in the hook vs `projectHashForCwd(workingDir)` in `hook-stats.mts` share normalize-lowercase-sha256-slice12 logic but with different inputs. Could collapse into a `normalizeProjectPath` helper; current duplication is ~6 lines so not pure win — defer.