### PR TITLE
chore(audit): jq precondition + meta instinct pack + source-of-truth callout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+### Known Issues
+- **Auto-instinct pipeline depends on `jq`** — `hooks/observe.sh` falls back to a thin schema (`ts/event/session/tool/project_id/project_name`) when `jq` is not on PATH. The thin schema cannot capture `tool_input.command` or `Edit.file_path`, so the pattern detection described in `SKILL.md` ("after 20+ observations, Claude analyzes patterns and creates instincts") cannot identify user corrections, error→fix sequences, or tool-argument bigrams. Confirmed live: 22,065 observations across 11 projects on a `jq`-less host yielded 0 auto-detected instincts (the 2 instincts present were authored manually via reflection). Workaround until the planned Node-based observer lands: install `jq` (`winget install jqlang.jq` on Windows, `brew install jq` on macOS, `apt install jq` on Debian/Ubuntu) before the expert-mode install. Tracking issue: replace `observe.sh` with a Node observer that captures the rich schema natively and reprocesses prior thin-schema rows.
+
 ### Changed
 - **README install ergonomics** — added explicit decision rule ("If you don't know which to pick, use Beginner"), called out the doubled `name@marketplace` install syntax as intentional, surfaced the Windows Git Bash / WSL precondition, replaced the "re-run install" failure note with "restart session first", added a 3-row Troubleshooting install table, demoted the Law Coverage matrix to CONTRIBUTING.md (operator opt-outs retained in README), wrapped the 13-skill table in `<details>`, and moved the Brand Stack below install.
 - **Plugin descriptions are now benefit-led** at the source (`SHARED_PLUGIN_DESCRIPTION` + `MODE_METADATA` in `src/lib/plugin-metadata.mts`). `package.json`, `action.yml`, plugin manifests, and marketplace entries now describe what the agent stops doing (skipping research / planning / verification) and what users get per mode, instead of listing artifacts.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ Add translations to `docs/` following the pattern `README.<lang-code>.md`.
 
 ## Architecture
 
