### PR TITLE
feat(invariant): fail verify on unaccounted orchestrator routing targets

### DIFF
--- a/bin/check-routing-targets.mjs
+++ b/bin/check-routing-targets.mjs
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Routing-Target Invariant Check
+ *
+ * Verifies that every routing target named in the orchestrator skill at
+ * skills/proceed-with-the-recommendation.md § "Routing Table (with Inline
+ * Fallbacks)" either:
+ *   (a) ships bundled at plugins/continuous-improvement/skills/<name>/SKILL.md, or
+ *   (b) is declared in the root-level optional-companions.json file.
+ *
+ * Catches: a routing-table row that names a skill the bundle does not ship and
+ * the maintainer has not declared as an optional companion. Without this gate,
+ * such drift only surfaces at runtime when the orchestrator routes to a target
+ * that resolves to neither a bundled skill nor an inline fallback the
+ * maintainer was tracking.
+ *
+ * Usage:
+ *   node bin/check-routing-targets.mjs              # Check the current repo
+ *   node bin/check-routing-targets.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every routing target is accounted for (bundled or optional-declared)
+ *   1 — at least one routing target is unaccounted for
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const ORCHESTRATOR_SKILL_PATH = "skills/proceed-with-the-recommendation.md";
+const OPTIONAL_COMPANIONS_PATH = "optional-companions.json";
+const PLUGIN_SKILLS_DIR = "plugins/continuous-improvement/skills";
+const SECTION_HEADER = "### Routing Table (with Inline Fallbacks)";
+
+export function discoverBundledSkills(repoRoot) {
+    const dir = join(repoRoot, PLUGIN_SKILLS_DIR);
+    let entries;
+    try {
+        entries = readdirSync(dir);
+    }
+    catch {
+        return new Set();
+    }
+    const names = new Set();
+    for (const name of entries) {
+        const skillFile = join(dir, name, "SKILL.md");
+        try {
+            const stat = statSync(skillFile);
+            if (stat.isFile()) names.add(name);
+        }
+        catch { /* not a skill dir */ }
+    }
+    return names;
+}
+
+export function loadOptionalCompanions(repoRoot) {
+    const path = join(repoRoot, OPTIONAL_COMPANIONS_PATH);
+    const raw = readFileSync(path, "utf8");
+    const data = JSON.parse(raw);
+    if (!Array.isArray(data.optional_companions)) {
+        throw new Error(`${OPTIONAL_COMPANIONS_PATH}: missing or non-array "optional_companions" field`);
+    }
+    return new Set(data.optional_companions);
+}
+
+export function extractRoutingTargets(orchestratorMarkdown) {
+    const lines = orchestratorMarkdown.split(/\r?\n/);
+    const headerIdx = lines.findIndex((line) => line.trim() === SECTION_HEADER);
+    if (headerIdx === -1) {
+        throw new Error(`Routing-table section header not found: "${SECTION_HEADER}"`);
+    }
+    const targets = [];
+    let inTable = false;
+    let sawHeaderRow = false;
+    let sawDividerRow = false;
+    for (let i = headerIdx + 1; i < lines.length; i += 1) {
+        const line = lines[i];
+        const trimmed = line.trim();
+        if (trimmed.startsWith("## ") || trimmed.startsWith("### ")) break;
+        if (!trimmed.startsWith("|")) {
+            if (inTable) break;
+            continue;
+        }
+        if (!sawHeaderRow) { sawHeaderRow = true; inTable = true; continue; }
+        if (!sawDividerRow) { sawDividerRow = true; continue; }
+        const cells = trimmed.split("|").map((c) => c.trim());
+        // cells[0] and cells[last] are empty strings from leading/trailing pipes.
+        // cells[1] = "Recommendation type", cells[2] = "Preferred skill", cells[3] = "Inline fallback".
+        const preferredCell = cells[2] ?? "";
+        const tokens = [...preferredCell.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+        for (const token of tokens) {
+            targets.push({ rowIndex: targets.length, recommendationType: cells[1] ?? "", target: token });
+        }
+    }
+    return targets;
+}
+
+export function checkRoutingTargets(repoRoot) {
+    const orchestratorPath = join(repoRoot, ORCHESTRATOR_SKILL_PATH);
+    const orchestratorContent = readFileSync(orchestratorPath, "utf8");
+    const targets = extractRoutingTargets(orchestratorContent);
+    const bundled = discoverBundledSkills(repoRoot);
+    const optional = loadOptionalCompanions(repoRoot);
+    const drifts = [];
+    for (const t of targets) {
+        if (bundled.has(t.target)) continue;
+        if (optional.has(t.target)) continue;
+        drifts.push(t);
+    }
+    return { targets, drifts, bundledCount: bundled.size, optionalCount: optional.size };
+}
+
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const { targets, drifts, bundledCount, optionalCount } = checkRoutingTargets(repoRoot);
+    if (drifts.length === 0) {
+        console.log(`OK routing-targets: all ${targets.length} routing target(s) accounted for ` +
+            `(${bundledCount} bundled skill(s), ${optionalCount} optional companion(s) declared).`);
+        exit(0);
+    }
+    console.error(`FAIL routing-targets: ${drifts.length} unaccounted target(s) in ${ORCHESTRATOR_SKILL_PATH}.\n`);
+    for (const d of drifts) {
+        console.error(`  - "${d.target}" — referenced by row "${d.recommendationType}"`);
+        console.error(`      Not bundled at ${PLUGIN_SKILLS_DIR}/${d.target}/SKILL.md`);
+        console.error(`      Not declared in ${OPTIONAL_COMPANIONS_PATH}`);
+    }
+    console.error(`\nFix: either bundle the skill (add plugins/continuous-improvement/skills/<name>/SKILL.md ` +
+        `via the source skill + 'npm run build'), OR declare it in ${OPTIONAL_COMPANIONS_PATH} ` +
+        `with a pointer note in docs/audits/.`);
+    exit(1);
+}
+
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-routing-targets.mjs")) {
+    main();
+}

