### PR TITLE
chore(repo): pin LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,51 @@
+# Force LF line endings for all text files in the repo, regardless of the
+# contributor's autocrlf setting. Without this, every Windows checkout converts
+# LF to CRLF on disk and `git status` shows tens of unmodified files as "M",
+# making explicit-stage workflows noisy and easy to mis-stage.
+#
+# `text=auto` lets git detect text vs binary; `eol=lf` forces LF in the working
+# tree on every platform. Explicit per-extension rules below pin the most
+# common file types so detection cannot drift.
+
+* text=auto eol=lf
+
+# Source code — always LF in working tree.
+*.mts        text eol=lf
+*.mjs        text eol=lf
+*.ts         text eol=lf
+*.js         text eol=lf
+*.cjs        text eol=lf
+*.json       text eol=lf
+*.jsonl      text eol=lf
+*.md         text eol=lf
+*.yml        text eol=lf
+*.yaml       text eol=lf
+*.toml       text eol=lf
+*.css        text eol=lf
+*.html       text eol=lf
+*.svg        text eol=lf
+
+# Shell + scripts — must stay LF or they break on Linux runners and CI.
+*.sh         text eol=lf
+*.bash       text eol=lf
+*.zsh        text eol=lf
+
+# Binaries — never normalize.
+*.png        binary
+*.jpg        binary
+*.jpeg       binary
+*.gif        binary
+*.webp       binary
+*.ico        binary
+*.pdf        binary
+*.zip        binary
+*.gz         binary
+*.tar        binary
+*.tgz        binary
+*.woff       binary
+*.woff2      binary
+*.ttf        binary
+*.eot        binary
+*.mp4        binary
+*.mp3        binary
+*.wav        binary


### PR DESCRIPTION
## Summary

Adds the missing root `.gitattributes` so Windows checkouts stop creating phantom CRLF "modifications" after every `npm run build`. Pins every text file to LF in the working tree on all platforms via `* text=auto eol=lf`, with explicit per-extension rules and a binary list so detection cannot drift.

## Why this lands

On this host (Windows + autocrlf) every `node bin/generate-plugin-manifests.mjs` regenerates 8 unrelated files with content-identical output that show up as `M` in `git status` (LF→CRLF on disk). Across this session alone the noise touched PRs #66, #68, #73, #74 — every PR had to manually filter `git diff --stat` (real changes) from `git status` (phantom drift). This PR kills the tax permanently.

## Verification

```
$ git check-attr -a bin/check-routing-targets.mjs README.md skills/proceed-with-the-recommendation.md
bin/check-routing-targets.mjs: text: set
bin/check-routing-targets.mjs: eol: lf
README.md: text: set
README.md: eol: lf
skills/proceed-with-the-recommendation.md: text: set
skills/proceed-with-the-recommendation.md: eol: lf
```

`git status` after staging shows only the new `.gitattributes` — no existing file got renormalized as part of this PR.

## Drift flagged for follow-up (NOT touched in this PR)

If contributors start seeing phantom line-ending diffs on touched files after this lands, that's the signal to ship a separate single-concern renormalization PR:

```
git add --renormalize .
git commit -m "chore(repo): renormalize line endings to LF"
```

Kept out of this PR because that command stages every text file in the repo, which would make the diff impossible to review and would conflict with the `git add . / -A` guardrail used on this host.

## What this PR does NOT do

- No content changes to any source file
- No edits to `.gitignore`, `.editorconfig`, or any other repo-config file
- No CI workflow changes
- No working-tree renormalization

## Test plan

- [ ] Merge, then on a fresh Windows checkout: run `npm install && npm run build` and confirm `git status` is clean (no phantom CRLF drift)
- [ ] On Linux/Mac: run `npm run build` and confirm no behavior change
- [ ] Check that binary assets in `assets/` (gif/png) are still byte-identical after a checkout