### PR TITLE
docs(messaging): lead with the agent-failure pattern this fixes

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.",
+      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
       "version": "3.6.0",
       "source": "./plugins/continuous-improvement",
       "author": {

--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@
 
 ---
 
+## The problem this solves
+
+You have used Claude Code (or any agentic coding tool) long enough to recognize the failure pattern.
+
+| You ask the agent to... | What actually happens |
+|---|---|
+| Add a feature | It edits five files, never runs the build, says "done" |
+| Fix a bug | It reinvents a helper that already exists in the repo |
+| Refactor a module | It bundles three unrelated changes into one commit |
+| Pick up where last session ended | It re-explores from zero — the prior session's lessons are gone |
+| Verify the change works | It claims "this should work" without running a single test |
+
+Every one of those failures is the agent skipping a step a disciplined engineer would not skip. The 7 Laws of AI Agent Discipline names each step, gives it a hook or a skill that enforces it, and feeds the captured patterns back into the agent so the same mistake gets harder to repeat next session.
+
+## What you get
+
+- **A 7-step discipline** the agent must follow every task — research → plan → execute one thing → verify → reflect → learn → iterate. Each Law has at least one skill or hook that enforces it.
+- **13 bundled skills** that turn the Laws from a doc into runtime behavior — `gateguard` blocks unverified Edit/Write/destructive Bash, `tdd-workflow` enforces RED → GREEN → REFACTOR, `verification-loop` runs build/types/tests/security before "done", `proceed-with-the-recommendation` walks any agent's recommendation list top-to-bottom with per-item verification.
+- **Mulahazah, the auto-leveling instinct engine** — hooks capture every tool call; after ~20 observations the agent analyzes patterns and creates instincts with confidence scores. Suggestions appear at 0.5+, auto-apply at 0.7+, decay when ignored. Project-scoped, promote to global after 2+ projects. You configure nothing.
+- **A GitHub Action transcript linter** that catches skipped Laws in CI — writes without prior research, edits without verification, too many files at once.
+- **Two install paths** — Beginner is two slash commands inside Claude Code (no Node, no bash, ~90% of users). Expert adds the MCP server, observation hooks, instinct packs, and the linter.
+
+The whole thing is MIT, free, and lives in this one repo. No service, no account, no telemetry leaves your machine.
+
+---
+
 ## Install
 
 **If you don't know which to pick, use Beginner.** It is enough for ~90% of users and adds no Node or bash dependency.

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -22,7 +22,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.";
+const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
 export function isPluginMode(value) {
     return value === "beginner" || value === "expert";
 }

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # continuous-improvement
 
-> The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.
+> Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.
 
 ## What This Is
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.6.0",
-  "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts. Beginner: one /plugin install command. Expert: adds MCP tools, session hooks, and a GitHub Action transcript linter.",
+  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.",
+      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
       "version": "3.6.0",
       "source": "./",
       "author": {

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.6.0",
-  "description": "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.",
+  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
   "author": {
     "name": "naimkatiman",
     "url": "https://github.com/naimkatiman"

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -22,7 +22,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.";
+const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
 export function isPluginMode(value) {
     return value === "beginner" || value === "expert";
 }

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -135,7 +135,7 @@ const KEYWORDS = [
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
 const SHARED_PLUGIN_DESCRIPTION =
-  "The 7 Laws of AI Agent Discipline for Claude Code. Stops your agent from skipping research, planning, and verification, and turns repeated patterns into instincts.";
+  "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
 
 export function isPluginMode(value: string | undefined): value is PluginMode {
   return value === "beginner" || value === "expert";


### PR DESCRIPTION
## Summary

A first-time visitor to the README or the plugin marketplace listing should see, in under 30 seconds, the concrete failure pattern this repo solves and what they get if they install. Previously they hit Install before seeing why they would.

- **README**: insert a `## The problem this solves` table (5 concrete agent-failure cases — edits without verifying, reinvents existing helpers, bundles unrelated changes, loses session lessons, claims "this should work") followed by a `## What you get` rundown of the 13 enforcement skills, Mulahazah, and the GitHub Action linter — between the hero and Install.
- **Single source of truth**: rewrite `SHARED_PLUGIN_DESCRIPTION` in `src/lib/plugin-metadata.mts` to lead with the failure pattern. Build cascades the new copy to `.claude-plugin/marketplace.json`, `plugins/.../plugin.json`, `plugins/.../marketplace.json`, and `lib/plugin-metadata.mjs`.
- **`package.json`** and **`llms.txt`**: mirror the new framing so npm and the LLM-readable summary agree with the README hero.

No version bump (3.6.0 stays) — pure messaging update, no behavior change. Locked install-decision-rule literal preserved per `verify:docs-substrings`.

## Test plan

- [x] `npm run verify:all` — all 6 lints green (skill-mirror, skill-tiers, skill-law-tag, docs-substrings 114/114, everything-mirror, typecheck)
- [x] `npm test` — 463/463 pass
- [x] Confirm `git diff --stat` shows only the 9 intended files (no autocrlf-only noise leaked into the commit)
- [ ] Open the README on GitHub after merge; eyeball that the new sections render and the table is readable
- [ ] Refresh the marketplace listing in Claude Code (`/plugin marketplace update continuous-improvement`); confirm the new description shows up