--- a/optional-companions.json
+++ b/optional-companions.json
@@ -1,0 +1,23 @@
+{
+  "_doc": "Routing targets in skills/proceed-with-the-recommendation.md that are NOT bundled with the continuous-improvement plugin. See docs/audits/2026-05-06-routing-target-gap.md for source plugins, licenses, and inline-fallback summaries. The bin/check-routing-targets.mjs invariant fails when proceed-with-the-recommendation.md names a target that is neither bundled in plugins/continuous-improvement/skills/ nor listed here. When a target gets vendored into the plugin bundle, remove it from this list so the invariant enforces that future references resolve to the bundled copy.",
+  "optional_companions": [
+    "code-review",
+    "commit-commands:commit",
+    "commit-commands:commit-push-pr",
+    "documentation-lookup",
+    "frontend-design:frontend-design",
+    "loop",
+    "schedule",
+    "security-review",
+    "simplify",
+    "superpowers:brainstorming",
+    "superpowers:dispatching-parallel-agents",
+    "superpowers:finishing-a-development-branch",
+    "superpowers:requesting-code-review",
+    "superpowers:systematic-debugging",
+    "superpowers:test-driven-development",
+    "superpowers:verification-before-completion",
+    "superpowers:writing-plans",
+    "update-config"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "verify:skill-law-tag": "node bin/check-skill-law-tag.mjs",
     "verify:docs-substrings": "node bin/check-docs-substrings.mjs",
     "verify:everything-mirror": "node bin/check-everything-mirror.mjs",
-    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run typecheck"
+    "verify:routing-targets": "node bin/check-routing-targets.mjs",
+    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run typecheck"
   },
   "files": [
     ".claude-plugin/",

--- a/test/check-routing-targets.test.mjs
+++ b/test/check-routing-targets.test.mjs
@@ -1,0 +1,253 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+    checkRoutingTargets,
+    discoverBundledSkills,
+    extractRoutingTargets,
+    loadOptionalCompanions,
+} from "../bin/check-routing-targets.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-routing-targets.mjs");
+const PLUGIN_SKILLS = "plugins/continuous-improvement/skills";
+
+function setupRepo() {
+    const root = mkdtempSync(join(tmpdir(), "routing-targets-test-"));
+    mkdirSync(join(root, PLUGIN_SKILLS), { recursive: true });
+    mkdirSync(join(root, "skills"), { recursive: true });
+    return root;
+}
+
+function writeBundled(root, name) {
+    const dir = join(root, PLUGIN_SKILLS, name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`);
+}
+
+function writeOrchestrator(root, tableRows) {
+    const body = [
+        "# Proceed With The Recommendation",
+        "",
+        "## Phase 3 — Route",
+        "",
+        "### Routing Table (with Inline Fallbacks)",
+        "",
+        "| Recommendation type | Preferred skill | Inline fallback |",
+        "|---|---|---|",
+        ...tableRows,
+        "",
+        "## Phase 4 — Verify",
+        "",
+        "Smallest check that proves correctness.",
+        "",
+    ].join("\n");
+    writeFileSync(join(root, "skills", "proceed-with-the-recommendation.md"), body);
+}
+
+function writeOptionalCompanions(root, companions) {
+    writeFileSync(join(root, "optional-companions.json"), JSON.stringify({
+        _doc: "test fixture",
+        optional_companions: companions,
+    }, null, 2));
+}
+
+describe("check-routing-targets — parser", () => {
+    it("extracts every backtick-quoted token from the Preferred skill column", () => {
+        const md = [
+            "### Routing Table (with Inline Fallbacks)",
+            "",
+            "| Recommendation type | Preferred skill | Inline fallback |",
+            "|---|---|---|",
+            "| One target | `alpha` | inline |",
+            "| Two targets | `beta` or `gamma` | inline |",
+            "| Sub-skill notation | `superpowers:writing-plans` | inline |",
+            "",
+            "## Next Section",
+            "",
+        ].join("\n");
+        const targets = extractRoutingTargets(md);
+        assert.deepEqual(
+            targets.map((t) => t.target),
+            ["alpha", "beta", "gamma", "superpowers:writing-plans"],
+        );
+    });
+
+    it("stops parsing at the next ## or ### header", () => {
+        const md = [
+            "### Routing Table (with Inline Fallbacks)",
+            "",
+            "| col1 | col2 | col3 |",
+            "|---|---|---|",
+            "| Real row | `alpha` | inline |",
+            "",
+            "### Some Other Subsection",
+            "",
+            "| Recommendation type | Preferred skill | Inline fallback |",
+            "|---|---|---|",
+            "| Should NOT be parsed | `noise` | inline |",
+        ].join("\n");
+        const targets = extractRoutingTargets(md);
+        assert.deepEqual(targets.map((t) => t.target), ["alpha"]);
+    });
+
+    it("throws when the routing-table section header is missing", () => {
+        assert.throws(
+            () => extractRoutingTargets("# A skill\n\nNo routing table here.\n"),
+            /Routing-table section header not found/,
+        );
+    });
+
+    it("ignores backtick tokens in the Inline fallback column", () => {
+        const md = [
+            "### Routing Table (with Inline Fallbacks)",
+            "",
+            "| col1 | col2 | col3 |",
+            "|---|---|---|",
+            "| Row A | `alpha` | edit `~/.claude/settings.json` then restart |",
+            "",
+        ].join("\n");
+        const targets = extractRoutingTargets(md);
+        assert.deepEqual(targets.map((t) => t.target), ["alpha"]);
+    });
+});
+
+describe("check-routing-targets — invariant", () => {
+    it("returns zero drifts when every target is either bundled or declared optional", () => {
+        const root = setupRepo();
+        try {
+            writeBundled(root, "alpha");
+            writeOrchestrator(root, [
+                "| Bundled row | `alpha` | inline |",
+                "| Optional row | `beta` | inline |",
+            ]);
+            writeOptionalCompanions(root, ["beta"]);
+            const result = checkRoutingTargets(root);
+            assert.equal(result.drifts.length, 0);
+            assert.equal(result.targets.length, 2);
+            assert.equal(result.bundledCount, 1);
+            assert.equal(result.optionalCount, 1);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("flags a target that is neither bundled nor declared optional", () => {
+        const root = setupRepo();
+        try {
+            writeBundled(root, "alpha");
+            writeOrchestrator(root, [
+                "| Bundled row | `alpha` | inline |",
+                "| Unknown row | `gamma` | inline |",
+            ]);
+            writeOptionalCompanions(root, []);
+            const result = checkRoutingTargets(root);
+            assert.equal(result.drifts.length, 1);
+            assert.equal(result.drifts[0].target, "gamma");
+            assert.equal(result.drifts[0].recommendationType, "Unknown row");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("treats bundled and bare-namespace as exact-match (does not auto-resolve sub-skills)", () => {
+        const root = setupRepo();
+        try {
+            writeBundled(root, "superpowers");
+            writeOrchestrator(root, [
+                "| Sub-skill row | `superpowers:writing-plans` | inline |",
+            ]);
+            writeOptionalCompanions(root, []);
+            const result = checkRoutingTargets(root);
+            assert.equal(result.drifts.length, 1);
+            assert.equal(result.drifts[0].target, "superpowers:writing-plans");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("loadOptionalCompanions throws on a malformed companions file", () => {
+        const root = setupRepo();
+        try {
+            writeFileSync(join(root, "optional-companions.json"), JSON.stringify({ wrong_key: [] }));
+            assert.throws(() => loadOptionalCompanions(root), /missing or non-array/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("discoverBundledSkills returns an empty set when the plugin skills dir is missing", () => {
+        const root = mkdtempSync(join(tmpdir(), "routing-targets-empty-"));
+        try {
+            assert.equal(discoverBundledSkills(root).size, 0);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("check-routing-targets — CLI", () => {
+    it("exits 0 with OK message on a clean synthetic repo", () => {
+        const root = setupRepo();
+        try {
+            writeBundled(root, "alpha");
+            writeOrchestrator(root, [
+                "| Bundled row | `alpha` | inline |",
+                "| Optional row | `beta` | inline |",
+            ]);
+            writeOptionalCompanions(root, ["beta"]);
+            const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            assert.match(out, /OK routing-targets: all 2 routing target\(s\) accounted for/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+
+    it("exits 1 with FAIL message on a drifted synthetic repo", () => {
+        const root = setupRepo();
+        try {
+            writeBundled(root, "alpha");
+            writeOrchestrator(root, [
+                "| Unknown row | `gamma` | inline |",
+            ]);
+            writeOptionalCompanions(root, []);
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /FAIL routing-targets: 1 unaccounted target/);
+                assert.match(e.stderr ?? "", /"gamma"/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero on drift");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+
+describe("check-routing-targets — live repo", () => {
+    it("verifies the live repo has zero unaccounted routing targets", () => {
+        const result = checkRoutingTargets(REPO_ROOT);
+        assert.equal(
+            result.drifts.length,
+            0,
+            `live repo has unaccounted routing targets: ${JSON.stringify(result.drifts, null, 2)}`,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `bin/check-routing-targets.mjs` that parses the routing table in `skills/proceed-with-the-recommendation.md` and asserts every named target either ships at `plugins/continuous-improvement/skills/<name>/SKILL.md` or is declared in the new `optional-companions.json`.
- Adds `optional-companions.json` listing the 18 currently-external routing targets.
- Adds `test/check-routing-targets.test.mjs` (12 tests covering parser, invariant, CLI, and a live-repo zero-drift assertion).
- Wires `verify:routing-targets` into `package.json` and chains it into `verify:all`.

## Why this lands

This is R3 of the bundling-vs-soft-dependency walk. Pairs with PR #65 (audit), #66 (plugin README), #68 (point-of-use markers). R1 documented the gap; R2/R4 made it visible to humans; R3 makes it a tracked invariant: any future edit to the routing table that names an unaccounted skill fails `verify:all` and CI.

Live results on this branch: `OK routing-targets: all 21 routing target(s) accounted for (13 bundled skill(s), 18 optional companion(s) declared).`

## Convention deviation from the literal recommendation

The recommendation said "extend `bin/generate-plugin-manifests.mjs` to fail the build." This PR ships the invariant as a separate `verify:routing-targets` script per the existing `check-skill-mirror` / `check-skill-tiers` / `check-skill-law-tag` convention. Reasoning: build-time enforcement inside the generator would prevent regenerating the bundle to fix drift; verify-time enforcement (in `verify:all` and CI) is the existing gate shape and matches what every other invariant does in this repo.

## Maintenance contract

When a future change adds a new routing-table row in `skills/proceed-with-the-recommendation.md`:

- If the named skill already ships in `plugins/continuous-improvement/skills/<name>/SKILL.md` — nothing else to do; the check passes.
- If the named skill is external — add the exact identifier to `optional-companions.json` `optional_companions` array.
- If the named skill gets vendored into the bundle (R5 territory) — remove the entry from `optional-companions.json` so the check enforces that future references resolve to the bundled copy.

## What this PR does NOT do

- No changes to source skill content (R4 / PR #68 owns that)
- No changes to README copy (R2 / PR #66)
- No changes to the audit doc (R1 / PR #65)
- No third-party vendoring (R5 still held)
- No marketplace registration (R6 still held)

## Test plan

- [ ] `node bin/check-routing-targets.mjs` exits 0 with `OK routing-targets: all 21 ...`
- [ ] `node --test test/check-routing-targets.test.mjs` passes 12/12
- [ ] `npm run verify:all` (after `npm install` for tsc) includes routing-targets check
- [ ] Inject a fake row `| Test | \`nonexistent-skill\` | inline |` into `skills/proceed-with-the-recommendation.md` → check exits 1 with "FAIL routing-targets: 1 unaccounted target"