### PR TITLE
fix(observer): capture PostToolUse output by reading tool_response field

### DIFF
--- a/bin/observe.mjs
+++ b/bin/observe.mjs
@@ -49,14 +49,14 @@ function runObserver() {
     ensureDir(projectDir);
     rotateIfNeeded(obsFile, projectDir);
     const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-    const event = payload.tool_output !== undefined ? "tool_complete" : "tool_start";
+    const event = payload.tool_response !== undefined ? "tool_complete" : "tool_start";
     const row = {
         ts,
         event,
         session: payload.session_id,
         tool: payload.tool_name,
         input_summary: summariseInput(payload.tool_name, payload.tool_input),
-        output_summary: summariseOutput(payload.tool_output),
+        output_summary: summariseOutput(payload.tool_response),
         project_id: projectHash,
         project_name: projectName,
     };

--- a/lib/observe-event.mjs
+++ b/lib/observe-event.mjs
@@ -15,6 +15,12 @@ const OUTPUT_TRUNCATE = 200;
  * hook event. Returns null for any unparseable or schema-invalid input —
  * never throws. Empty/null/array payloads are rejected (the harness only
  * sends objects).
+ *
+ * Field-name normalisation: Claude Code's PostToolUse payload uses
+ * `tool_response`. Older mocks and some third-party harnesses emit
+ * `tool_output` or `toolOutput`. We accept all three at the boundary and
+ * expose a single `tool_response` field downstream so the discriminator and
+ * `summariseOutput` only have to know one name.
  */
 export function parseHookPayload(raw) {
     if (!raw)
@@ -33,11 +39,16 @@ export function parseHookPayload(raw) {
     if (typeof obj.tool_name !== "string" || obj.tool_name.length === 0) {
         return null;
     }
+    const toolResponse = obj.tool_response !== undefined
+        ? obj.tool_response
+        : obj.tool_output !== undefined
+            ? obj.tool_output
+            : obj.toolOutput;
     return {
         tool_name: obj.tool_name,
         session_id: typeof obj.session_id === "string" ? obj.session_id : "",
         tool_input: obj.tool_input,
-        tool_output: obj.tool_output,
+        tool_response: toolResponse,
     };
 }
 /**
@@ -85,9 +96,9 @@ export function summariseInput(toolName, input) {
     }
 }
 /**
- * Extract a short summary from `tool_output`. Strings pass through (capped at
- * OUTPUT_TRUNCATE); numbers/booleans coerce to string; objects JSON-stringify.
- * Null/undefined collapse to "".
+ * Extract a short summary from `tool_response`. Strings pass through (capped
+ * at OUTPUT_TRUNCATE); numbers/booleans coerce to string; objects
+ * JSON-stringify. Null/undefined collapse to "".
  */
 export function summariseOutput(output) {
     if (output === null || output === undefined)

--- a/plugins/continuous-improvement/bin/observe.mjs
+++ b/plugins/continuous-improvement/bin/observe.mjs
@@ -49,14 +49,14 @@ function runObserver() {
     ensureDir(projectDir);
     rotateIfNeeded(obsFile, projectDir);
     const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-    const event = payload.tool_output !== undefined ? "tool_complete" : "tool_start";
+    const event = payload.tool_response !== undefined ? "tool_complete" : "tool_start";
     const row = {
         ts,
         event,
         session: payload.session_id,
         tool: payload.tool_name,
         input_summary: summariseInput(payload.tool_name, payload.tool_input),
-        output_summary: summariseOutput(payload.tool_output),
+        output_summary: summariseOutput(payload.tool_response),
         project_id: projectHash,
         project_name: projectName,
     };

--- a/plugins/continuous-improvement/lib/observe-event.mjs
+++ b/plugins/continuous-improvement/lib/observe-event.mjs
@@ -15,6 +15,12 @@ const OUTPUT_TRUNCATE = 200;
  * hook event. Returns null for any unparseable or schema-invalid input —
  * never throws. Empty/null/array payloads are rejected (the harness only
  * sends objects).
+ *
+ * Field-name normalisation: Claude Code's PostToolUse payload uses
+ * `tool_response`. Older mocks and some third-party harnesses emit
+ * `tool_output` or `toolOutput`. We accept all three at the boundary and
+ * expose a single `tool_response` field downstream so the discriminator and
+ * `summariseOutput` only have to know one name.
  */
 export function parseHookPayload(raw) {
     if (!raw)
@@ -33,11 +39,16 @@ export function parseHookPayload(raw) {
     if (typeof obj.tool_name !== "string" || obj.tool_name.length === 0) {
         return null;
     }
+    const toolResponse = obj.tool_response !== undefined
+        ? obj.tool_response
+        : obj.tool_output !== undefined
+            ? obj.tool_output
+            : obj.toolOutput;
     return {
         tool_name: obj.tool_name,
         session_id: typeof obj.session_id === "string" ? obj.session_id : "",
         tool_input: obj.tool_input,
-        tool_output: obj.tool_output,
+        tool_response: toolResponse,
     };
 }
 /**
@@ -85,9 +96,9 @@ export function summariseInput(toolName, input) {
     }
 }
 /**
- * Extract a short summary from `tool_output`. Strings pass through (capped at
- * OUTPUT_TRUNCATE); numbers/booleans coerce to string; objects JSON-stringify.
- * Null/undefined collapse to "".
+ * Extract a short summary from `tool_response`. Strings pass through (capped
+ * at OUTPUT_TRUNCATE); numbers/booleans coerce to string; objects
+ * JSON-stringify. Null/undefined collapse to "".
  */
 export function summariseOutput(output) {
     if (output === null || output === undefined)

--- a/src/bin/observe.mts
+++ b/src/bin/observe.mts
@@ -57,14 +57,14 @@ function runObserver(): void {
   rotateIfNeeded(obsFile, projectDir);
 
   const ts = new Date().toISOString().replace(/\.\d{3}Z$/, "Z");
-  const event = payload.tool_output !== undefined ? "tool_complete" : "tool_start";
+  const event = payload.tool_response !== undefined ? "tool_complete" : "tool_start";
   const row = {
     ts,
     event,
     session: payload.session_id,
     tool: payload.tool_name,
     input_summary: summariseInput(payload.tool_name, payload.tool_input),
-    output_summary: summariseOutput(payload.tool_output),
+    output_summary: summariseOutput(payload.tool_response),
     project_id: projectHash,
     project_name: projectName,
   };

--- a/src/lib/observe-event.mts
+++ b/src/lib/observe-event.mts
@@ -16,14 +16,16 @@ export interface HookPayload {
   tool_name: string;
   session_id: string;
   tool_input: unknown;
-  tool_output: unknown;
+  tool_response: unknown;
 }
 
 interface RawHookPayload {
   tool_name?: unknown;
   session_id?: unknown;
   tool_input?: unknown;
+  tool_response?: unknown;
   tool_output?: unknown;
+  toolOutput?: unknown;
 }
 
 /**
@@ -31,6 +33,12 @@ interface RawHookPayload {
  * hook event. Returns null for any unparseable or schema-invalid input —
  * never throws. Empty/null/array payloads are rejected (the harness only
  * sends objects).
+ *
+ * Field-name normalisation: Claude Code's PostToolUse payload uses
+ * `tool_response`. Older mocks and some third-party harnesses emit
+ * `tool_output` or `toolOutput`. We accept all three at the boundary and
+ * expose a single `tool_response` field downstream so the discriminator and
+ * `summariseOutput` only have to know one name.
  */
 export function parseHookPayload(raw: string): HookPayload | null {
   if (!raw) return null;
@@ -47,11 +55,17 @@ export function parseHookPayload(raw: string): HookPayload | null {
   if (typeof obj.tool_name !== "string" || obj.tool_name.length === 0) {
     return null;
   }
+  const toolResponse =
+    obj.tool_response !== undefined
+      ? obj.tool_response
+      : obj.tool_output !== undefined
+        ? obj.tool_output
+        : obj.toolOutput;
   return {
     tool_name: obj.tool_name,
     session_id: typeof obj.session_id === "string" ? obj.session_id : "",
     tool_input: obj.tool_input,
-    tool_output: obj.tool_output,
+    tool_response: toolResponse,
   };
 }
 
@@ -100,9 +114,9 @@ export function summariseInput(toolName: string, input: unknown): string {
 }
 
 /**
- * Extract a short summary from `tool_output`. Strings pass through (capped at
- * OUTPUT_TRUNCATE); numbers/booleans coerce to string; objects JSON-stringify.
- * Null/undefined collapse to "".
+ * Extract a short summary from `tool_response`. Strings pass through (capped
+ * at OUTPUT_TRUNCATE); numbers/booleans coerce to string; objects
+ * JSON-stringify. Null/undefined collapse to "".
  */
 export function summariseOutput(output: unknown): string {
   if (output === null || output === undefined) return "";

--- a/src/test/observe-event.test.mts
+++ b/src/test/observe-event.test.mts
@@ -27,10 +27,26 @@ describe("parseHookPayload", () => {
     assert.equal(result.tool_name, "Bash");
     assert.equal(result.session_id, "abc-123");
     assert.deepEqual(result.tool_input, { command: "git status" });
-    assert.equal(result.tool_output, undefined, "PreToolUse has no tool_output");
+    assert.equal(result.tool_response, undefined, "PreToolUse has no tool_response");
   });
 
-  it("parses a well-formed PostToolUse payload (with tool_output)", () => {
+  it("parses a well-formed PostToolUse payload (canonical tool_response)", () => {
+    const raw = JSON.stringify({
+      tool_name: "Bash",
+      session_id: "abc-123",
+      tool_input: { command: "echo hi" },
+      tool_response: { stdout: "hi", stderr: "", interrupted: false },
+    });
+    const result = parseHookPayload(raw);
+    assert.ok(result);
+    assert.deepEqual(result.tool_response, {
+      stdout: "hi",
+      stderr: "",
+      interrupted: false,
+    });
+  });
+
+  it("accepts legacy tool_output as an alias for tool_response", () => {
     const raw = JSON.stringify({
       tool_name: "Read",
       session_id: "abc-123",
@@ -39,7 +55,32 @@ describe("parseHookPayload", () => {
     });
     const result = parseHookPayload(raw);
     assert.ok(result);
-    assert.equal(result.tool_output, "file contents here");
+    assert.equal(result.tool_response, "file contents here");
+  });
+
+  it("accepts toolOutput camelCase as an alias for tool_response", () => {
+    const raw = JSON.stringify({
+      tool_name: "Read",
+      session_id: "abc-123",
+      tool_input: { file_path: "/x" },
+      toolOutput: "from a third-party harness",
+    });
+    const result = parseHookPayload(raw);
+    assert.ok(result);
+    assert.equal(result.tool_response, "from a third-party harness");
+  });
+
+  it("prefers tool_response over tool_output when both are present", () => {
+    const raw = JSON.stringify({
+      tool_name: "Read",
+      session_id: "abc-123",
+      tool_input: { file_path: "/x" },
+      tool_response: "canonical",
+      tool_output: "legacy",
+    });
+    const result = parseHookPayload(raw);
+    assert.ok(result);
+    assert.equal(result.tool_response, "canonical");
   });
 
   it("returns null for malformed JSON without throwing", () => {
@@ -200,7 +241,7 @@ describe("HookPayload type contract", () => {
       tool_name: "Bash",
       session_id: "x",
       tool_input: { command: "ls" },
-      tool_output: undefined,
+      tool_response: undefined,
     };
     assert.equal(sample.tool_name, "Bash");
   });

--- a/src/test/observe.test.mts
+++ b/src/test/observe.test.mts
@@ -116,10 +116,30 @@ describe("observe.mjs (Node observer entrypoint)", () => {
     assert.match(last.project_id, /^[0-9a-f]{12}$/, "project_id is sha256 first 12 hex");
   });
 
-  it("writes a tool_complete row for a payload with tool_output", () => {
+  it("writes a tool_complete row for a payload with canonical tool_response", () => {
+    const payload = JSON.stringify({
+      tool_name: "Bash",
+      session_id: "session-B",
+      tool_input: { command: "echo hi" },
+      tool_response: { stdout: "hi\n", stderr: "", interrupted: false },
+    });
+    const result = runObserve(payload, {
+      HOME: tempHome,
+      CLAUDE_PROJECT_DIR: "/tmp/test-project-A",
+    });
+    assert.equal(result.status, 0);
+
+    const rows = readObservations(tempHome);
+    const last = rows[rows.length - 1];
+    assert.equal(last.event, "tool_complete");
+    assert.equal(last.input_summary, "echo hi", "rich schema captures Bash command on Post events too");
+    assert.match(last.output_summary, /"stdout":"hi/);
+  });
+
+  it("treats legacy tool_output as tool_response for back-compat", () => {
     const payload = JSON.stringify({
       tool_name: "Read",
-      session_id: "session-B",
+      session_id: "session-B-legacy",
       tool_input: { file_path: "/tmp/foo.txt" },
       tool_output: "file contents here",
     });
@@ -132,7 +152,7 @@ describe("observe.mjs (Node observer entrypoint)", () => {
     const rows = readObservations(tempHome);
     const last = rows[rows.length - 1];
     assert.equal(last.event, "tool_complete");
-    assert.equal(last.input_summary, "/tmp/foo.txt", "rich schema captures Edit/Read file_path");
+    assert.equal(last.input_summary, "/tmp/foo.txt");
     assert.equal(last.output_summary, "file contents here");
   });
 

--- a/test/observe-event.test.mjs
+++ b/test/observe-event.test.mjs
@@ -19,9 +19,24 @@ describe("parseHookPayload", () => {
         assert.equal(result.tool_name, "Bash");
         assert.equal(result.session_id, "abc-123");
         assert.deepEqual(result.tool_input, { command: "git status" });
-        assert.equal(result.tool_output, undefined, "PreToolUse has no tool_output");
+        assert.equal(result.tool_response, undefined, "PreToolUse has no tool_response");
     });
-    it("parses a well-formed PostToolUse payload (with tool_output)", () => {
+    it("parses a well-formed PostToolUse payload (canonical tool_response)", () => {
+        const raw = JSON.stringify({
+            tool_name: "Bash",
+            session_id: "abc-123",
+            tool_input: { command: "echo hi" },
+            tool_response: { stdout: "hi", stderr: "", interrupted: false },
+        });
+        const result = parseHookPayload(raw);
+        assert.ok(result);
+        assert.deepEqual(result.tool_response, {
+            stdout: "hi",
+            stderr: "",
+            interrupted: false,
+        });
+    });
+    it("accepts legacy tool_output as an alias for tool_response", () => {
         const raw = JSON.stringify({
             tool_name: "Read",
             session_id: "abc-123",
@@ -30,7 +45,30 @@ describe("parseHookPayload", () => {
         });
         const result = parseHookPayload(raw);
         assert.ok(result);
-        assert.equal(result.tool_output, "file contents here");
+        assert.equal(result.tool_response, "file contents here");
+    });
+    it("accepts toolOutput camelCase as an alias for tool_response", () => {
+        const raw = JSON.stringify({
+            tool_name: "Read",
+            session_id: "abc-123",
+            tool_input: { file_path: "/x" },
+            toolOutput: "from a third-party harness",
+        });
+        const result = parseHookPayload(raw);
+        assert.ok(result);
+        assert.equal(result.tool_response, "from a third-party harness");
+    });
+    it("prefers tool_response over tool_output when both are present", () => {
+        const raw = JSON.stringify({
+            tool_name: "Read",
+            session_id: "abc-123",
+            tool_input: { file_path: "/x" },
+            tool_response: "canonical",
+            tool_output: "legacy",
+        });
+        const result = parseHookPayload(raw);
+        assert.ok(result);
+        assert.equal(result.tool_response, "canonical");
     });
     it("returns null for malformed JSON without throwing", () => {
         const malformed = "{not valid json";
@@ -164,7 +202,7 @@ describe("HookPayload type contract", () => {
             tool_name: "Bash",
             session_id: "x",
             tool_input: { command: "ls" },
-            tool_output: undefined,
+            tool_response: undefined,
         };
         assert.equal(sample.tool_name, "Bash");
     });

--- a/test/observe.test.mjs
+++ b/test/observe.test.mjs
@@ -92,10 +92,28 @@ describe("observe.mjs (Node observer entrypoint)", () => {
         assert.match(last.ts, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
         assert.match(last.project_id, /^[0-9a-f]{12}$/, "project_id is sha256 first 12 hex");
     });
-    it("writes a tool_complete row for a payload with tool_output", () => {
+    it("writes a tool_complete row for a payload with canonical tool_response", () => {
+        const payload = JSON.stringify({
+            tool_name: "Bash",
+            session_id: "session-B",
+            tool_input: { command: "echo hi" },
+            tool_response: { stdout: "hi\n", stderr: "", interrupted: false },
+        });
+        const result = runObserve(payload, {
+            HOME: tempHome,
+            CLAUDE_PROJECT_DIR: "/tmp/test-project-A",
+        });
+        assert.equal(result.status, 0);
+        const rows = readObservations(tempHome);
+        const last = rows[rows.length - 1];
+        assert.equal(last.event, "tool_complete");
+        assert.equal(last.input_summary, "echo hi", "rich schema captures Bash command on Post events too");
+        assert.match(last.output_summary, /"stdout":"hi/);
+    });
+    it("treats legacy tool_output as tool_response for back-compat", () => {
         const payload = JSON.stringify({
             tool_name: "Read",
-            session_id: "session-B",
+            session_id: "session-B-legacy",
             tool_input: { file_path: "/tmp/foo.txt" },
             tool_output: "file contents here",
         });
@@ -107,7 +125,7 @@ describe("observe.mjs (Node observer entrypoint)", () => {
         const rows = readObservations(tempHome);
         const last = rows[rows.length - 1];
         assert.equal(last.event, "tool_complete");
-        assert.equal(last.input_summary, "/tmp/foo.txt", "rich schema captures Edit/Read file_path");
+        assert.equal(last.input_summary, "/tmp/foo.txt");
         assert.equal(last.output_summary, "file contents here");
     });
     it("captures Edit file_path in input_summary", () => {


### PR DESCRIPTION
## Summary

Fixes a silent observer bug where every row in `observations.jsonl` was logged as `event:"tool_start"` with an empty `output_summary`, making PreToolUse and PostToolUse rows indistinguishable and erasing all tool-output capture.

**Root cause:** Claude Code's PostToolUse hook payload field is `tool_response`. The observer only checked `tool_output`, which Claude Code does not send. The discriminator therefore never fired, and `summariseOutput` always saw `undefined`.

Cross-confirmed against this repo's own reference: [third-party/oh-my-claudecode/templates/hooks/post-tool-use.mjs:243](https://github.com/naimkatiman/continuous-improvement/blob/main/third-party/oh-my-claudecode/templates/hooks/post-tool-use.mjs#L243) — `data.tool_response || data.toolOutput || ''`.

## Fix

`parseHookPayload` now accepts three field names at the boundary and normalises to a single canonical field:

| Source field | Origin | Status |
|---|---|---|
| `tool_response` | Claude Code (canonical) | preferred |
| `tool_output` | older mocks / earlier observer self-tests | accepted |
| `toolOutput` | third-party harnesses | accepted |

Downstream — discriminator (`bin/observe.mts:60`) and `summariseOutput` — only sees the normalised `tool_response`.

## Live verification

Patched the host install at `~/.claude/instincts/{bin,lib}/observe.mjs` mirroring this PR, then triggered a Bash call from a live session. Two consecutive rows in `observations.jsonl`:

```
{"ts":"...","event":"tool_start",   "tool":"Bash", "input_summary":"echo VERIFY-MARKER...", "output_summary":""}
{"ts":"...","event":"tool_complete","tool":"Bash", "input_summary":"echo VERIFY-MARKER...", "output_summary":"{\"stdout\":\"VERIFY-MARKER-003811\",\"stderr\":\"\",\"interrupted\":false,\"isImage\":false,\"noOutputExpected\":false}"}
```

Pre/Post are now semantically distinct and `output_summary` is populated.

## Test plan

- [x] `npm test` — 467/467 passing locally on Windows + Git Bash
- [x] New unit tests for the parser:
  - `parses a well-formed PostToolUse payload (canonical tool_response)`
  - `accepts legacy tool_output as an alias for tool_response`
  - `accepts toolOutput camelCase as an alias for tool_response`
  - `prefers tool_response over tool_output when both are present`
- [x] New observer-entrypoint tests:
  - `writes a tool_complete row for a payload with canonical tool_response`
  - `treats legacy tool_output as tool_response for back-compat`
- [x] `HookPayload` type contract updated: field renamed `tool_output` → `tool_response`
- [x] Generated mirrors regenerated via `npm run build` (`bin/`, `lib/`, `plugins/continuous-improvement/{bin,lib}/`)

## Out of scope

- The bash fallback in `hooks/observe.sh` still uses `grep -q '"tool_output"'`. The fallback only fires when Node is missing, and the marker check fails-safe (defaults to `tool_start`), so existing operators stay no worse than today. Follow-up issue if we want to upgrade the fallback to also recognise `tool_response`.
- Lockfile drift (`package-lock.json` still records 3.3.0 vs `package.json` 3.6.0) — separate concern; not bundled here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)