### PR TITLE
chore(release): cut 3.5.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,16 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+---
+
+## [3.5.1] — 2026-05-05
+
 ### Changed
 - **README install ergonomics** — added explicit decision rule ("If you don't know which to pick, use Beginner"), called out the doubled `name@marketplace` install syntax as intentional, surfaced the Windows Git Bash / WSL precondition, replaced the "re-run install" failure note with "restart session first", added a 3-row Troubleshooting install table, demoted the Law Coverage matrix to CONTRIBUTING.md (operator opt-outs retained in README), wrapped the 13-skill table in `<details>`, and moved the Brand Stack below install.
-- **Plugin descriptions are now benefit-led** at the source (`SHARED_PLUGIN_DESCRIPTION` + `MODE_METADATA` in `src/lib/plugin-metadata.mts`). `package.json`, `action.yml`, plugin manifests, and marketplace entries now describe what the agent stops doing (skipping research / planning / verification) and what users get per mode, instead of listing artifacts.
+- **Plugin descriptions are now benefit-led** at the source (`SHARED_PLUGIN_DESCRIPTION` + `MODE_METADATA` in `src/lib/plugin-metadata.mts`). `package.json`, `action.yml`, plugin manifests, marketplace entries, and `llms.txt` now describe what the agent stops doing (skipping research / planning / verification) and what users get per mode, instead of listing artifacts.
+
+### Added
+- **Two new docs-substring locks** in `bin/check-docs-substrings.mjs` (114 total, was 112): the README install decision rule (`"If you don't know which to pick, use Beginner."`) and the CONTRIBUTING.md `## Law Coverage Matrix` heading anchor referenced from README. Renaming either silently is now a lint failure.
 
 ### Removed
 - **"Curated PM plugins moved" notice** removed from README. Earlier versions of this marketplace bundled 8 product-management plugins by [Paweł Huryn](https://www.productcompass.pm); those have not appeared in the listing since the 7 Laws refocus and the README notice was stale housekeeping. Source plugin directories under `plugins/pm-*` remain on disk pending follow-up removal.

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.5.0";
+export const VERSION = "3.5.1";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts. Beginner: one /plugin install command. Expert: adds MCP tools, session hooks, and a GitHub Action transcript linter.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.",
-      "version": "3.5.0",
+      "version": "3.5.1",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.5.0";
+export const VERSION = "3.5.1";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
   "tools": [

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.5.0";
+export const VERSION = "3.5.1";
 
 export const PLUGIN_MODES = ["beginner", "expert"] as const;
 


### PR DESCRIPTION
## Summary

Cut 3.5.1. Bumps version on the source-of-truth (`src/lib/plugin-metadata.mts` + `package.json`) and cascades through the 5 generated plugin manifests via `npm run build`.

CHANGELOG entry covers what shipped to main on 2026-05-05 but was not yet reflected in the package version:
- **README install ergonomics** — explicit decision rule, Windows precondition surfaced, Troubleshooting table, Law Coverage matrix demoted to CONTRIBUTING.md, 13-skill table collapsed, PM-notice removed.
- **Benefit-led plugin descriptions** across npm, plugin manifests, GitHub Action, marketplace entries, and `llms.txt` — single source-of-truth in `SHARED_PLUGIN_DESCRIPTION` + `MODE_METADATA`.
- **Two new docs-substring locks** (114 total): the README install decision rule and the CONTRIBUTING.md `## Law Coverage Matrix` anchor. Renaming either silently is now a lint failure.

This is the first commit on this repo to ship via feature-branch + PR (per the new operator policy, recorded in memory `feedback_pr_flow_for_main.md`). Prior 2026-05-05 commits (`9d3c9bf`, `7fc9515`) were direct-to-main with branch-protection bypass.

## Test plan

- [x] `npm run verify:all` — 6/6 lints + typecheck green
- [x] `npm test` — 405/405 passing
- [x] All 5 generated mirrors carry `"version": "3.5.1"`
- [ ] Reviewer: confirm the `4 of 4 required status checks` pass on the PR
- [ ] Reviewer: merge via `Squash and merge` (one-concern release commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)