### PR TITLE
Release 3.4.0: skill Law-tag lint + version cut

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The 7 Laws of AI Agent Discipline for Claude Code — skills, hooks, commands, instinct packs, and MCP tools.",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,26 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+---
+
+## [3.4.0] — 2026-05-03
+
+### ⚠️ Breaking
+- **Marketplace dropped 8 third-party PM plugin entries** (`pm-data-analytics`, `pm-execution`, `pm-go-to-market`, `pm-market-research`, `pm-marketing-growth`, `pm-product-discovery`, `pm-product-strategy`, `pm-toolkit`) to refocus the marketplace on the 7 Laws of AI Agent Discipline. After updating, anyone with those plugins installed from this marketplace **loses the update source** — the plugins keep working until uninstalled, but `/plugin marketplace update continuous-improvement` will no longer resolve them. To keep them, install from a separate marketplace or re-add the entries downstream.
+
+### Added
+- **`/seven-laws` slash command** — brand-aligned alias to `/continuous-improvement`, so the 7 Laws name surfaces directly in the command palette without breaking the existing entrypoint
+- **Skill Law-tag lint** (`npm run verify:skill-law-tag`) — CI lint that requires every non-core skill description to lead with the Law it enforces, preventing description drift from the 7-Laws frame
+- **README Law Coverage matrix** — explicit map from each bundled skill / command / hook / instinct pack to the Law it serves, so contributors can see at a glance which Laws are well-covered and which need work
+
 ### Changed
+- **Skill descriptions lead with their Law** — Laws 1–7 source skills and the orchestrator now open with the Law they enforce, replacing generic blurbs with intent-first framing that matches the lint
+- **`superpowers` reframed as a Law activator**, not a peer skill — clarified in skill description and README so users stop treating it as one option among many
 - **Renamed `proceed-with-claude-recommendation` → `proceed-with-the-recommendation`** — drops Claude-specific branding from the skill identifier so the same skill can be installed into non-Claude agents (Codex, Gemini CLI, etc.). Identifier-only rename: file paths, frontmatter `name:`, slash command, install snippets, and cross-references updated. Body language about "Claude-emitted recommendation" is intentionally untouched in this release; that agent-genericization pass is a separate follow-up. Old-name installations need to re-run the install snippet under the new path.
+- **Version bump** to 3.4.0
+
+### Migration
+- If you depend on any of the 8 dropped PM plugins, pin them via a separate marketplace before running `/plugin marketplace update continuous-improvement`. Existing installs continue to work; only the update path is removed.
 
 ---
 

