### PR TITLE
ci(workflows): skill drift check between obra snapshot and CI dispatcher

### DIFF
--- a/.github/workflows/skills-drift.yml
+++ b/.github/workflows/skills-drift.yml
@@ -1,0 +1,78 @@
+name: Skills Drift Check
+
+on:
+  pull_request:
+    paths:
+      - 'third-party/superpowers/**'
+      - 'plugins/continuous-improvement/skills/superpowers/SKILL.md'
+
+jobs:
+  skills-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: List upstream snapshot skill directories
+        run: |
+          set -euo pipefail
+          UPSTREAM_DIR="third-party/superpowers/skills"
+          if [ ! -d "$UPSTREAM_DIR" ]; then
+            echo "ERROR: $UPSTREAM_DIR does not exist"
+            exit 1
+          fi
+          find "$UPSTREAM_DIR" -mindepth 1 -maxdepth 1 -type d -printf '%f\n' \
+            | sort -u > /tmp/upstream.txt
+          echo "Upstream skills:"
+          cat /tmp/upstream.txt
+          echo "Total: $(wc -l < /tmp/upstream.txt)"
+
+      - name: Extract dispatcher skill references
+        run: |
+          set -euo pipefail
+          DISPATCHER="plugins/continuous-improvement/skills/superpowers/SKILL.md"
+          if [ ! -f "$DISPATCHER" ]; then
+            echo "ERROR: $DISPATCHER does not exist"
+            exit 1
+          fi
+          # Canonical declaration: every workflow skill is referenced as **name**
+          # in either the workflow table (section "The Basic Workflow") or the
+          # bullet list (section "Skill Library"). Restrict to lowercase + hyphen
+          # tokens of length >= 2 so unrelated bold words (e.g. "**Critical**")
+          # never leak in.
+          grep -oE '\*\*[a-z][a-z-]+\*\*' "$DISPATCHER" \
+            | sed 's/\*\*//g' \
+            | sort -u > /tmp/dispatcher.txt
+          echo "Dispatcher skills:"
+          cat /tmp/dispatcher.txt
+          echo "Total: $(wc -l < /tmp/dispatcher.txt)"
+
+      - name: Diff dispatcher vs upstream
+        run: |
+          set -euo pipefail
+          MISSING_UPSTREAM=$(comm -23 /tmp/dispatcher.txt /tmp/upstream.txt)
+          ORPHAN_UPSTREAM=$(comm -13 /tmp/dispatcher.txt /tmp/upstream.txt)
+
+          if [ -n "$MISSING_UPSTREAM" ] || [ -n "$ORPHAN_UPSTREAM" ]; then
+            echo "✗ Skill drift detected between dispatcher and upstream snapshot"
+            echo ""
+            echo "Dispatcher: plugins/continuous-improvement/skills/superpowers/SKILL.md"
+            echo "Upstream:   third-party/superpowers/skills/"
+            echo ""
+            if [ -n "$MISSING_UPSTREAM" ]; then
+              echo "Referenced in dispatcher, missing from upstream snapshot:"
+              echo "$MISSING_UPSTREAM" | sed 's/^/  - /'
+              echo ""
+            fi
+            if [ -n "$ORPHAN_UPSTREAM" ]; then
+              echo "Present in upstream snapshot, not referenced by dispatcher:"
+              echo "$ORPHAN_UPSTREAM" | sed 's/^/  - /'
+              echo ""
+            fi
+            echo "Resolve by syncing the dispatcher SKILL.md table/list with the snapshot,"
+            echo "or by refreshing the snapshot under third-party/superpowers/skills/."
+            exit 1
+          fi
+
+          DISPATCHER_COUNT=$(wc -l < /tmp/dispatcher.txt)
+          UPSTREAM_COUNT=$(wc -l < /tmp/upstream.txt)
+          echo "✓ ${DISPATCHER_COUNT} dispatcher skills, ${UPSTREAM_COUNT} upstream skills, exact match"


