### PR TITLE
docs(commands): add Operator Stakes section to /discipline reference card

### DIFF
--- a/commands/discipline.md
+++ b/commands/discipline.md
@@ -19,6 +19,20 @@ Print this card and check yourself against each law.
 | 6 | **Iterate One Change** | Am I changing one thing at a time? | "And also..." |
 | 7 | **Learn From Every Session** | Did I capture this as an instinct? | "Next time I'll..." |
 
+## Operator Stakes
+
+The Laws above are the *how*. These five principles are the *why*: code ships from your account, the incident lands on your pager, the bill hits your budget. Each one pairs with the Law that prevents it from going wrong.
+
+| # | Principle | Vibe coder | Engineer | Law |
+|---|-----------|------------|----------|-----|
+| 1 | **Ownership** | Ships auth, moves on | Adds rate limits, audit logs, password-reset flow, incident runbook before shipping | 4 |
+| 2 | **Reliability over cleverness** | Accepts a clever regex + heavy lib that breaks on ISO 8601 with millis | Picks the boring tested API, writes tests for leap years and DST | 1 |
+| 3 | **Systems thinking** | Builds in-memory CSV export, works for 100 dev users, OOMs in prod | Asks row count first, picks paginated background job + S3 link | 2 |
+| 4 | **Problem framing** | Builds the websocket chat the ticket asked for | Finds out users wanted faster support replies, not chat | 1 |
+| 5 | **Constraints management** | Calls the $0.02/image model on every upload | Does the math, adds client-side validation + caching + cheaper triage model | 2 |
+
+Code is a liability, not an asset. Speed without these five turns into someone else's incident at 3am — except the someone is you.
+
 ## The Loop
 
 ```

--- a/plugins/continuous-improvement/commands/discipline.md
+++ b/plugins/continuous-improvement/commands/discipline.md
@@ -19,6 +19,20 @@ Print this card and check yourself against each law.
 | 6 | **Iterate One Change** | Am I changing one thing at a time? | "And also..." |
 | 7 | **Learn From Every Session** | Did I capture this as an instinct? | "Next time I'll..." |
 
+## Operator Stakes
+
+The Laws above are the *how*. These five principles are the *why*: code ships from your account, the incident lands on your pager, the bill hits your budget. Each one pairs with the Law that prevents it from going wrong.
+
+| # | Principle | Vibe coder | Engineer | Law |
+|---|-----------|------------|----------|-----|
+| 1 | **Ownership** | Ships auth, moves on | Adds rate limits, audit logs, password-reset flow, incident runbook before shipping | 4 |
+| 2 | **Reliability over cleverness** | Accepts a clever regex + heavy lib that breaks on ISO 8601 with millis | Picks the boring tested API, writes tests for leap years and DST | 1 |
+| 3 | **Systems thinking** | Builds in-memory CSV export, works for 100 dev users, OOMs in prod | Asks row count first, picks paginated background job + S3 link | 2 |
+| 4 | **Problem framing** | Builds the websocket chat the ticket asked for | Finds out users wanted faster support replies, not chat | 1 |
+| 5 | **Constraints management** | Calls the $0.02/image model on every upload | Does the math, adds client-side validation + caching + cheaper triage model | 2 |
+
+Code is a liability, not an asset. Speed without these five turns into someone else's incident at 3am — except the someone is you.
+
 ## The Loop
 
 ```


### PR DESCRIPTION
## Summary

- Adds an **Operator Stakes** section to the `/discipline` quick-reference card, between "The Laws" table and "The Loop" diagram.
- Frames five operator principles — Ownership, Reliability over cleverness, Systems thinking, Problem framing, Constraints management — as the *why* behind the existing seven Laws (the *how*), each with a vibe-coder vs engineer contrast and a back-reference to the Law it most directly enforces.
- Updates both mirrored copies in lock-step: `commands/discipline.md` (root) and `plugins/continuous-improvement/commands/discipline.md` (plugin mirror).

## Provenance

This edit was salvaged from a stale dirty working tree on the main checkout — authored in a prior session, left uncommitted, recovered into a clean PR branch off `origin/main` rather than discarded. The salvaged blob hash matches the main-checkout dirty content exactly (`9e027ff..a985b19` on both files).

## Test plan

- [ ] Render `commands/discipline.md` and confirm the new "Operator Stakes" table displays cleanly (5 rows, "Vibe coder" / "Engineer" / "Law" columns aligned).
- [ ] Diff `commands/discipline.md` against `plugins/continuous-improvement/commands/discipline.md` — they must remain byte-identical (the mirror invariant).
- [ ] Run `/discipline` (or load the slash command) and confirm the new section is visible in the rendered card and does not break the "The Loop" / "Self-Check" sections that follow.
- [ ] Spot-check the Law back-references (4, 1, 2, 1, 2) — each principle's `Law` column points at one of the seven Laws and the mapping is defensible.