### PR TITLE
chore(release): cut 3.5.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The 7 Laws of AI Agent Discipline for Claude Code — skills, hooks, commands, instinct packs, and MCP tools.",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ All notable changes to this skill are documented here.
 
 ---
 
+## [3.5.0] — 2026-05-04
+
+### Added
+- **Audience-tier system in `wild-risa-balance`** — beginner emits 3–5 goal-driven items with no WILD/RISA labels; expert keeps the ≥7 floor (2 WILD + ≥5 RISA). `proceed-with-the-recommendation` Phase 1 validates against the tier contract instead of a flat floor, and the Phase 7 close renders the tier suffix in the heading (`## Recommendation (expert|beginner)`) so the audit trail records which tier produced the list.
+- **`Recommendation: no` escape valve in both tiers** of `wild-risa-balance` and `proceed-with-the-recommendation`. When no real recommendation can be produced without padding, the close ships a literal `no` body under the tier-suffixed heading — an explicit operator handoff signal (switch session, switch specialist agent, switch framing, sleep on it), never a silent skip. Padding to hit the floor is the failure mode this prevents.
+- **`CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` operator opt-out** for `hooks/three-section-close.mjs`. When set, the hook short-circuits before any enforcement or telemetry. Per-operator escape hatch for cases where end-of-turn reflection should run as internal thinking instead of visible output. Public default unchanged — the rule still fires for everyone else. Test infrastructure (`buildIsolatedEnv()` + 5 manual env constructions) now strips the env var before spawning the hook so existing enforcement tests cannot silently disable themselves when the developer has the flag set.
+
+### Tests
+- **Locked the `no` escape valve literals** in `verify:docs-substrings` (102 → 112 assertions) and in the `wild-risa-tiers` test (22 → 32 assertions, 5 literals × 2 mirrors). Each lock carries a rationale string naming the behavior it defends so a future maintainer reading a failure understands why the literal is locked.
+
+---
+
 ## [3.4.1] — 2026-05-03
 
 ### Added

--- a/docs/plans/2026-04-28-rebrand-from-ecc.md
+++ b/docs/plans/2026-04-28-rebrand-from-ecc.md
@@ -2,7 +2,7 @@
 
 **Date:** 2026-04-28
 **Owner:** Naim Katiman
-**Status:** in progress
+**Status:** complete (verified 2026-05-04)
 
 ## Why
 