### PR DESCRIPTION
## Summary

Adds `.github/workflows/skills-drift.yml`, a PR-only workflow that fails if the workflow skill names referenced in the CI fork's superpowers dispatcher (`plugins/continuous-improvement/skills/superpowers/SKILL.md`) drift from the directory names under the vendored Obra snapshot (`third-party/superpowers/skills/`).

The drift radar: when Obra renames or removes a skill on a refresh, the dispatcher silently goes stale. This workflow catches that on every PR that touches either side.

**Depends on #56.** Once #56 merges, retarget this PR to `main`.

## Design

- Trigger: `pull_request` with `paths` filter on `third-party/superpowers/**` and the dispatcher SKILL.md.
- Single shell-only job on `ubuntu-latest`. No external GitHub Actions beyond `actions/checkout@v4`.
- Three steps: list upstream skill dirs → extract dispatcher skill names → diff with `comm`.

### Extraction strategy

Used the `**name**` bold-marker pattern with a lowercase-only filter (`\*\*[a-z][a-z-]+\*\*`). Both the workflow table at the top of `SKILL.md` and the bullet list under `## Skill Library` use this exact form for every skill, and `sort -u` deduplicates the union. The lowercase filter excludes unrelated emphasized phrases like `**Spec compliance**` or `**Code quality**` that already live in the file. Cross-checking both sources (table + bullets) is automatic this way; if either omits a name, it still appears via the other, but if a name is misspelled in either place, the diff fires.

## Local dry-run

### Success case (clean snapshot, exact match)

```
Upstream skills:
brainstorming
dispatching-parallel-agents
executing-plans
finishing-a-development-branch
receiving-code-review
requesting-code-review
subagent-driven-development
systematic-debugging
test-driven-development
using-git-worktrees
using-superpowers
verification-before-completion
writing-plans
writing-skills
Total: 14

Dispatcher skills:
brainstorming
dispatching-parallel-agents
executing-plans
finishing-a-development-branch
receiving-code-review
requesting-code-review
subagent-driven-development
systematic-debugging
test-driven-development
using-git-worktrees
using-superpowers
verification-before-completion
writing-plans
writing-skills
Total: 14

✓ 14 dispatcher skills, 14 upstream skills, exact match
```

### Forced-failure case (`brainstorming` → `brainstroming` in dispatcher, then reverted)

```
✗ Skill drift detected between dispatcher and upstream snapshot

Dispatcher: plugins/continuous-improvement/skills/superpowers/SKILL.md
Upstream:   third-party/superpowers/skills/

Referenced in dispatcher, missing from upstream snapshot:
  - brainstroming

Present in upstream snapshot, not referenced by dispatcher:
  - brainstorming

Resolve by syncing the dispatcher SKILL.md table/list with the snapshot,
or by refreshing the snapshot under third-party/superpowers/skills/.
EXIT_CODE=1
```

The dispatcher SKILL.md was restored from a backup after the forced-failure run. `git status` and `git diff plugins/continuous-improvement/skills/superpowers/SKILL.md` confirm zero modifications to the dispatcher in this PR.

## Test plan

- [ ] CI green on this PR (paths filter triggers because `.github/workflows/skills-drift.yml` is added but not in the trigger paths — confirm whether Actions schedules it on this PR; if not, it will run on the next PR that touches the watched paths).
- [ ] After #56 merges, retarget this PR base to `main` and confirm CI still green.
- [ ] After merge, mutate dispatcher SKILL.md in a test PR (rename one skill) → confirm Skills Drift Check fails with a clean delta listing.
- [ ] After confirming, revert the test PR and confirm Skills Drift Check goes green again.

## Out of scope

- Does NOT modify the dispatcher SKILL.md.
- Does NOT modify the snapshot.
- Does NOT cover non-workflow skills (only the 14 dispatcher-referenced workflow skills).