### PR TITLE
docs(release): adopt v3 float-tag convention and codify retarget policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -183,6 +183,33 @@ Every bundled skill, command, and hook enforces at least one of the 7 Laws. Use 
 
 The lint `verify:skill-law-tag` (run by `verify:all`) blocks any new skill whose `description:` does not start with `Enforces Law N`, so this table has a mechanical companion that prevents drift.
 
+## Release
+
+### Float-tag policy (`v3`, `v4`, ...)
+
+The `v3` lightweight tag is a floating major-version pointer used by GitHub Action consumers (`naimkatiman/continuous-improvement@v3`). It must be retargeted to the latest published `v3.x.y` tag on every minor or patch release.
+
+```bash
+# After tagging and publishing the GitHub Release for v3.X.Y:
+git tag -f v3 v3.X.Y
+git push origin v3 --force
+```
+
+The force-push is intentional and only applies to the floating tag — never to `vX.Y.Z` pinned tags or to branches. Consumers using `@v3.6.0` are unaffected; only `@v3` consumers see the new code on their next `actions/checkout`. This matches the actions/checkout, actions/setup-node, etc. ecosystem convention.
+
+If you cut a new major version (e.g. `v4.0.0`), create a fresh `v4` floating tag rather than retargeting `v3` — the float tag tracks the *current* major, never the *latest* across majors. This preserves the SemVer guarantee that `@v3` stays breaking-change-safe for as long as the v3 line is supported.
+
+### Release checklist
+
+1. Bump version in `package.json`, `plugins/continuous-improvement/.claude-plugin/plugin.json`, and `.claude-plugin/marketplace.json` + `plugins/continuous-improvement/.claude-plugin/marketplace.json`.
+2. Add the new section to `CHANGELOG.md`.
+3. Run `npm run verify:all` and `npm test`.
+4. Commit on a release branch, open PR, merge to `main`.
+5. Tag the merge commit: `git tag vX.Y.Z` and `git push origin vX.Y.Z`.
+6. Publish the GitHub Release with `gh release create vX.Y.Z --notes-file <changelog-section>` (or via the web UI).
+7. **Retarget the float tag** per the policy above.
+8. `npm publish` once the GitHub Release is live.
+
 ## License
 
 By contributing, you agree that your contributions will be licensed under the MIT License.

--- a/README.md
+++ b/README.md
@@ -285,11 +285,13 @@ A new skill is a fit if it provably enforces (or is a routed activator for) at l
 Lint agent behavior in CI. Detects skipped laws.
 
 ```yaml
-- uses: naimkatiman/continuous-improvement@v3.6.0
+- uses: naimkatiman/continuous-improvement@v3
   with:
     transcript-path: agent-log.jsonl
     strict: true
 ```
+
+`@v3` is a floating major-version tag that retargets on every `v3.x.y` release. Pin to a specific tag (`@v3.6.0`) if you need byte-reproducible CI; use `@v3` to ride patch and minor bumps automatically. See [CONTRIBUTING.md § Release](CONTRIBUTING.md#release) for the retarget policy.
 
 Catches: writes without prior research (Law 1), too many edits without verification (Law 3), code changes without tests/builds (Law 4), too many files at once (Law 6). Run locally with `node bin/lint-transcript.mjs <file>`.
 


### PR DESCRIPTION
## Summary

Now that the `v3` floating tag exists at the v3.6.0 commit, this PR makes the convention real in the docs and codifies the policy that keeps it accurate.

- **README.md**: revert the GitHub Action snippet from `@v3.6.0` back to `@v3` to model the recommended pattern. Adds a one-line note that pinned `@v3.6.0` is still valid for consumers who want byte-reproducible CI, with a pointer to the retarget policy in CONTRIBUTING.md.
- **CONTRIBUTING.md**: new `## Release` section. Documents:
  - Float-tag policy with the exact retarget commands (`git tag -f v3 v3.X.Y` + `git push origin v3 --force`) and why the force-push is acceptable in this specific case (only applies to floating tags, never to pinned `vX.Y.Z` tags or branches)
  - Major-bump rule (cut a fresh `v4` floating tag, never retarget `v3` across majors)
  - Release checklist that ties float-tag retargeting in as step 7 so future maintainers do not forget it

Single concern: float-tag convention. README models the pattern; CONTRIBUTING codifies the policy. No other documentation or source files touched.

## Test plan

- [x] `npm run verify:docs-substrings` — passes (114/114 substring assertions)
- [x] `npm run verify:routing-targets` — passes (21/21 routing targets)
- [x] Spot-check the new CONTRIBUTING.md anchor `#release` resolves from the README link
- [ ] Maintainer to confirm the release checklist matches their actual flow (especially step 8: `npm publish` order vs GitHub Release order)