### PR TITLE
feat(skills): proactive roadmap surfacing + verification Phase 7

### DIFF
--- a/plugins/continuous-improvement/skills/verification-loop/SKILL.md
+++ b/plugins/continuous-improvement/skills/verification-loop/SKILL.md
@@ -86,6 +86,24 @@ Review each changed file for:
 - Missing error handling
 - Potential edge cases
 
+### Phase 7: Result + Completeness Gate
+
+Phases 1–6 verify mechanism — build green, types clean, tests pass, no secrets, diff intentional. Phase 7 verifies outcome: did the work the operator actually asked for actually land? Mechanism passing while outcome is missing is the most expensive failure mode in this loop, because the green report invites a merge that doesn't deliver.
+
+Two questions, both required to be `Yes`:
+
+**1. Did the stated goal land? Yes/No + evidence.**
+
+The stated goal is the goal as named at task start, not the goal as remembered now. If the operator asked "fix the bug where X happens", evidence is the bug no longer happening (failing test now passes, repro screenshot, manual verification). If they asked "add an admin button", evidence is the button visible and functional in the running UI. Build-green is not evidence of result — it is evidence of mechanism. Don't conflate.
+
+**2. Did every promised step finish? Yes/No + list.**
+
+Enumerate every step you said you would do — the recommendation list, the plan doc, the TodoWrite items, the commit-by-commit roadmap. Mark each Done or Skipped. If any are Skipped, name them and the reason. A "complete" verification with silently skipped promises is a trust violation, not a deliverable.
+
+Both gates are independent: `Yes` on goal alone means a half-complete checklist that may break later; `Yes` on completeness alone means busywork that didn't deliver. Both must be `Yes` — even if the previous six phases all pass — or the work isn't done.
+
+If either is `No`, the verification report goes back to the operator with the explicit gap, not on to PR. The operator decides whether the gap is acceptable to ship as-is or whether more work is required first. Never silently downgrade to "ready" because the mechanism phases looked good.
+
 ## Output Format
 
 After running all phases, produce a verification report:
@@ -94,12 +112,14 @@ After running all phases, produce a verification report:
 VERIFICATION REPORT
 ==================
 
-Build:     [PASS/FAIL]
-Types:     [PASS/FAIL] (X errors)
-Lint:      [PASS/FAIL] (X warnings)
-Tests:     [PASS/FAIL] (X/Y passed, Z% coverage)
-Security:  [PASS/FAIL] (X issues)
-Diff:      [X files changed]
+Build:        [PASS/FAIL]
+Types:        [PASS/FAIL] (X errors)
+Lint:         [PASS/FAIL] (X warnings)
+Tests:        [PASS/FAIL] (X/Y passed, Z% coverage)
+Security:     [PASS/FAIL] (X issues)
+Diff:         [X files changed]
+Goal landed:  [YES/NO] — <one-line evidence or gap>
+All promised: [YES/NO] — <X of Y steps Done; list any Skipped>
 
 Overall:   [READY/NOT READY] for PR
 
@@ -107,6 +127,8 @@ Issues to Fix:
 1. ...
 2. ...
 ```
+
+`Overall: READY` requires every line above to pass, including both Phase 7 gates. Mechanism-green plus outcome-`No` is `NOT READY` — surface the gap, do not ship.
 
 ## Continuous Mode
 

--- a/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
+++ b/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
@@ -186,6 +186,6 @@ Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side
 ## Related
 
 - `continuous-improvement` — the 7 Laws card (core skill)
-- `proceed-with-the-recommendation` — execution arm
+- `proceed-with-the-recommendation` — execution arm; carries surfaced items across the surface → execute boundary defined in the Proactive Roadmap Surfacing section above
 - `superpowers:brainstorming` — upstream WILD generator
 - `verification-loop` — downstream RISA verifier

--- a/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
+++ b/plugins/continuous-improvement/skills/wild-risa-balance/SKILL.md
@@ -178,10 +178,10 @@ RISA baseline — ship regardless (5 of ≥5)
 2. Rename the ambiguous flag to match its actual behavior.
 3. Backfill the type on the public export that currently widens to `any`.
 4. Wire the existing Stop hook into the new skill's checklist gate.
-5. Update the README mirror so the bundled plugin matches the source skill.
+5. Update the README mirror so the bundled plugin matches the source skill. (surfaced — verify:skill-mirror gate flagged drift in last CI run)
 ```
 
-Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side if the surface warrants it.
+Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side if the surface warrants it. The fifth RISA item is marked `(surfaced — <source>)` to demonstrate the convention from the Proactive Roadmap Surfacing section: items lifted from a roadmap or memory carry an inline source attribution so the operator can tell roadmap-driven items apart from current-request items.
 
 ## Related
 

--- a/skills/verification-loop.md
+++ b/skills/verification-loop.md
@@ -86,6 +86,24 @@ Review each changed file for:
 - Missing error handling
 - Potential edge cases
 
+### Phase 7: Result + Completeness Gate
+
+Phases 1–6 verify mechanism — build green, types clean, tests pass, no secrets, diff intentional. Phase 7 verifies outcome: did the work the operator actually asked for actually land? Mechanism passing while outcome is missing is the most expensive failure mode in this loop, because the green report invites a merge that doesn't deliver.
+
+Two questions, both required to be `Yes`:
+
+**1. Did the stated goal land? Yes/No + evidence.**
+
+The stated goal is the goal as named at task start, not the goal as remembered now. If the operator asked "fix the bug where X happens", evidence is the bug no longer happening (failing test now passes, repro screenshot, manual verification). If they asked "add an admin button", evidence is the button visible and functional in the running UI. Build-green is not evidence of result — it is evidence of mechanism. Don't conflate.
+
+**2. Did every promised step finish? Yes/No + list.**
+
+Enumerate every step you said you would do — the recommendation list, the plan doc, the TodoWrite items, the commit-by-commit roadmap. Mark each Done or Skipped. If any are Skipped, name them and the reason. A "complete" verification with silently skipped promises is a trust violation, not a deliverable.
+
+Both gates are independent: `Yes` on goal alone means a half-complete checklist that may break later; `Yes` on completeness alone means busywork that didn't deliver. Both must be `Yes` — even if the previous six phases all pass — or the work isn't done.
+
+If either is `No`, the verification report goes back to the operator with the explicit gap, not on to PR. The operator decides whether the gap is acceptable to ship as-is or whether more work is required first. Never silently downgrade to "ready" because the mechanism phases looked good.
+
 ## Output Format
 
 After running all phases, produce a verification report:
@@ -94,12 +112,14 @@ After running all phases, produce a verification report:
 VERIFICATION REPORT
 ==================
 
-Build:     [PASS/FAIL]
-Types:     [PASS/FAIL] (X errors)
-Lint:      [PASS/FAIL] (X warnings)
-Tests:     [PASS/FAIL] (X/Y passed, Z% coverage)
-Security:  [PASS/FAIL] (X issues)
-Diff:      [X files changed]
+Build:        [PASS/FAIL]
+Types:        [PASS/FAIL] (X errors)
+Lint:         [PASS/FAIL] (X warnings)
+Tests:        [PASS/FAIL] (X/Y passed, Z% coverage)
+Security:     [PASS/FAIL] (X issues)
+Diff:         [X files changed]
+Goal landed:  [YES/NO] — <one-line evidence or gap>
+All promised: [YES/NO] — <X of Y steps Done; list any Skipped>
 
 Overall:   [READY/NOT READY] for PR
 
@@ -107,6 +127,8 @@ Issues to Fix:
 1. ...
 2. ...
 ```
+
+`Overall: READY` requires every line above to pass, including both Phase 7 gates. Mechanism-green plus outcome-`No` is `NOT READY` — surface the gap, do not ship.
 
 ## Continuous Mode
 

--- a/skills/wild-risa-balance.md
+++ b/skills/wild-risa-balance.md
@@ -186,6 +186,6 @@ Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side
 ## Related
 
 - `continuous-improvement` — the 7 Laws card (core skill)
-- `proceed-with-the-recommendation` — execution arm
+- `proceed-with-the-recommendation` — execution arm; carries surfaced items across the surface → execute boundary defined in the Proactive Roadmap Surfacing section above
 - `superpowers:brainstorming` — upstream WILD generator
 - `verification-loop` — downstream RISA verifier

--- a/skills/wild-risa-balance.md
+++ b/skills/wild-risa-balance.md
@@ -178,10 +178,10 @@ RISA baseline — ship regardless (5 of ≥5)
 2. Rename the ambiguous flag to match its actual behavior.
 3. Backfill the type on the public export that currently widens to `any`.
 4. Wire the existing Stop hook into the new skill's checklist gate.
-5. Update the README mirror so the bundled plugin matches the source skill.
+5. Update the README mirror so the bundled plugin matches the source skill. (surfaced — verify:skill-mirror gate flagged drift in last CI run)
 ```
 
-Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side if the surface warrants it.
+Total: 7 items (2 WILD + 5 RISA). That is the floor — emit more on either side if the surface warrants it. The fifth RISA item is marked `(surfaced — <source>)` to demonstrate the convention from the Proactive Roadmap Surfacing section: items lifted from a roadmap or memory carry an inline source attribution so the operator can tell roadmap-driven items apart from current-request items.
 
 ## Related
 


### PR DESCRIPTION
## Summary

- Adds **Proactive Roadmap Surfacing** section to `wild-risa-balance` defining a hard "surface, do not execute" boundary for known-but-undone roadmap items, with trigger conditions, format, and anti-patterns.
- Dogfoods the `(surfaced — <source>)` marker in the skill's own Example block.
- Cross-references `proceed-with-the-recommendation` from the Related footer so the surface → execute boundary is discoverable without re-reading the body.
- Adds **Phase 7 Result + Completeness Gate** to `verification-loop`: two questions (did the stated goal land; did every promised step finish), both required `Yes`. Mechanism-green plus outcome-`No` is `NOT READY`.
- Updates the verification report Output Format to include `Goal landed:` and `All promised:` lines.

## Why

Two gaps surfaced from a 7-Habits → 7-Laws mapping discussion:

- **Habit 1 (proactive).** Agents either sit silent on known next steps or run them unprompted. Surfacing bridges those two failure modes without violating the global "stop and ask" rule. The boundary is non-negotiable: surface emits a recommendation item; execution still requires explicit "proceed"/"go".
- **Habit 4 (win-win).** Reframed from token economy to **result + task completeness** as the optimization target. Tokens stay a ceiling via `token-budget-advisor`, never the success metric. Mechanism passing while outcome is missing is the most expensive failure mode in the verification loop, because the green report invites a merge that doesn't deliver.

## Test plan

- [x] `node bin/check-skill-mirror.mjs` — passes (13 skill pairs match)
- [x] `node bin/check-skill-tiers.mjs` — passes (13 source skills, recognized tiers)
- [x] `node bin/check-skill-law-tag.mjs` — passes (Law tags present)
- [x] `node bin/check-docs-substrings.mjs` — passes (114 substring assertions)
- [x] `node bin/check-everything-mirror.mjs` — passes (24 mirrored files)
- [ ] Operator review of the surface → execute boundary wording in `wild-risa-balance.md`
- [ ] Operator review of Phase 7 gate semantics in `verification-loop.md`
- [ ] CI green on `verify:all` and any typecheck/test workflows

## Out of scope (explicitly deferred)

- **WILD #1** from the recommendation: "Phase 0 reflex inside `proceed-with-the-recommendation`" — own design conversation, not bundled here.
- **WILD #2:** "Bundle verification-loop gate into wild-risa-balance" — collapsing two skills, structurally risky immediately after authoring the proactive section. Kept separate intentionally.
- **8 pre-existing manifest drift files** on `origin/main` (`marketplace.json`, `plugins/{beginner,expert}.json`, `plugins/continuous-improvement/{README.md,hooks/hooks.json,skills/README.md,.claude-plugin/marketplace.json,.claude-plugin/plugin.json}`) are unrelated to this PR — they regenerate dirty from `node bin/generate-plugin-manifests.mjs` on a clean main checkout. Left for a separate housekeeping PR or the parallel `feat/node-observer-rich-schema` branch, where the same drift is already visible.

## Commits

1. `feat(wild-risa-balance): surface roadmap gaps as recommendations, never as fait accompli` — adds the new section.
2. `docs(wild-risa-balance): demonstrate (surfaced) marker in Example block` — dogfoods the marker.
3. `docs(wild-risa-balance): cross-reference surface→execute boundary from Related footer` — discoverability.
4. `feat(verification-loop): add Phase 7 Result + Completeness gate` — Habit 4 result+completeness check.