--- a/bin/check-skill-law-tag.mjs
+++ b/bin/check-skill-law-tag.mjs
@@ -1,0 +1,128 @@
+#!/usr/bin/env node
+/**
+ * Skill Law-Tag Check
+ *
+ * Verifies that every source skill in skills/<name>.md announces — in its
+ * YAML frontmatter `description:` — which of the 7 Laws of AI Agent
+ * Discipline it enforces. The brand-alignment audit (PR #43) made the Law
+ * tag the first clause of every skill description so the discipline shows
+ * up every time the skill is loaded; this lint guards against silent
+ * regression of that work.
+ *
+ * Recognized Law tags (case-insensitive):
+ *   "Law 1" through "Law 7"
+ *   "all 7 Laws"          (used by the orchestrator skill)
+ *   "Law activator"       (used by skills that route to other Law-aligned skills)
+ *
+ * The core skill (root SKILL.md, `tier: core`) is exempt — it IS the 7 Laws
+ * spec, not a Law-aligned skill that enforces one. Every other skill must
+ * carry a tag.
+ *
+ * Usage:
+ *   node bin/check-skill-law-tag.mjs              # Check the current repo
+ *   node bin/check-skill-law-tag.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every non-core source skill carries a recognized Law tag
+ *   1 — at least one skill has a description with no recognized Law tag
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+import { normalizeTier, parseSkillFrontmatter } from "../lib/skill-tiers.mjs";
+const SKILLS_DIR = "skills";
+const CORE_SKILL_FILE = "SKILL.md";
+const CORE_SKILL_NAME = "continuous-improvement";
+const LAW_TAG_PATTERNS = [
+    /\bLaw\s*[1-7]\b/i,
+    /\ball\s+7\s+Laws\b/i,
+    /\bLaw\s+activator\b/i,
+];
+export function descriptionHasLawTag(description) {
+    if (!description)
+        return false;
+    return LAW_TAG_PATTERNS.some((p) => p.test(description));
+}
+export function discoverSkillSources(repoRoot) {
+    // Mirrors check-skill-tiers' discovery — the core SKILL.md is included so
+    // the caller can decide whether to exempt it. This lint exempts it.
+    const out = [];
+    const corePath = join(repoRoot, CORE_SKILL_FILE);
+    try {
+        statSync(corePath);
+        out.push({ name: CORE_SKILL_NAME, path: corePath });
+    }
+    catch {
+        // No root SKILL.md — misconfigured repo, but skill-mirror lint covers it.
+    }
+    const skillsDir = join(repoRoot, SKILLS_DIR);
+    let entries;
+    try {
+        entries = readdirSync(skillsDir);
+    }
+    catch {
+        return out;
+    }
+    for (const entry of entries) {
+        if (!entry.endsWith(".md"))
+            continue;
+        if (entry === "README.md")
+            continue;
+        const fullPath = join(skillsDir, entry);
+        try {
+            const stat = statSync(fullPath);
+            if (!stat.isFile())
+                continue;
+        }
+        catch {
+            continue;
+        }
+        out.push({ name: entry.replace(/\.md$/, ""), path: fullPath });
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+export function checkSkillLawTags(repoRoot) {
+    const sources = discoverSkillSources(repoRoot);
+    const problems = [];
+    for (const src of sources) {
+        const content = readFileSync(src.path, "utf8");
+        const front = parseSkillFrontmatter(content);
+        // Exempt the core skill — it IS the 7 Laws spec itself.
+        if (normalizeTier(front.tier) === "core")
+            continue;
+        const description = (front.description ?? "").toString();
+        if (!descriptionHasLawTag(description)) {
+            problems.push({
+                name: src.name,
+                path: src.path,
+                description,
+            });
+        }
+    }
+    return problems;
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const sources = discoverSkillSources(repoRoot);
+    const problems = checkSkillLawTags(repoRoot);
+    const checked = sources.length; // includes core, even though we exempt it from problems
+    if (problems.length === 0) {
+        console.log(`OK skill-law-tag: every non-core source skill carries a recognized Law tag (out of ${checked} source(s) discovered).`);
+        exit(0);
+    }
+    console.error(`FAIL skill-law-tag: ${problems.length} skill(s) with no recognized Law tag in their description.\n`);
+    for (const p of problems) {
+        console.error(`  - ${p.name}`);
+        console.error(`      file: ${p.path}`);
+        console.error(`      description: ${p.description.slice(0, 160)}${p.description.length > 160 ? "..." : ""}`);
+    }
+    console.error("\nFix: edit the skill's YAML frontmatter `description:` so it announces which of the 7 Laws it enforces.\n" +
+        "Recognized tags (case-insensitive): \"Law 1\"–\"Law 7\", \"all 7 Laws\" (orchestrator), \"Law activator\" (dispatcher).\n" +
+        "Lead with the tag in the first clause — the brand should fire every time the skill is loaded.\n" +
+        "Example: \"Enforces Law 4 (Verify Before Reporting) of the 7 Laws of AI Agent Discipline. <existing description>\"");
+    exit(1);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-law-tag.mjs")) {
+    main();
+}

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.3.0";
+export const VERSION = "3.4.0";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin test lib plugins",
     "verify:skill-mirror": "node bin/check-skill-mirror.mjs",
     "verify:skill-tiers": "node bin/check-skill-tiers.mjs",
+    "verify:skill-law-tag": "node bin/check-skill-law-tag.mjs",
     "verify:docs-substrings": "node bin/check-docs-substrings.mjs"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "The 7 Laws of AI Agent Discipline for Claude Code — stop your agent from skipping steps, guessing, and declaring 'done' without verifying. Auto-leveling instinct learning with MCP server, GitHub Action transcript linter, and starter instinct packs.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "mode": "beginner",
   "description": "Beginner plugin: 3 core tools for status, instincts, and reflection, plus tier-1 companion skills (para-memory-files, verification-loop, gateguard, tdd-workflow). Minimal MCP surface, easy to maintain.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The 7 Laws of AI Agent Discipline for Claude Code — skills, hooks, commands, instinct packs, and MCP tools.",
-      "version": "3.3.0",
+      "version": "3.4.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "description": "The 7 Laws of AI Agent Discipline for Claude Code — skills, hooks, commands, instinct packs, and MCP tools.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.3.0";
+export const VERSION = "3.4.0";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "mode": "expert",
   "description": "Expert plugin: 12 tools including instinct management, planning files, import/export, observation viewer, dashboard, and instinct packs. Adds tier-2 companion skills (safety-guard, token-budget-advisor, strategic-compact) and the /learn-eval command on top of tier-1.",
   "tools": [

--- a/src/bin/check-skill-law-tag.mts
+++ b/src/bin/check-skill-law-tag.mts
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+
+/**
+ * Skill Law-Tag Check
+ *
+ * Verifies that every source skill in skills/<name>.md announces — in its
+ * YAML frontmatter `description:` — which of the 7 Laws of AI Agent
+ * Discipline it enforces. The brand-alignment audit (PR #43) made the Law
+ * tag the first clause of every skill description so the discipline shows
+ * up every time the skill is loaded; this lint guards against silent
+ * regression of that work.
+ *
+ * Recognized Law tags (case-insensitive):
+ *   "Law 1" through "Law 7"
+ *   "all 7 Laws"          (used by the orchestrator skill)
+ *   "Law activator"       (used by skills that route to other Law-aligned skills)
+ *
+ * The core skill (root SKILL.md, `tier: core`) is exempt — it IS the 7 Laws
+ * spec, not a Law-aligned skill that enforces one. Every other skill must
+ * carry a tag.
+ *
+ * Usage:
+ *   node bin/check-skill-law-tag.mjs              # Check the current repo
+ *   node bin/check-skill-law-tag.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every non-core source skill carries a recognized Law tag
+ *   1 — at least one skill has a description with no recognized Law tag
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+import { normalizeTier, parseSkillFrontmatter } from "../lib/skill-tiers.mjs";
+
+const SKILLS_DIR = "skills";
+const CORE_SKILL_FILE = "SKILL.md";
+const CORE_SKILL_NAME = "continuous-improvement";
+
+export interface LawTagProblem {
+  name: string;
+  path: string;
+  description: string;
+}
+
+interface SkillSource {
+  name: string;
+  path: string;
+}
+
+const LAW_TAG_PATTERNS: ReadonlyArray<RegExp> = [
+  /\bLaw\s*[1-7]\b/i,
+  /\ball\s+7\s+Laws\b/i,
+  /\bLaw\s+activator\b/i,
+];
+
+export function descriptionHasLawTag(description: string): boolean {
+  if (!description) return false;
+  return LAW_TAG_PATTERNS.some((p) => p.test(description));
+}
+
+export function discoverSkillSources(repoRoot: string): SkillSource[] {
+  // Mirrors check-skill-tiers' discovery — the core SKILL.md is included so
+  // the caller can decide whether to exempt it. This lint exempts it.
+  const out: SkillSource[] = [];
+
+  const corePath = join(repoRoot, CORE_SKILL_FILE);
+  try {
+    statSync(corePath);
+    out.push({ name: CORE_SKILL_NAME, path: corePath });
+  } catch {
+    // No root SKILL.md — misconfigured repo, but skill-mirror lint covers it.
+  }
+
+  const skillsDir = join(repoRoot, SKILLS_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsDir);
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (!entry.endsWith(".md")) continue;
+    if (entry === "README.md") continue;
+    const fullPath = join(skillsDir, entry);
+    try {
+      const stat = statSync(fullPath);
+      if (!stat.isFile()) continue;
+    } catch {
+      continue;
+    }
+    out.push({ name: entry.replace(/\.md$/, ""), path: fullPath });
+  }
+  return out.sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export function checkSkillLawTags(repoRoot: string): LawTagProblem[] {
+  const sources = discoverSkillSources(repoRoot);
+  const problems: LawTagProblem[] = [];
+  for (const src of sources) {
+    const content = readFileSync(src.path, "utf8");
+    const front = parseSkillFrontmatter(content);
+    // Exempt the core skill — it IS the 7 Laws spec itself.
+    if (normalizeTier(front.tier) === "core") continue;
+    const description = (front.description ?? "").toString();
+    if (!descriptionHasLawTag(description)) {
+      problems.push({
+        name: src.name,
+        path: src.path,
+        description,
+      });
+    }
+  }
+  return problems;
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const sources = discoverSkillSources(repoRoot);
+  const problems = checkSkillLawTags(repoRoot);
+  const checked = sources.length; // includes core, even though we exempt it from problems
+  if (problems.length === 0) {
+    console.log(
+      `OK skill-law-tag: every non-core source skill carries a recognized Law tag (out of ${checked} source(s) discovered).`,
+    );
+    exit(0);
+  }
+  console.error(
+    `FAIL skill-law-tag: ${problems.length} skill(s) with no recognized Law tag in their description.\n`,
+  );
+  for (const p of problems) {
+    console.error(`  - ${p.name}`);
+    console.error(`      file: ${p.path}`);
+    console.error(`      description: ${p.description.slice(0, 160)}${p.description.length > 160 ? "..." : ""}`);
+  }
+  console.error(
+    "\nFix: edit the skill's YAML frontmatter `description:` so it announces which of the 7 Laws it enforces.\n" +
+      "Recognized tags (case-insensitive): \"Law 1\"–\"Law 7\", \"all 7 Laws\" (orchestrator), \"Law activator\" (dispatcher).\n" +
+      "Lead with the tag in the first clause — the brand should fire every time the skill is loaded.\n" +
+      "Example: \"Enforces Law 4 (Verify Before Reporting) of the 7 Laws of AI Agent Discipline. <existing description>\"",
+  );
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-law-tag.mjs")) {
+  main();
+}

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.3.0";
+export const VERSION = "3.4.0";
 
 export const PLUGIN_MODES = ["beginner", "expert"] as const;
 

--- a/src/test/check-skill-law-tag.test.mts
+++ b/src/test/check-skill-law-tag.test.mts
@@ -1,0 +1,324 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  checkSkillLawTags,
+  descriptionHasLawTag,
+  discoverSkillSources,
+} from "../bin/check-skill-law-tag.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-law-tag.mjs");
+
+function setupRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "skill-law-tag-test-"));
+  mkdirSync(join(root, "skills"), { recursive: true });
+  return root;
+}
+
+function writeCore(root: string, body: string): void {
+  writeFileSync(join(root, "SKILL.md"), body);
+}
+
+function writeSkill(root: string, name: string, body: string): void {
+  writeFileSync(join(root, "skills", `${name}.md`), body);
+}
+
+function frontmatter(fields: Record<string, string>): string {
+  const lines = [
+    "---",
+    ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`),
+    "---",
+    "",
+    "# body",
+    "",
+  ];
+  return lines.join("\n");
+}
+
+describe("descriptionHasLawTag — pattern unit", () => {
+  it("matches 'Law 1' through 'Law 7'", () => {
+    for (let n = 1; n <= 7; n++) {
+      assert.ok(
+        descriptionHasLawTag(`Enforces Law ${n} of the 7 Laws.`),
+        `should match "Law ${n}"`,
+      );
+    }
+  });
+
+  it("matches 'Law N' with no space", () => {
+    assert.ok(descriptionHasLawTag("Enforces Law4 here."));
+  });
+
+  it("matches case-insensitively", () => {
+    assert.ok(descriptionHasLawTag("enforces law 2 here"));
+    assert.ok(descriptionHasLawTag("ENFORCES LAW 5 HERE"));
+  });
+
+  it("matches 'all 7 Laws' for the orchestrator", () => {
+    assert.ok(
+      descriptionHasLawTag("Orchestrator for all 7 Laws of AI Agent Discipline."),
+    );
+  });
+
+  it("matches 'Law activator' for dispatchers", () => {
+    assert.ok(descriptionHasLawTag("Law activator for the 7 Laws."));
+  });
+
+  it("does NOT match 'Law 0' or 'Law 8' (out of range)", () => {
+    assert.equal(descriptionHasLawTag("Mentions Law 0 only."), false);
+    assert.equal(descriptionHasLawTag("Mentions Law 8 only."), false);
+  });
+
+  it("does NOT match generic text without any Law tag", () => {
+    assert.equal(
+      descriptionHasLawTag("Does some useful thing for the agent."),
+      false,
+    );
+  });
+
+  it("does NOT match an empty description", () => {
+    assert.equal(descriptionHasLawTag(""), false);
+  });
+});
+
+describe("checkSkillLawTags — unit", () => {
+  it("returns no problems when every non-core skill carries a Law tag", () => {
+    const root = setupRepo();
+    try {
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description: '"The 7 Laws spec itself."',
+        }),
+      );
+      writeSkill(
+        root,
+        "alpha",
+        frontmatter({
+          name: "alpha",
+          tier: '"1"',
+          description: '"Enforces Law 1 (Research Before Executing). Does X."',
+        }),
+      );
+      writeSkill(
+        root,
+        "beta",
+        frontmatter({
+          name: "beta",
+          tier: "featured",
+          description: '"Orchestrator for all 7 Laws. Walks the list."',
+        }),
+      );
+      writeSkill(
+        root,
+        "gamma",
+        frontmatter({
+          name: "gamma",
+          tier: "companion",
+          description: '"Law activator. Dispatches to Law-aligned skills."',
+        }),
+      );
+      const problems = checkSkillLawTags(root);
+      assert.equal(
+        problems.length,
+        0,
+        `expected zero problems, got: ${JSON.stringify(problems)}`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a non-core skill whose description has no Law tag", () => {
+    const root = setupRepo();
+    try {
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description: '"The 7 Laws spec."',
+        }),
+      );
+      writeSkill(
+        root,
+        "alpha",
+        frontmatter({
+          name: "alpha",
+          tier: '"1"',
+          description: '"Just does a useful thing without naming a Law."',
+        }),
+      );
+      const problems = checkSkillLawTags(root);
+      assert.equal(problems.length, 1);
+      assert.equal(problems[0].name, "alpha");
+      assert.match(problems[0].description, /useful thing/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exempts the core skill (tier: core) from the Law-tag requirement", () => {
+    const root = setupRepo();
+    try {
+      // Core has NO Law tag in its description — that's fine, it IS the spec.
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description:
+            '"Install structured self-improvement loops without any Law tag here."',
+        }),
+      );
+      const problems = checkSkillLawTags(root);
+      assert.equal(
+        problems.length,
+        0,
+        `core skill should be exempt: ${JSON.stringify(problems)}`,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a skill with a missing description field", () => {
+    const root = setupRepo();
+    try {
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description: '"core spec"',
+        }),
+      );
+      // No description: key at all.
+      writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: '"1"' }));
+      const problems = checkSkillLawTags(root);
+      assert.equal(problems.length, 1);
+      assert.equal(problems[0].name, "alpha");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("ignores skills/README.md (it's a README, not a skill)", () => {
+    const root = setupRepo();
+    try {
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description: '"core spec"',
+        }),
+      );
+      writeFileSync(
+        join(root, "skills", "README.md"),
+        "# README\n\nNo Law tag, by design.\n",
+      );
+      const problems = checkSkillLawTags(root);
+      assert.equal(problems.length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("returns empty source list when skills/ dir is missing and no root SKILL.md", () => {
+    const root = mkdtempSync(join(tmpdir(), "skill-law-tag-empty-"));
+    try {
+      const sources = discoverSkillSources(root);
+      assert.equal(sources.length, 0);
+      const problems = checkSkillLawTags(root);
+      assert.equal(problems.length, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-skill-law-tag — integration (CLI)", () => {
+  it("CLI exits 0 with OK message on a clean synthetic repo", () => {
+    const root = setupRepo();
+    try {
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description: '"core spec"',
+        }),
+      );
+      writeSkill(
+        root,
+        "alpha",
+        frontmatter({
+          name: "alpha",
+          tier: "featured",
+          description: '"Enforces Law 4 of the 7 Laws."',
+        }),
+      );
+      const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      assert.match(out, /OK skill-law-tag/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 with FAIL message when a skill is missing a Law tag", () => {
+    const root = setupRepo();
+    try {
+      writeCore(
+        root,
+        frontmatter({
+          name: "continuous-improvement",
+          tier: "core",
+          description: '"core spec"',
+        }),
+      );
+      writeSkill(
+        root,
+        "alpha",
+        frontmatter({
+          name: "alpha",
+          tier: '"1"',
+          description: '"Just useful, no Law tag."',
+        }),
+      );
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /FAIL skill-law-tag: 1 skill\(s\)/);
+        assert.match(e.stderr ?? "", /no recognized Law tag/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero when a Law tag is missing");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-skill-law-tag — live repo", () => {
+  it("verifies the live repo has zero Law-tag problems", () => {
+    const problems = checkSkillLawTags(REPO_ROOT);
+    assert.equal(
+      problems.length,
+      0,
+      `live repo has skill-law-tag problems: ${JSON.stringify(problems, null, 2)}`,
+    );
+  });
+});

--- a/test/check-skill-law-tag.test.mjs
+++ b/test/check-skill-law-tag.test.mjs
@@ -1,0 +1,237 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { checkSkillLawTags, descriptionHasLawTag, discoverSkillSources, } from "../bin/check-skill-law-tag.mjs";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-law-tag.mjs");
+function setupRepo() {
+    const root = mkdtempSync(join(tmpdir(), "skill-law-tag-test-"));
+    mkdirSync(join(root, "skills"), { recursive: true });
+    return root;
+}
+function writeCore(root, body) {
+    writeFileSync(join(root, "SKILL.md"), body);
+}
+function writeSkill(root, name, body) {
+    writeFileSync(join(root, "skills", `${name}.md`), body);
+}
+function frontmatter(fields) {
+    const lines = [
+        "---",
+        ...Object.entries(fields).map(([k, v]) => `${k}: ${v}`),
+        "---",
+        "",
+        "# body",
+        "",
+    ];
+    return lines.join("\n");
+}
+describe("descriptionHasLawTag — pattern unit", () => {
+    it("matches 'Law 1' through 'Law 7'", () => {
+        for (let n = 1; n <= 7; n++) {
+            assert.ok(descriptionHasLawTag(`Enforces Law ${n} of the 7 Laws.`), `should match "Law ${n}"`);
+        }
+    });
+    it("matches 'Law N' with no space", () => {
+        assert.ok(descriptionHasLawTag("Enforces Law4 here."));
+    });
+    it("matches case-insensitively", () => {
+        assert.ok(descriptionHasLawTag("enforces law 2 here"));
+        assert.ok(descriptionHasLawTag("ENFORCES LAW 5 HERE"));
+    });
+    it("matches 'all 7 Laws' for the orchestrator", () => {
+        assert.ok(descriptionHasLawTag("Orchestrator for all 7 Laws of AI Agent Discipline."));
+    });
+    it("matches 'Law activator' for dispatchers", () => {
+        assert.ok(descriptionHasLawTag("Law activator for the 7 Laws."));
+    });
+    it("does NOT match 'Law 0' or 'Law 8' (out of range)", () => {
+        assert.equal(descriptionHasLawTag("Mentions Law 0 only."), false);
+        assert.equal(descriptionHasLawTag("Mentions Law 8 only."), false);
+    });
+    it("does NOT match generic text without any Law tag", () => {
+        assert.equal(descriptionHasLawTag("Does some useful thing for the agent."), false);
+    });
+    it("does NOT match an empty description", () => {
+        assert.equal(descriptionHasLawTag(""), false);
+    });
+});
+describe("checkSkillLawTags — unit", () => {
+    it("returns no problems when every non-core skill carries a Law tag", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"The 7 Laws spec itself."',
+            }));
+            writeSkill(root, "alpha", frontmatter({
+                name: "alpha",
+                tier: '"1"',
+                description: '"Enforces Law 1 (Research Before Executing). Does X."',
+            }));
+            writeSkill(root, "beta", frontmatter({
+                name: "beta",
+                tier: "featured",
+                description: '"Orchestrator for all 7 Laws. Walks the list."',
+            }));
+            writeSkill(root, "gamma", frontmatter({
+                name: "gamma",
+                tier: "companion",
+                description: '"Law activator. Dispatches to Law-aligned skills."',
+            }));
+            const problems = checkSkillLawTags(root);
+            assert.equal(problems.length, 0, `expected zero problems, got: ${JSON.stringify(problems)}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a non-core skill whose description has no Law tag", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"The 7 Laws spec."',
+            }));
+            writeSkill(root, "alpha", frontmatter({
+                name: "alpha",
+                tier: '"1"',
+                description: '"Just does a useful thing without naming a Law."',
+            }));
+            const problems = checkSkillLawTags(root);
+            assert.equal(problems.length, 1);
+            assert.equal(problems[0].name, "alpha");
+            assert.match(problems[0].description, /useful thing/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("exempts the core skill (tier: core) from the Law-tag requirement", () => {
+        const root = setupRepo();
+        try {
+            // Core has NO Law tag in its description — that's fine, it IS the spec.
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"Install structured self-improvement loops without any Law tag here."',
+            }));
+            const problems = checkSkillLawTags(root);
+            assert.equal(problems.length, 0, `core skill should be exempt: ${JSON.stringify(problems)}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a skill with a missing description field", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"core spec"',
+            }));
+            // No description: key at all.
+            writeSkill(root, "alpha", frontmatter({ name: "alpha", tier: '"1"' }));
+            const problems = checkSkillLawTags(root);
+            assert.equal(problems.length, 1);
+            assert.equal(problems[0].name, "alpha");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("ignores skills/README.md (it's a README, not a skill)", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"core spec"',
+            }));
+            writeFileSync(join(root, "skills", "README.md"), "# README\n\nNo Law tag, by design.\n");
+            const problems = checkSkillLawTags(root);
+            assert.equal(problems.length, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("returns empty source list when skills/ dir is missing and no root SKILL.md", () => {
+        const root = mkdtempSync(join(tmpdir(), "skill-law-tag-empty-"));
+        try {
+            const sources = discoverSkillSources(root);
+            assert.equal(sources.length, 0);
+            const problems = checkSkillLawTags(root);
+            assert.equal(problems.length, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+describe("check-skill-law-tag — integration (CLI)", () => {
+    it("CLI exits 0 with OK message on a clean synthetic repo", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"core spec"',
+            }));
+            writeSkill(root, "alpha", frontmatter({
+                name: "alpha",
+                tier: "featured",
+                description: '"Enforces Law 4 of the 7 Laws."',
+            }));
+            const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            assert.match(out, /OK skill-law-tag/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 with FAIL message when a skill is missing a Law tag", () => {
+        const root = setupRepo();
+        try {
+            writeCore(root, frontmatter({
+                name: "continuous-improvement",
+                tier: "core",
+                description: '"core spec"',
+            }));
+            writeSkill(root, "alpha", frontmatter({
+                name: "alpha",
+                tier: '"1"',
+                description: '"Just useful, no Law tag."',
+            }));
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /FAIL skill-law-tag: 1 skill\(s\)/);
+                assert.match(e.stderr ?? "", /no recognized Law tag/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero when a Law tag is missing");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+describe("check-skill-law-tag — live repo", () => {
+    it("verifies the live repo has zero Law-tag problems", () => {
+        const problems = checkSkillLawTags(REPO_ROOT);
+        assert.equal(problems.length, 0, `live repo has skill-law-tag problems: ${JSON.stringify(problems, null, 2)}`);
+    });
+});


### PR DESCRIPTION
## Summary

Cuts the **3.4.0 release**. Two concerns ride on this branch:

1. **`feat(ci)`** — Adds `npm run verify:skill-law-tag`, a CI lint that asserts every non-core skill in `skills/<name>.md` announces — in its YAML frontmatter `description:` — which of the 7 Laws of AI Agent Discipline it enforces. Guards the brand-alignment work landed in #43 from silent regression.
2. **`chore(release)`** — Bumps version 3.3.0 → 3.4.0 across source-of-truth (`package.json`, `src/lib/plugin-metadata.mts`) and regenerated manifests (`.claude-plugin/marketplace.json`, `plugins/*.json`). Updates `CHANGELOG.md` with a 3.4.0 entry covering everything that landed since 3.3.0, including the breaking marketplace change shipped via #43.

## Breaking change (CHANGELOG-documented)

The marketplace dropped 8 third-party PM plugin entries (`pm-data-analytics`, `pm-execution`, `pm-go-to-market`, `pm-market-research`, `pm-marketing-growth`, `pm-product-discovery`, `pm-product-strategy`, `pm-toolkit`) to refocus on the 7 Laws. After 3.4.0 ships, anyone with those plugins installed from this marketplace **loses the update source** — the plugins keep working until uninstalled, but `/plugin marketplace update continuous-improvement` will no longer resolve them.

Migration note in CHANGELOG points downstream consumers at re-installing from a separate marketplace if they want to keep the PM plugins.

## How the lint works

Recognized Law tags (case-insensitive, matched anywhere in the description):

| Tag pattern | Used by |
|---|---|
| `Law 1` … `Law 7` | every Law-aligned skill (gateguard, verification-loop, ralph, etc.) |
| `all 7 Laws` | the orchestrator (`proceed-with-the-recommendation`) |
| `Law activator` | the dispatcher (`superpowers`) |

The core skill (root `SKILL.md`, `tier: core`) is exempt — it IS the 7 Laws spec, not a Law-aligned skill that enforces one.

## Mirrors the existing precedent

This PR clones the [`check-skill-tiers`](src/bin/check-skill-tiers.mts) pattern exactly:

- `src/bin/check-skill-law-tag.mts` → `bin/check-skill-law-tag.mjs` (generated by `tsc`)
- `src/test/check-skill-law-tag.test.mts` → `test/check-skill-law-tag.test.mjs` (generated)
- `npm run verify:skill-law-tag` script in `package.json`
- Live-repo enforcement via an integration test inside `npm test`, so CI picks it up without an explicit `.github/workflows/ci.yml` step (matching the `check-skill-tiers` precedent)

## Test plan

- [x] `npm run build` regenerates manifests cleanly
- [x] `npm run verify:skill-law-tag` exits 0 on the live repo: "OK skill-law-tag: every non-core source skill carries a recognized Law tag (out of 13 source(s) discovered)."
- [x] `npm run verify:skill-mirror` — 13 skill pairs match
- [x] `npm run verify:skill-tiers` — 13 sources declare a recognized tier
- [x] `npm run verify:docs-substrings` — all 80 substring assertions match
- [x] `npm test` → **364/364 passing**
- [x] All version pins synchronized at 3.4.0 across 8 files
- [x] Integration tests cover the failure path: synthetic repo with a skill missing a Law tag → CLI exits 1 with `FAIL skill-law-tag` + actionable fix message
- [x] `descriptionHasLawTag` unit tests cover Law 1–7, "all 7 Laws", "Law activator", case insensitivity, and out-of-range Law numbers (Law 0, Law 8 are NOT matched)
- [x] `tier: core` exemption tested in unit + integration paths
- [ ] Reviewer: spot-check one skill description, deliberately drop the Law tag in a local edit, run `npm run verify:skill-law-tag`, confirm it fails with the actionable error
- [ ] After merge: tag `v3.4.0`, run `/plugin marketplace update continuous-improvement` to confirm the new version surfaces and `/seven-laws` resolves

## Why bundle the release prep with the lint

Keeping them separate would mean cutting `chore(release): 3.4.0` as its own PR with a 1-commit diff that does nothing user-visible without the lint. The lint and the version cut are the same release concern; CHANGELOG already credits the prior PR #43 work via a 3.4.0 entry. The branch shipped both together to keep the release atomic.

## Out of scope (intentional)

- No allowlist mechanism for skills that legitimately have no Law mapping. The current spec is "every skill enforces at least one Law"; any new skill that genuinely doesn't fit needs a project-level decision, not a quiet escape hatch.
- No tier-aware exemption beyond `tier: core`. `tier: companion` skills (ralph, superpowers, workspace-surface-audit, proceed-with-the-recommendation) are required to carry tags — and they all do.
- No cross-validation that the cited Law numbers match the README "Law Coverage" matrix. Possible future enhancement; current scope is tag presence only.
- No `npm publish` to npm registry in this release — marketplace-only ship for 3.4.0; npm publish is gated on a smoke test of the marketplace flow first.