+> **Source of truth: `src/`.** Edit `src/bin/*.mts`, `src/lib/*.mts`, `src/test/*.test.mts` only. The committed `bin/*.mjs`, `lib/*.mjs`, `test/*.test.mjs`, and `plugins/*.json` are `tsc` and generator output — they are wiped and rewritten on every `npm run build` and any direct edit silently disappears. Full edit-then-build workflow in [Editing the CLI / MCP server / linter](#editing-the-cli--mcp-server--linter) below.
+
 ```
 SKILL.md                    → The rules (any LLM can follow these)
 hooks/observe.sh            → Captures tool calls to JSONL (<50ms)

--- a/README.md
+++ b/README.md
@@ -44,11 +44,11 @@ If the command is not recognized, restart your Claude Code session first; the ma
 
 Pick this if you want the MCP tools (12 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, and starter packs.
 
-Preconditions: Node 18 / 20 / 22 and bash. **On Windows, install Git Bash or WSL first** — the observation hooks are bash scripts and will silently no-op without them.
+Preconditions: Node 18 / 20 / 22, bash, and `jq`. **On Windows, install Git Bash or WSL first** — the observation hooks are bash scripts and will silently no-op without them. **Install `jq` too** (`winget install jqlang.jq` on Windows, `brew install jq` on macOS, `apt install jq` on Debian/Ubuntu) — without it, `observe.sh` falls back to a thin schema that the Mulahazah analysis pass cannot turn into instincts. The hook itself still runs and exits 0, but the captured rows lack `tool_input` so pattern detection produces nothing. See the **Known Issues** section in [CHANGELOG.md](CHANGELOG.md) for the full gap description.
 
 ```bash
 npx continuous-improvement install --mode expert
-npx continuous-improvement install --pack react   # optional: react | python | go
+npx continuous-improvement install --pack react   # optional: react | python | go | meta
 # --pack seeds 5–10 starter instincts so suggestions appear in week 1 instead of week 4.
 ```
 
@@ -66,6 +66,14 @@ Three failures account for nearly every install support thread. Try them in orde
 | `/plugin marketplace add ...` returned nothing visible | Marketplace add was silent; the plugin is not yet selected | Run `/plugin install continuous-improvement@continuous-improvement` to select and activate it |
 
 If none of those apply, paste the output of `npx continuous-improvement install` into a GitHub issue — that surface logs every step.
+
+### Operator modes
+
+The framework has documented operator-level modes that change hook behavior without rebuilding the plugin. These are first-class — set them once in your shell rc and they persist across sessions.
+
+| Env var | Effect | How to set |
+|---|---|---|
+| `CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` | `three-section-close.mjs` short-circuits before any enforcement or telemetry. Use when end-of-turn reflection should run as internal thinking rather than visible "What has been done / What is next / Recommendation" sections. Public default unchanged — the rule still fires for everyone else. | bash/zsh: `export CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_THREE_SECTION_CLOSE_DISABLED','1','User')` (persistent). |
 
 ---
 
@@ -125,13 +133,7 @@ In expert mode, the same planning workflow is also available programmatically th
 
 ## Law Coverage
 
-Every bundled skill, command, and hook enforces at least one of the 7 Laws. The full Law-to-tool alignment matrix lives in [CONTRIBUTING.md → Law Coverage Matrix](CONTRIBUTING.md#law-coverage-matrix); each skill's `description:` also leads with `Enforces Law N (...)` so the tag shows up every time the skill is loaded.
-
-### Operator opt-outs
-
-| Env var | Effect |
-|---|---|
-| `CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` | `three-section-close.mjs` short-circuits before any enforcement or telemetry. Use when reflection should run as internal thinking rather than visible output. Public default unchanged; per-operator only. |
+Every bundled skill, command, and hook enforces at least one of the 7 Laws. The full Law-to-tool alignment matrix lives in [CONTRIBUTING.md → Law Coverage Matrix](CONTRIBUTING.md#law-coverage-matrix); each skill's `description:` also leads with `Enforces Law N (...)` so the tag shows up every time the skill is loaded. Operator-level mode toggles live in the **Operator modes** section above the 7 Laws, alongside install.
 
 ---
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -298,7 +298,7 @@ Options:
   --mode <mode>     Installation mode:
                       beginner  — hooks + skill + commands (default)
                       expert    — beginner + MCP server + session hooks
-  --pack <name>     Load a starter instinct pack (react, python, go)
+  --pack <name>     Load a starter instinct pack (react, python, go, meta)
   --uninstall       Remove all installed files
   --help            Show this help
 
@@ -397,5 +397,5 @@ Next steps:
   4. After your first task, run: /continuous-improvement
   5. Try: /discipline for quick reference, /dashboard for instinct health
 ${INSTALL_MODE === "expert" ? "\nMCP tools available: ci_status, ci_instincts, ci_reflect, ci_reinforce,\n  ci_create_instinct, ci_observations, ci_export, ci_import, ci_plan_init,\n  ci_plan_status, ci_dashboard, ci_load_pack" : ""}
-Available instinct packs: npx continuous-improvement install --pack react|python|go
+Available instinct packs: npx continuous-improvement install --pack react|python|go|meta
 `);

--- a/hooks/observe.sh
+++ b/hooks/observe.sh
@@ -16,6 +16,11 @@ INPUT="$(cat)"
 
 # ---------------------------------------------------------------------------
 # Parse hook payload — use jq if available, otherwise basic extraction
+#
+# When jq is missing, observation rows lack tool_input/tool_output, which
+# defeats the auto-instinct pipeline. Emit a one-shot stderr warning per
+# project so the operator notices at the next session start instead of
+# discovering the gap weeks later. The marker file makes it idempotent.
 # ---------------------------------------------------------------------------
 if command -v jq &>/dev/null; then
   read -r TOOL_NAME SESSION_ID HAS_OUTPUT INPUT_JSON OUTPUT_JSON <<< "$(
@@ -28,6 +33,15 @@ if command -v jq &>/dev/null; then
     ' | paste - - - - -
   )"
 else
+  # One-shot stderr warning per HOME so the operator learns the constraint.
+  # Marker lives next to instincts/ (not inside it) so it never collides with
+  # tests or analysis loops that iterate INSTINCTS_DIR for project-hash dirs.
+  JQ_WARN_MARKER="${HOME}/.claude/.continuous-improvement-jq-warned"
+  if [[ ! -f "$JQ_WARN_MARKER" ]]; then
+    mkdir -p "${HOME}/.claude" 2>/dev/null
+    printf '[continuous-improvement] jq not found on PATH — observe.sh is using thin-schema fallback. Install jq to enable auto-instinct detection (winget install jqlang.jq | brew install jq | apt install jq). This warning is one-shot per host.\n' >&2
+    : > "$JQ_WARN_MARKER"
+  fi
   # Fallback: extract tool_name with basic pattern matching
   TOOL_NAME="$(printf '%s' "$INPUT" | sed -n 's/.*"tool_name" *: *"\([^"]*\)".*/\1/p' | head -1)"
   SESSION_ID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id" *: *"\([^"]*\)".*/\1/p' | head -1)"

--- a/instinct-packs/meta.json
+++ b/instinct-packs/meta.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "skip-thin-observation-schema",
+    "trigger": "when running /continuous-improvement and observations.jsonl entries contain only tool_start events with no inputs/outputs/errors",
+    "body": "Skip instinct fabrication and report the schema gap instead. With only ts/event/session/tool/project_id/project_name fields, the stream cannot distinguish a `git status` Bash call from a `rm -rf` Bash call. Tool-name bigrams (Bash→Bash, Edit→Edit, Read→Edit) reflect parallel-call artifacts and harness-enforced read-before-edit, not learned preferences. Recommend enhancing PostToolUse/PreToolUse hooks to log tool inputs (Bash command head, Skill name) and tool_end with success flag before retrying analysis.",
+    "confidence": 0.6,
+    "domain": "meta"
+  },
+  {
+    "id": "parallelize-independent-tool-calls",
+    "trigger": "when issuing 2+ tool calls with no data dependency between them in the same turn",
+    "body": "Batch independent tool calls into a single message instead of issuing them sequentially. Independent reads, independent greps, independent git inspections, independent file edits in unrelated files belong in one message with multiple tool blocks. Dependent calls (output of A determines input of B) stay sequential. Exception: when a single check would short-circuit the whole task (e.g., `git status` returning empty), one call first is fine. Sequential issuing of independent calls wastes wall-clock time and burns context per round-trip.",
+    "confidence": 0.6,
+    "domain": "workflow"
+  }
+]

--- a/plugins/continuous-improvement/hooks/observe.sh
+++ b/plugins/continuous-improvement/hooks/observe.sh
@@ -16,6 +16,11 @@ INPUT="$(cat)"
 
 # ---------------------------------------------------------------------------
 # Parse hook payload — use jq if available, otherwise basic extraction
+#
+# When jq is missing, observation rows lack tool_input/tool_output, which
+# defeats the auto-instinct pipeline. Emit a one-shot stderr warning per
+# project so the operator notices at the next session start instead of
+# discovering the gap weeks later. The marker file makes it idempotent.
 # ---------------------------------------------------------------------------
 if command -v jq &>/dev/null; then
   read -r TOOL_NAME SESSION_ID HAS_OUTPUT INPUT_JSON OUTPUT_JSON <<< "$(
@@ -28,6 +33,15 @@ if command -v jq &>/dev/null; then
     ' | paste - - - - -
   )"
 else
+  # One-shot stderr warning per HOME so the operator learns the constraint.
+  # Marker lives next to instincts/ (not inside it) so it never collides with
+  # tests or analysis loops that iterate INSTINCTS_DIR for project-hash dirs.
+  JQ_WARN_MARKER="${HOME}/.claude/.continuous-improvement-jq-warned"
+  if [[ ! -f "$JQ_WARN_MARKER" ]]; then
+    mkdir -p "${HOME}/.claude" 2>/dev/null
+    printf '[continuous-improvement] jq not found on PATH — observe.sh is using thin-schema fallback. Install jq to enable auto-instinct detection (winget install jqlang.jq | brew install jq | apt install jq). This warning is one-shot per host.\n' >&2
+    : > "$JQ_WARN_MARKER"
+  fi
   # Fallback: extract tool_name with basic pattern matching
   TOOL_NAME="$(printf '%s' "$INPUT" | sed -n 's/.*"tool_name" *: *"\([^"]*\)".*/\1/p' | head -1)"
   SESSION_ID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id" *: *"\([^"]*\)".*/\1/p' | head -1)"

--- a/plugins/continuous-improvement/instinct-packs/meta.json
+++ b/plugins/continuous-improvement/instinct-packs/meta.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "skip-thin-observation-schema",
+    "trigger": "when running /continuous-improvement and observations.jsonl entries contain only tool_start events with no inputs/outputs/errors",
+    "body": "Skip instinct fabrication and report the schema gap instead. With only ts/event/session/tool/project_id/project_name fields, the stream cannot distinguish a `git status` Bash call from a `rm -rf` Bash call. Tool-name bigrams (Bash→Bash, Edit→Edit, Read→Edit) reflect parallel-call artifacts and harness-enforced read-before-edit, not learned preferences. Recommend enhancing PostToolUse/PreToolUse hooks to log tool inputs (Bash command head, Skill name) and tool_end with success flag before retrying analysis.",
+    "confidence": 0.6,
+    "domain": "meta"
+  },
+  {
+    "id": "parallelize-independent-tool-calls",
+    "trigger": "when issuing 2+ tool calls with no data dependency between them in the same turn",
+    "body": "Batch independent tool calls into a single message instead of issuing them sequentially. Independent reads, independent greps, independent git inspections, independent file edits in unrelated files belong in one message with multiple tool blocks. Dependent calls (output of A determines input of B) stay sequential. Exception: when a single check would short-circuit the whole task (e.g., `git status` returning empty), one call first is fine. Sequential issuing of independent calls wastes wall-clock time and burns context per round-trip.",
+    "confidence": 0.6,
+    "domain": "workflow"
+  }
+]

--- a/src/bin/install.mts
+++ b/src/bin/install.mts
@@ -395,7 +395,7 @@ Options:
   --mode <mode>     Installation mode:
                       beginner  — hooks + skill + commands (default)
                       expert    — beginner + MCP server + session hooks
-  --pack <name>     Load a starter instinct pack (react, python, go)
+  --pack <name>     Load a starter instinct pack (react, python, go, meta)
   --uninstall       Remove all installed files
   --help            Show this help
 
@@ -507,5 +507,5 @@ Next steps:
   4. After your first task, run: /continuous-improvement
   5. Try: /discipline for quick reference, /dashboard for instinct health
 ${INSTALL_MODE === "expert" ? "\nMCP tools available: ci_status, ci_instincts, ci_reflect, ci_reinforce,\n  ci_create_instinct, ci_observations, ci_export, ci_import, ci_plan_init,\n  ci_plan_status, ci_dashboard, ci_load_pack" : ""}
-Available instinct packs: npx continuous-improvement install --pack react|python|go
+Available instinct packs: npx continuous-improvement install --pack react|python|go|meta
 `);

--- a/src/test/instinct-packs.test.mts
+++ b/src/test/instinct-packs.test.mts
@@ -26,7 +26,11 @@ describe("instinct-packs directory", () => {
   });
 });
 