@@ -73,3 +73,32 @@ After the final commit, the entire repo (excluding `node_modules` and this plan 
 - Git commit message history. Old commits with `ECC` in subject lines stay untouched. Rewriting public history is high-blast-radius for negligible benefit.
 - Any reference inside `node_modules/`. Vendor code.
 - This plan doc itself (which intentionally documents the old term to explain the rebrand).
+
+---
+
+## Conclusion (2026-05-04)
+
+**Status: complete.** The mechanical rebrand from `ECC` / `Everything Claude Code` to `continuous-improvement` landed across all 25 in-scope files via the C1–C5 commit split. Verification grep across `*.md`, `*.json`, `*.mjs`, `*.ts`, `*.mts`, `*.yml` (excluding `node_modules/` and this plan doc) returns **zero hits** as of 2026-05-04. The brand is now consistent across the public face, all 13 source skills, both plugin mirrors, marketplace manifests, and the Codex AGENTS bridge.
+
+### Canonical brand stack (frozen)
+
+The repo ships under a deliberate three-layer brand. Use the layer that fits the audience; do not collapse them.
+
+| Layer | Name | When to use it |
+|---|---|---|
+| **Brand (public face)** | The 7 Laws of AI Agent Discipline | Tweets, talks, README hero, marketplace listing, GitHub repo description |
+| **Engine (mechanism)** | Mulahazah | The auto-leveling instinct system inside it (`observe.sh`, instinct packs, confidence scoring) |
+| **Package (technical)** | `continuous-improvement` | `npm install`, `/plugin install`, `package.json` `name`, plugin.json `name`, repo slug, settings.json key |
+
+The brand stack is documented in `README.md` ("The Brand Stack" section) and enforced indirectly by `verify:skill-law-tag` (every skill description leads with `Enforces Law N`, which keeps the 7 Laws front-and-center on every load).
+
+### Rules in effect going forward
+
+- New skills, hooks, commands, docs MUST use the package name `continuous-improvement` and the brand name "The 7 Laws of AI Agent Discipline" — never "ECC" or "Everything Claude Code", which remain the property of `affaan-m/everything-claude-code`.
+- The verification grep at the top of this plan doc remains the definition of "clean" — if a future change reintroduces an `ECC` reference, the lint surface (or a hand-run grep) catches it.
+- The GitHub repo description leads with the brand name, not the engine name and not the package name. Updated 2026-05-04 in lockstep with this conclusion.
+
+### Closes
+
+- 2026-04-28 plan started.
+- 2026-05-04 plan closed. No follow-up work scheduled. If a future external integration (e.g. a fork or downstream plugin) reintroduces `ECC` strings into this repo, open a new plan doc rather than reopening this one.

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.4.1";
+export const VERSION = "3.5.0";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "The 7 Laws of AI Agent Discipline for Claude Code (engine: Mulahazah). Stop your agent from skipping steps, guessing, and declaring 'done' without verifying. Beginner: 13-skill plugin bundle. Expert: MCP server (12 tools), session hooks, instinct packs, GitHub Action transcript linter.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "mode": "beginner",
   "description": "Beginner plugin: 3 core tools for status, instincts, and reflection, plus tier-1 companion skills (para-memory-files, verification-loop, gateguard, tdd-workflow). Minimal MCP surface, easy to maintain.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The 7 Laws of AI Agent Discipline for Claude Code — skills, hooks, commands, instinct packs, and MCP tools.",
-      "version": "3.4.1",
+      "version": "3.5.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "The 7 Laws of AI Agent Discipline for Claude Code — skills, hooks, commands, instinct packs, and MCP tools.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.4.1";
+export const VERSION = "3.5.0";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "mode": "expert",
   "description": "Expert plugin: 12 tools including instinct management, planning files, import/export, observation viewer, dashboard, and instinct packs. Adds tier-2 companion skills (safety-guard, token-budget-advisor, strategic-compact) and the /learn-eval command on top of tier-1.",
   "tools": [

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.4.1";
+export const VERSION = "3.5.0";
 
 export const PLUGIN_MODES = ["beginner", "expert"] as const;
 


### PR DESCRIPTION
## Summary

Cuts **continuous-improvement 3.5.0**. Bumps version across 4 source-of-truth files + regenerated manifests, promotes the [Unreleased] CHANGELOG block, and ships the four post-3.4.1 commits to the marketplace.

Semver minor (two `feat:` commits since 3.4.1).

## Shipped in 3.5.0

### Added
- **Audience-tier system** in `wild-risa-balance` (beginner: 3-5 goal-driven items, no WILD/RISA labels; expert: >=7 items, 2 WILD + >=5 RISA). `proceed-with-the-recommendation` Phase 1 validates against the tier contract; Phase 7 close renders tier suffix in heading (`## Recommendation (expert|beginner)`) for audit-trail clarity.
- **`Recommendation: no` escape valve** in both tiers. Explicit operator handoff signal (switch session, switch specialist, switch framing, sleep on it) when no real recommendation can be produced without padding. Never a silent skip.
- **`CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` operator opt-out** for `hooks/three-section-close.mjs`. Per-operator escape hatch; public default unchanged. Test infra (`buildIsolatedEnv()` + 5 manual env constructions) strips the var before spawning the hook so enforcement tests cannot silently disable themselves.

### Tests
- Locked the `no` escape valve literals in `verify:docs-substrings` (102 -> 112) and `wild-risa-tiers` test (22 -> 32, 5 literals × 2 mirrors).

## Verification

- [x] `npm run build` regenerated all manifests
- [x] `npm run verify:all` — 5 lints + typecheck pass
- [x] `npm test` — 399/399 pass, 0 fail
- [x] Version bumped in 4 source-of-truth files + 6 generated manifests (10 total)
- [x] CHANGELOG `[Unreleased]` promoted to `[3.5.0] - 2026-05-04`

## Test plan post-merge

- [ ] Run `/plugin marketplace update continuous-improvement` and confirm 3.5.0 resolves
- [ ] Reinstall plugin globally; confirm beginner + expert manifests show `version: 3.5.0`
- [ ] Smoke-test the `Recommendation: no` escape valve under `wild-risa-balance` (both tiers)
- [ ] Set `CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` and confirm Stop hook short-circuits