### PR TITLE
fix(invariant): add missing .mts sources for check-routing-targets (follow-up to #69)

### DIFF
--- a/bin/check-routing-targets.mjs
+++ b/bin/check-routing-targets.mjs
@@ -25,12 +25,10 @@
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import { argv, cwd, exit } from "node:process";
-
 const ORCHESTRATOR_SKILL_PATH = "skills/proceed-with-the-recommendation.md";
 const OPTIONAL_COMPANIONS_PATH = "optional-companions.json";
 const PLUGIN_SKILLS_DIR = "plugins/continuous-improvement/skills";
 const SECTION_HEADER = "### Routing Table (with Inline Fallbacks)";
-
 export function discoverBundledSkills(repoRoot) {
     const dir = join(repoRoot, PLUGIN_SKILLS_DIR);
     let entries;
@@ -45,13 +43,15 @@ export function discoverBundledSkills(repoRoot) {
         const skillFile = join(dir, name, "SKILL.md");
         try {
             const stat = statSync(skillFile);
-            if (stat.isFile()) names.add(name);
+            if (stat.isFile())
+                names.add(name);
         }
-        catch { /* not a skill dir */ }
+        catch {
+            /* not a skill dir */
+        }
     }
     return names;
 }
-
 export function loadOptionalCompanions(repoRoot) {
     const path = join(repoRoot, OPTIONAL_COMPANIONS_PATH);
     const raw = readFileSync(path, "utf8");
@@ -61,7 +61,6 @@ export function loadOptionalCompanions(repoRoot) {
     }
     return new Set(data.optional_companions);
 }
-
 export function extractRoutingTargets(orchestratorMarkdown) {
     const lines = orchestratorMarkdown.split(/\r?\n/);
     const headerIdx = lines.findIndex((line) => line.trim() === SECTION_HEADER);
@@ -75,25 +74,37 @@ export function extractRoutingTargets(orchestratorMarkdown) {
     for (let i = headerIdx + 1; i < lines.length; i += 1) {
         const line = lines[i];
         const trimmed = line.trim();
-        if (trimmed.startsWith("## ") || trimmed.startsWith("### ")) break;
+        if (trimmed.startsWith("## ") || trimmed.startsWith("### "))
+            break;
         if (!trimmed.startsWith("|")) {
-            if (inTable) break;
+            if (inTable)
+                break;
             continue;
         }
-        if (!sawHeaderRow) { sawHeaderRow = true; inTable = true; continue; }
-        if (!sawDividerRow) { sawDividerRow = true; continue; }
+        if (!sawHeaderRow) {
+            sawHeaderRow = true;
+            inTable = true;
+            continue;
+        }
+        if (!sawDividerRow) {
+            sawDividerRow = true;
+            continue;
+        }
         const cells = trimmed.split("|").map((c) => c.trim());
         // cells[0] and cells[last] are empty strings from leading/trailing pipes.
         // cells[1] = "Recommendation type", cells[2] = "Preferred skill", cells[3] = "Inline fallback".
         const preferredCell = cells[2] ?? "";
         const tokens = [...preferredCell.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
         for (const token of tokens) {
-            targets.push({ rowIndex: targets.length, recommendationType: cells[1] ?? "", target: token });
+            targets.push({
+                rowIndex: targets.length,
+                recommendationType: cells[1] ?? "",
+                target: token,
+            });
         }
     }
     return targets;
 }
-
 export function checkRoutingTargets(repoRoot) {
     const orchestratorPath = join(repoRoot, ORCHESTRATOR_SKILL_PATH);
     const orchestratorContent = readFileSync(orchestratorPath, "utf8");
@@ -102,13 +113,19 @@ export function checkRoutingTargets(repoRoot) {
     const optional = loadOptionalCompanions(repoRoot);
     const drifts = [];
     for (const t of targets) {
-        if (bundled.has(t.target)) continue;
-        if (optional.has(t.target)) continue;
+        if (bundled.has(t.target))
+            continue;
+        if (optional.has(t.target))
+            continue;
         drifts.push(t);
     }
-    return { targets, drifts, bundledCount: bundled.size, optionalCount: optional.size };
+    return {
+        targets,
+        drifts,
+        bundledCount: bundled.size,
+        optionalCount: optional.size,
+    };
 }
-
 function main() {
     const repoRoot = argv[2] ?? cwd();
     const { targets, drifts, bundledCount, optionalCount } = checkRoutingTargets(repoRoot);
@@ -128,7 +145,6 @@ function main() {
         `with a pointer note in docs/audits/.`);
     exit(1);
 }
-
 const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
 if (invokedDirectly || argv[1]?.endsWith("check-routing-targets.mjs")) {
     main();

--- a/src/bin/check-routing-targets.mts
+++ b/src/bin/check-routing-targets.mts
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+/**
+ * Routing-Target Invariant Check
+ *
+ * Verifies that every routing target named in the orchestrator skill at
+ * skills/proceed-with-the-recommendation.md § "Routing Table (with Inline
+ * Fallbacks)" either:
+ *   (a) ships bundled at plugins/continuous-improvement/skills/<name>/SKILL.md, or
+ *   (b) is declared in the root-level optional-companions.json file.
+ *
+ * Catches: a routing-table row that names a skill the bundle does not ship and
+ * the maintainer has not declared as an optional companion. Without this gate,
+ * such drift only surfaces at runtime when the orchestrator routes to a target
+ * that resolves to neither a bundled skill nor an inline fallback the
+ * maintainer was tracking.
+ *
+ * Usage:
+ *   node bin/check-routing-targets.mjs              # Check the current repo
+ *   node bin/check-routing-targets.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every routing target is accounted for (bundled or optional-declared)
+ *   1 — at least one routing target is unaccounted for
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const ORCHESTRATOR_SKILL_PATH = "skills/proceed-with-the-recommendation.md";
+const OPTIONAL_COMPANIONS_PATH = "optional-companions.json";
+const PLUGIN_SKILLS_DIR = "plugins/continuous-improvement/skills";
+const SECTION_HEADER = "### Routing Table (with Inline Fallbacks)";
+
+export interface RoutingTarget {
+  rowIndex: number;
+  recommendationType: string;
+  target: string;
+}
+
+export interface CheckResult {
+  targets: RoutingTarget[];
+  drifts: RoutingTarget[];
+  bundledCount: number;
+  optionalCount: number;
+}
+
+export function discoverBundledSkills(repoRoot: string): Set<string> {
+  const dir = join(repoRoot, PLUGIN_SKILLS_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return new Set();
+  }
+  const names = new Set<string>();
+  for (const name of entries) {
+    const skillFile = join(dir, name, "SKILL.md");
+    try {
+      const stat = statSync(skillFile);
+      if (stat.isFile()) names.add(name);
+    } catch {
+      /* not a skill dir */
+    }
+  }
+  return names;
+}
+
+export function loadOptionalCompanions(repoRoot: string): Set<string> {
+  const path = join(repoRoot, OPTIONAL_COMPANIONS_PATH);
+  const raw = readFileSync(path, "utf8");
+  const data = JSON.parse(raw) as { optional_companions?: unknown };
+  if (!Array.isArray(data.optional_companions)) {
+    throw new Error(
+      `${OPTIONAL_COMPANIONS_PATH}: missing or non-array "optional_companions" field`,
+    );
+  }
+  return new Set(data.optional_companions as string[]);
+}
+
+export function extractRoutingTargets(
+  orchestratorMarkdown: string,
+): RoutingTarget[] {
+  const lines = orchestratorMarkdown.split(/\r?\n/);
+  const headerIdx = lines.findIndex((line) => line.trim() === SECTION_HEADER);
+  if (headerIdx === -1) {
+    throw new Error(
+      `Routing-table section header not found: "${SECTION_HEADER}"`,
+    );
+  }
+  const targets: RoutingTarget[] = [];
+  let inTable = false;
+  let sawHeaderRow = false;
+  let sawDividerRow = false;
+  for (let i = headerIdx + 1; i < lines.length; i += 1) {
+    const line = lines[i];
+    const trimmed = line.trim();
+    if (trimmed.startsWith("## ") || trimmed.startsWith("### ")) break;
+    if (!trimmed.startsWith("|")) {
+      if (inTable) break;
+      continue;
+    }
+    if (!sawHeaderRow) {
+      sawHeaderRow = true;
+      inTable = true;
+      continue;
+    }
+    if (!sawDividerRow) {
+      sawDividerRow = true;
+      continue;
+    }
+    const cells = trimmed.split("|").map((c) => c.trim());
+    // cells[0] and cells[last] are empty strings from leading/trailing pipes.
+    // cells[1] = "Recommendation type", cells[2] = "Preferred skill", cells[3] = "Inline fallback".
+    const preferredCell = cells[2] ?? "";
+    const tokens = [...preferredCell.matchAll(/`([^`]+)`/g)].map((m) => m[1]);
+    for (const token of tokens) {
+      targets.push({
+        rowIndex: targets.length,
+        recommendationType: cells[1] ?? "",
+        target: token,
+      });
+    }
+  }
+  return targets;
+}
+
+export function checkRoutingTargets(repoRoot: string): CheckResult {
+  const orchestratorPath = join(repoRoot, ORCHESTRATOR_SKILL_PATH);
+  const orchestratorContent = readFileSync(orchestratorPath, "utf8");
+  const targets = extractRoutingTargets(orchestratorContent);
+  const bundled = discoverBundledSkills(repoRoot);
+  const optional = loadOptionalCompanions(repoRoot);
+  const drifts: RoutingTarget[] = [];
+  for (const t of targets) {
+    if (bundled.has(t.target)) continue;
+    if (optional.has(t.target)) continue;
+    drifts.push(t);
+  }
+  return {
+    targets,
+    drifts,
+    bundledCount: bundled.size,
+    optionalCount: optional.size,
+  };
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const { targets, drifts, bundledCount, optionalCount } =
+    checkRoutingTargets(repoRoot);
+  if (drifts.length === 0) {
+    console.log(
+      `OK routing-targets: all ${targets.length} routing target(s) accounted for ` +
+        `(${bundledCount} bundled skill(s), ${optionalCount} optional companion(s) declared).`,
+    );
+    exit(0);
+  }
+  console.error(
+    `FAIL routing-targets: ${drifts.length} unaccounted target(s) in ${ORCHESTRATOR_SKILL_PATH}.\n`,
+  );
+  for (const d of drifts) {
+    console.error(
+      `  - "${d.target}" — referenced by row "${d.recommendationType}"`,
+    );
+    console.error(
+      `      Not bundled at ${PLUGIN_SKILLS_DIR}/${d.target}/SKILL.md`,
+    );
+    console.error(`      Not declared in ${OPTIONAL_COMPANIONS_PATH}`);
+  }
+  console.error(
+    `\nFix: either bundle the skill (add plugins/continuous-improvement/skills/<name>/SKILL.md ` +
+      `via the source skill + 'npm run build'), OR declare it in ${OPTIONAL_COMPANIONS_PATH} ` +
+      `with a pointer note in docs/audits/.`,
+  );
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-routing-targets.mjs")) {
+  main();
+}

--- a/src/test/check-routing-targets.test.mts
+++ b/src/test/check-routing-targets.test.mts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  checkRoutingTargets,
+  discoverBundledSkills,
+  extractRoutingTargets,
+  loadOptionalCompanions,
+} from "../bin/check-routing-targets.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-routing-targets.mjs");
+const PLUGIN_SKILLS = "plugins/continuous-improvement/skills";
+
+function setupRepo(): string {
+  const root = mkdtempSync(join(tmpdir(), "routing-targets-test-"));
+  mkdirSync(join(root, PLUGIN_SKILLS), { recursive: true });
+  mkdirSync(join(root, "skills"), { recursive: true });
+  return root;
+}
+
+function writeBundled(root: string, name: string): void {
+  const dir = join(root, PLUGIN_SKILLS, name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`);
+}
+
+function writeOrchestrator(root: string, tableRows: string[]): void {
+  const body = [
+    "# Proceed With The Recommendation",
+    "",
+    "## Phase 3 — Route",
+    "",
+    "### Routing Table (with Inline Fallbacks)",
+    "",
+    "| Recommendation type | Preferred skill | Inline fallback |",
+    "|---|---|---|",
+    ...tableRows,
+    "",
+    "## Phase 4 — Verify",
+    "",
+    "Smallest check that proves correctness.",
+    "",
+  ].join("\n");
+  writeFileSync(
+    join(root, "skills", "proceed-with-the-recommendation.md"),
+    body,
+  );
+}
+
+function writeOptionalCompanions(root: string, companions: string[]): void {
+  writeFileSync(
+    join(root, "optional-companions.json"),
+    JSON.stringify(
+      {
+        _doc: "test fixture",
+        optional_companions: companions,
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+describe("check-routing-targets — parser", () => {
+  it("extracts every backtick-quoted token from the Preferred skill column", () => {
+    const md = [
+      "### Routing Table (with Inline Fallbacks)",
+      "",
+      "| Recommendation type | Preferred skill | Inline fallback |",
+      "|---|---|---|",
+      "| One target | `alpha` | inline |",
+      "| Two targets | `beta` or `gamma` | inline |",
+      "| Sub-skill notation | `superpowers:writing-plans` | inline |",
+      "",
+      "## Next Section",
+      "",
+    ].join("\n");
+    const targets = extractRoutingTargets(md);
+    assert.deepEqual(
+      targets.map((t) => t.target),
+      ["alpha", "beta", "gamma", "superpowers:writing-plans"],
+    );
+  });
+
+  it("stops parsing at the next ## or ### header", () => {
+    const md = [
+      "### Routing Table (with Inline Fallbacks)",
+      "",
+      "| col1 | col2 | col3 |",
+      "|---|---|---|",
+      "| Real row | `alpha` | inline |",
+      "",
+      "### Some Other Subsection",
+      "",
+      "| Recommendation type | Preferred skill | Inline fallback |",
+      "|---|---|---|",
+      "| Should NOT be parsed | `noise` | inline |",
+    ].join("\n");
+    const targets = extractRoutingTargets(md);
+    assert.deepEqual(
+      targets.map((t) => t.target),
+      ["alpha"],
+    );
+  });
+
+  it("throws when the routing-table section header is missing", () => {
+    assert.throws(
+      () => extractRoutingTargets("# A skill\n\nNo routing table here.\n"),
+      /Routing-table section header not found/,
+    );
+  });
+
+  it("ignores backtick tokens in the Inline fallback column", () => {
+    const md = [
+      "### Routing Table (with Inline Fallbacks)",
+      "",
+      "| col1 | col2 | col3 |",
+      "|---|---|---|",
+      "| Row A | `alpha` | edit `~/.claude/settings.json` then restart |",
+      "",
+    ].join("\n");
+    const targets = extractRoutingTargets(md);
+    assert.deepEqual(
+      targets.map((t) => t.target),
+      ["alpha"],
+    );
+  });
+});
+
+describe("check-routing-targets — invariant", () => {
+  it("returns zero drifts when every target is either bundled or declared optional", () => {
+    const root = setupRepo();
+    try {
+      writeBundled(root, "alpha");
+      writeOrchestrator(root, [
+        "| Bundled row | `alpha` | inline |",
+        "| Optional row | `beta` | inline |",
+      ]);
+      writeOptionalCompanions(root, ["beta"]);
+      const result = checkRoutingTargets(root);
+      assert.equal(result.drifts.length, 0);
+      assert.equal(result.targets.length, 2);
+      assert.equal(result.bundledCount, 1);
+      assert.equal(result.optionalCount, 1);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a target that is neither bundled nor declared optional", () => {
+    const root = setupRepo();
+    try {
+      writeBundled(root, "alpha");
+      writeOrchestrator(root, [
+        "| Bundled row | `alpha` | inline |",
+        "| Unknown row | `gamma` | inline |",
+      ]);
+      writeOptionalCompanions(root, []);
+      const result = checkRoutingTargets(root);
+      assert.equal(result.drifts.length, 1);
+      assert.equal(result.drifts[0].target, "gamma");
+      assert.equal(result.drifts[0].recommendationType, "Unknown row");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("treats bundled and bare-namespace as exact-match (does not auto-resolve sub-skills)", () => {
+    const root = setupRepo();
+    try {
+      writeBundled(root, "superpowers");
+      writeOrchestrator(root, [
+        "| Sub-skill row | `superpowers:writing-plans` | inline |",
+      ]);
+      writeOptionalCompanions(root, []);
+      const result = checkRoutingTargets(root);
+      assert.equal(result.drifts.length, 1);
+      assert.equal(result.drifts[0].target, "superpowers:writing-plans");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("loadOptionalCompanions throws on a malformed companions file", () => {
+    const root = setupRepo();
+    try {
+      writeFileSync(
+        join(root, "optional-companions.json"),
+        JSON.stringify({ wrong_key: [] }),
+      );
+      assert.throws(() => loadOptionalCompanions(root), /missing or non-array/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("discoverBundledSkills returns an empty set when the plugin skills dir is missing", () => {
+    const root = mkdtempSync(join(tmpdir(), "routing-targets-empty-"));
+    try {
+      assert.equal(discoverBundledSkills(root).size, 0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-routing-targets — CLI", () => {
+  it("exits 0 with OK message on a clean synthetic repo", () => {
+    const root = setupRepo();
+    try {
+      writeBundled(root, "alpha");
+      writeOrchestrator(root, [
+        "| Bundled row | `alpha` | inline |",
+        "| Optional row | `beta` | inline |",
+      ]);
+      writeOptionalCompanions(root, ["beta"]);
+      const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      assert.match(
+        out,
+        /OK routing-targets: all 2 routing target\(s\) accounted for/,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("exits 1 with FAIL message on a drifted synthetic repo", () => {
+    const root = setupRepo();
+    try {
+      writeBundled(root, "alpha");
+      writeOrchestrator(root, [
+        "| Unknown row | `gamma` | inline |",
+      ]);
+      writeOptionalCompanions(root, []);
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(
+          e.stderr ?? "",
+          /FAIL routing-targets: 1 unaccounted target/,
+        );
+        assert.match(e.stderr ?? "", /"gamma"/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero on drift");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-routing-targets — live repo", () => {
+  it("verifies the live repo has zero unaccounted routing targets", () => {
+    const result = checkRoutingTargets(REPO_ROOT);
+    assert.equal(
+      result.drifts.length,
+      0,
+      `live repo has unaccounted routing targets: ${JSON.stringify(result.drifts, null, 2)}`,
+    );
+  });
+});

--- a/test/check-routing-targets.test.mjs
+++ b/test/check-routing-targets.test.mjs
@@ -5,31 +5,22 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
-import {
-    checkRoutingTargets,
-    discoverBundledSkills,
-    extractRoutingTargets,
-    loadOptionalCompanions,
-} from "../bin/check-routing-targets.mjs";
-
+import { checkRoutingTargets, discoverBundledSkills, extractRoutingTargets, loadOptionalCompanions, } from "../bin/check-routing-targets.mjs";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const REPO_ROOT = join(__dirname, "..");
 const CHECKER = join(REPO_ROOT, "bin", "check-routing-targets.mjs");
 const PLUGIN_SKILLS = "plugins/continuous-improvement/skills";
-
 function setupRepo() {
     const root = mkdtempSync(join(tmpdir(), "routing-targets-test-"));
     mkdirSync(join(root, PLUGIN_SKILLS), { recursive: true });
     mkdirSync(join(root, "skills"), { recursive: true });
     return root;
 }
-
 function writeBundled(root, name) {
     const dir = join(root, PLUGIN_SKILLS, name);
     mkdirSync(dir, { recursive: true });
     writeFileSync(join(dir, "SKILL.md"), `# ${name}\n`);
 }
-
 function writeOrchestrator(root, tableRows) {
     const body = [
         "# Proceed With The Recommendation",
@@ -49,14 +40,12 @@ function writeOrchestrator(root, tableRows) {
     ].join("\n");
     writeFileSync(join(root, "skills", "proceed-with-the-recommendation.md"), body);
 }
-
 function writeOptionalCompanions(root, companions) {
     writeFileSync(join(root, "optional-companions.json"), JSON.stringify({
         _doc: "test fixture",
         optional_companions: companions,
     }, null, 2));
 }
-
 describe("check-routing-targets — parser", () => {
     it("extracts every backtick-quoted token from the Preferred skill column", () => {
         const md = [
@@ -72,12 +61,8 @@ describe("check-routing-targets — parser", () => {
             "",
         ].join("\n");
         const targets = extractRoutingTargets(md);
-        assert.deepEqual(
-            targets.map((t) => t.target),
-            ["alpha", "beta", "gamma", "superpowers:writing-plans"],
-        );
+        assert.deepEqual(targets.map((t) => t.target), ["alpha", "beta", "gamma", "superpowers:writing-plans"]);
     });
-
     it("stops parsing at the next ## or ### header", () => {
         const md = [
             "### Routing Table (with Inline Fallbacks)",
@@ -95,14 +80,9 @@ describe("check-routing-targets — parser", () => {
         const targets = extractRoutingTargets(md);
         assert.deepEqual(targets.map((t) => t.target), ["alpha"]);
     });
-
     it("throws when the routing-table section header is missing", () => {
-        assert.throws(
-            () => extractRoutingTargets("# A skill\n\nNo routing table here.\n"),
-            /Routing-table section header not found/,
-        );
+        assert.throws(() => extractRoutingTargets("# A skill\n\nNo routing table here.\n"), /Routing-table section header not found/);
     });
-
     it("ignores backtick tokens in the Inline fallback column", () => {
         const md = [
             "### Routing Table (with Inline Fallbacks)",
@@ -116,7 +96,6 @@ describe("check-routing-targets — parser", () => {
         assert.deepEqual(targets.map((t) => t.target), ["alpha"]);
     });
 });
-
 describe("check-routing-targets — invariant", () => {
     it("returns zero drifts when every target is either bundled or declared optional", () => {
         const root = setupRepo();
@@ -137,7 +116,6 @@ describe("check-routing-targets — invariant", () => {
             rmSync(root, { recursive: true, force: true });
         }
     });
-
     it("flags a target that is neither bundled nor declared optional", () => {
         const root = setupRepo();
         try {
@@ -156,7 +134,6 @@ describe("check-routing-targets — invariant", () => {
             rmSync(root, { recursive: true, force: true });
         }
     });
-
     it("treats bundled and bare-namespace as exact-match (does not auto-resolve sub-skills)", () => {
         const root = setupRepo();
         try {
@@ -173,7 +150,6 @@ describe("check-routing-targets — invariant", () => {
             rmSync(root, { recursive: true, force: true });
         }
     });
-
     it("loadOptionalCompanions throws on a malformed companions file", () => {
         const root = setupRepo();
         try {
@@ -184,7 +160,6 @@ describe("check-routing-targets — invariant", () => {
             rmSync(root, { recursive: true, force: true });
         }
     });
-
     it("discoverBundledSkills returns an empty set when the plugin skills dir is missing", () => {
         const root = mkdtempSync(join(tmpdir(), "routing-targets-empty-"));
         try {
@@ -195,7 +170,6 @@ describe("check-routing-targets — invariant", () => {
         }
     });
 });
-
 describe("check-routing-targets — CLI", () => {
     it("exits 0 with OK message on a clean synthetic repo", () => {
         const root = setupRepo();
@@ -213,7 +187,6 @@ describe("check-routing-targets — CLI", () => {
             rmSync(root, { recursive: true, force: true });
         }
     });
-
     it("exits 1 with FAIL message on a drifted synthetic repo", () => {
         const root = setupRepo();
         try {
@@ -240,14 +213,9 @@ describe("check-routing-targets — CLI", () => {
         }
     });
 });
-
 describe("check-routing-targets — live repo", () => {
     it("verifies the live repo has zero unaccounted routing targets", () => {
         const result = checkRoutingTargets(REPO_ROOT);
-        assert.equal(
-            result.drifts.length,
-            0,
-            `live repo has unaccounted routing targets: ${JSON.stringify(result.drifts, null, 2)}`,
-        );
+        assert.equal(result.drifts.length, 0, `live repo has unaccounted routing targets: ${JSON.stringify(result.drifts, null, 2)}`);
     });
 });


### PR DESCRIPTION
## Summary

PR #69 (the routing-target build invariant) shipped `bin/check-routing-targets.mjs` and `test/check-routing-targets.test.mjs` **without** corresponding `src/**/*.mts` sources. The `.mjs` files survive on `main` because tsc never deletes — but they violate the convention: every other `check-*` invariant in this repo has its source at `src/bin/check-*.mts` and `src/test/check-*.test.mts`, with the `.mjs` regenerated by tsc.

This PR closes the gap.

## Why this matters

Three triggers would silently lose the routing-target invariant on its current shape:
1. `npm run clean` deletes every `.mjs` in `bin/`, `lib/`, `test/`.
2. A future `tsc -p tsconfig.json` rebuild won't restore the `.mjs` without an `.mts`.
3. Anyone editing the routing-target check would expect to find the source under `src/` per repo convention.

## What this PR does

- `src/bin/check-routing-targets.mts`: TypeScript source (mirrors `src/bin/check-skill-mirror.mts` style — 2-space indent, exported interfaces, type annotations).
- `src/test/check-routing-targets.test.mts`: TypeScript test source.
- `bin/check-routing-targets.mjs`: regenerated by tsc (formatting-only delta vs `main` — one-line `if`s expanded, blank-line stripping in module body — no behavior change).
- `test/check-routing-targets.test.mjs`: regenerated by tsc (same kind of reformat).

## Verification

Locally in the worktree:
- `npm install` (3 packages, ~700ms)
- `npm run build` succeeds (`tsc` then `node bin/generate-plugin-manifests.mjs`)
- `node --test test/check-routing-targets.test.mjs` → **12/12 passing**

The CI gate that caught PR #66 (`git diff --exit-code -- bin test`) should pass: any future `npm run build` regenerates the same `.mjs` content this PR commits.

## Drift flagged for follow-up (NOT touched in this PR)

`package-lock.json` on `main` is at version `3.3.0` while `package.json` is at `3.6.0`. `npm install` regenerates the lock to `3.6.0`. This is a stale-lockfile bug independent of this PR — `npm ci` would fail in a fresh checkout. Worth a separate single-concern PR to bump the lock to match. I left it out per the no-drive-by-fixes rule.

## Test plan

- [ ] CI: all three Node matrix jobs (18, 20, 22) pass
- [ ] Re-run `npm run build` on a fresh checkout of this branch and confirm zero `git diff` in `bin/` and `test/`
- [ ] `node bin/check-routing-targets.mjs` exits 0 with `OK routing-targets: all 21 ...`
- [ ] `node --test test/check-routing-targets.test.mjs` passes 12/12