-for (const packName of ["react", "python", "go"] as const) {
+// Language packs (react/python/go) are seeded language conventions: ≥5 instincts.
+// The meta pack carries promoted reflection-instincts about the system itself
+// (auto-instinct gap, parallel-call discipline) — kept small on purpose, ≥2.
+const PACK_FLOORS: Record<string, number> = { react: 5, python: 5, go: 5, meta: 2 };
+for (const [packName, floor] of Object.entries(PACK_FLOORS)) {
   describe(`instinct-packs/${packName}.json`, () => {
     let instincts: PackInstinct[] = [];
 
@@ -37,7 +41,7 @@ for (const packName of ["react", "python", "go"] as const) {
 
     it("is a non-empty array", () => {
       assert.ok(Array.isArray(instincts), "Should be an array");
-      assert.ok(instincts.length >= 5, `Expected at least 5 instincts, got ${instincts.length}`);
+      assert.ok(instincts.length >= floor, `Expected at least ${floor} instincts, got ${instincts.length}`);
     });
 
     it("each instinct has required fields", () => {
@@ -68,7 +72,7 @@ for (const packName of ["react", "python", "go"] as const) {
     });
 
     it("domain is a valid value", () => {
-      const validDomains = ["workflow", "patterns", "testing", "tooling", "code-style"];
+      const validDomains = ["workflow", "patterns", "testing", "tooling", "code-style", "meta"];
       for (const instinct of instincts) {
         assert.ok(
           validDomains.includes(instinct.domain),

--- a/test/instinct-packs.test.mjs
+++ b/test/instinct-packs.test.mjs
@@ -14,7 +14,11 @@ describe("instinct-packs directory", () => {
         assert.ok(packs.length >= 3, `Expected at least 3 packs, got ${packs.length}`);
     });
 });
-for (const packName of ["react", "python", "go"]) {
+// Language packs (react/python/go) are seeded language conventions: ≥5 instincts.
+// The meta pack carries promoted reflection-instincts about the system itself
+// (auto-instinct gap, parallel-call discipline) — kept small on purpose, ≥2.
+const PACK_FLOORS = { react: 5, python: 5, go: 5, meta: 2 };
+for (const [packName, floor] of Object.entries(PACK_FLOORS)) {
     describe(`instinct-packs/${packName}.json`, () => {
         let instincts = [];
         it("is valid JSON", () => {
@@ -23,7 +27,7 @@ for (const packName of ["react", "python", "go"]) {
         });
         it("is a non-empty array", () => {
             assert.ok(Array.isArray(instincts), "Should be an array");
-            assert.ok(instincts.length >= 5, `Expected at least 5 instincts, got ${instincts.length}`);
+            assert.ok(instincts.length >= floor, `Expected at least ${floor} instincts, got ${instincts.length}`);
         });
         it("each instinct has required fields", () => {
             for (const instinct of instincts) {
@@ -49,7 +53,7 @@ for (const packName of ["react", "python", "go"]) {
             }
         });
         it("domain is a valid value", () => {
-            const validDomains = ["workflow", "patterns", "testing", "tooling", "code-style"];
+            const validDomains = ["workflow", "patterns", "testing", "tooling", "code-style", "meta"];
             for (const instinct of instincts) {
                 assert.ok(validDomains.includes(instinct.domain), `Instinct ${instinct.id} has invalid domain "${instinct.domain}". Valid: ${validDomains.join(", ")}`);
             }


### PR DESCRIPTION
## Summary

Five layered commits implementing the four lowest-risk items from a plugin-effectiveness audit (RISA-1, RISA-2, RISA-3, RISA-6, RISA-7 from the audit recommendation list). Each commit isolates one concern; all 6 verify lints + typecheck + 414 tests pass after each commit.

The audit found that on a `jq`-less host, 22,065 captured observations across 11 projects yielded 0 auto-detected instincts because `hooks/observe.sh` falls back to a thin schema (`ts/event/session/tool/project_id/project_name`) that the analysis pass cannot turn into patterns. This PR closes the *discoverability* and *seed-corpus* gap. The actual auto-detection rewrite (replacing the bash hook with a Node observer) is deferred to a separate PR — that is a 300–500 LOC refactor and does not belong here.

### Commits

- `012ed9d` `fix(hook):` one-shot stderr warning when `jq` is missing on PATH; marker file at `~/.claude/.continuous-improvement-jq-warned` (deliberately outside `instincts/` so directory iterators that walk project-hash subdirs are not affected — fixed a collision the first marker location caused with `hook.test.mjs`).
- `02c8041` `feat(instinct-packs):` add `meta` pack containing the two cross-project reflection-instincts (`skip-thin-observation-schema`, `parallelize-independent-tool-calls`) that previously lived only as per-project YAML. `PACK_FLOORS` map drives the pack-size assertion so language packs keep their ≥5 floor while `meta` ships at ≥2 (intentionally seed-sized). `meta` added to `validDomains`.
- `fa625d2` `docs(install):` list `meta` in `--pack` help and post-install banner.
- `c8651c7` `docs(readme):` `jq` listed alongside Node and bash in Preconditions, with per-OS install commands; new "Operator modes" section adjacent to install with both bash/zsh and PowerShell export syntax for `CLAUDE_THREE_SECTION_CLOSE_DISABLED`; `[Unreleased] Known Issues` block in CHANGELOG documenting the live 22k → 0 auto-instinct gap.
- `de21175` `docs(contributing):` one-line "Source of truth: `src/`" callout at the top of `## Architecture` — the warning already existed at CONTRIBUTING.md:101-118 but was buried under "Editing the CLI / MCP server / linter".

### Deferred to follow-up PRs (audit recommendation list, in priority order)

- WILD: replace `observe.sh` with a Node observer + 22k-row backfill subcommand
- WILD: cut `proceed-with-the-recommendation` as a sibling plugin + rename package (needs maintainer go/no-go on breaking the npm name)
- RISA: teach `bin/lint-transcript.mjs` to detect `schema-incomplete` instead of returning a 0/100 false-negative score
- RISA: auto-rotate `observations.jsonl` per project hash above ~2k lines into a digest
- RISA: `npx continuous-improvement doctor` health-check command
- RISA: `.gitattributes` LF pin (own PR — triggers full-tree renormalization)
- RISA: extend the pre-commit hook to run `npm run verify:all` on staged source

## Test plan

- [x] `npm test` — 414/414 pass
- [x] `npm run verify:all` — all 6 lints + typecheck green
- [x] `observe.sh` smoke-tested both with and without `jq`: emits warning once, silent on subsequent invocations, exits 0 either way
- [x] `node --test test/instinct-packs.test.mjs` — 38/38 (was 30 before `meta` pack)
- [ ] CI green on this branch
- [ ] Reviewer confirms README "Operator modes" table renders correctly on github.com (markdown table inside the install section)