### PR TITLE
chore(third-party): vendor ruvnet/ruflo (ruflo-swarm slice) @ addb5cd

### DIFF
--- a/docs/plans/2026-05-07-ruflo-swarm-vendor.md
+++ b/docs/plans/2026-05-07-ruflo-swarm-vendor.md
@@ -1,0 +1,114 @@
+# 2026-05-07 — Vendor `ruvnet/ruflo` `plugins/ruflo-swarm/` slice to `third-party/ruflo-swarm/`
+
+Plan for the second Superpowers-framework chain of the day: worktree → plan → verify → vendor → review → finish-branch → PR. Single-concern PR. No integration in this PR.
+
+## Goal
+
+Cold-storage snapshot of one plugin slice from upstream `ruvnet/ruflo` — specifically `plugins/ruflo-swarm/` — at `third-party/ruflo-swarm/`. This addresses the explicit agent-orchestration / agent-swarm gap the user identified ("the gap like agent ochestration and agent swarm from ruflo").
+
+This snapshot is **not loaded** by `plugins/continuous-improvement/`, **not registered** in `.claude-plugin/marketplace.json`, **not** wired into hooks. Same cold-storage policy as `third-party/superpowers/`, `third-party/oh-my-claudecode/`, and the just-merged `third-party/addy-agent-skills/`.
+
+## Why this slice, not the whole monorepo
+
+`ruvnet/ruflo` is a 32-plugin monorepo (~5 MB+ with media, MCP servers, TS source, neural-trader, market-data, IoT, federation, etc.). Vendoring all of it would:
+
+- Pull in 30+ plugins we have no current need for (high blast radius, low signal).
+- Compete directly with our 7 Laws and continuous-improvement learning systems (`ruflo-autopilot`, `ruflo-intelligence`, `ruflo-loop-workers`, `ruflo-rag-memory`, `ruflo-agentdb`, `ruflo-rvf` all overlap).
+- Bring in non-Claude vendor adapters and TypeScript build state we have explicitly excluded from prior snapshots.
+
+Cherry-picking `ruflo-swarm` only:
+
+- Surface area is ~9 files (2 agents + 2 commands + 2 skills + 1 ADR + 1 smoke script + README + plugin.json), ~30 KB.
+- Directly addresses the stated gap: agent-team coordination, Monitor stream-based observation, worktree isolation patterns.
+- Is parallel-readable against `superpowers:dispatching-parallel-agents` (Obra), our existing parallel-agent dispatch surface — not a replacement, an alternate take.
+- Stays inside our cold-storage discipline.
+
+Snapshot path is `third-party/ruflo-swarm/`, **not** `third-party/ruflo/`. The name reflects what was vendored. Anyone reading the path should not infer that the full monorepo lives here.
+
+## Pinned SHA
+
+`ruvnet/ruflo` @ `addb5cd3f30c4e9eef9b25084419bd1c5015e169` (2026-05-06T22:28:37Z, default branch `main`). Note: HEAD is a 3.7.0-alpha hotfix commit, but the `plugins/ruflo-swarm/` slice we're copying is content-stable across recent SHAs.
+
+## Selective scope (verbatim from upstream)
+
+Only the `plugins/ruflo-swarm/` subtree from upstream is vendored, plus the repo-root `LICENSE` for attribution.
+
+- `README.md` — plugin overview
+- `.claude-plugin/plugin.json` — plugin manifest (read-only; not registered in our marketplace)
+- `agents/architect.md`, `agents/coordinator.md` — 2 agent definitions
+- `commands/swarm.md`, `commands/watch.md` — 2 commands
+- `skills/swarm-init/SKILL.md`, `skills/monitor-stream/SKILL.md` — 2 skills
+- `docs/adrs/0001-swarm-contract.md` — architecture decision record
+- `scripts/smoke.sh` — smoke test script
+- `LICENSE` (MIT, ruvnet 2024-2026) — copied from repo root because the plugin slice has no own LICENSE; required for MIT attribution
+
+## Excluded from snapshot
+
+- The other 31 ruflo plugins (`ruflo-core`, `ruflo-loop-workers`, `ruflo-autopilot`, `ruflo-intelligence`, `ruflo-rag-memory`, `ruflo-agentdb`, etc.) — out of scope; cherry-pick discipline.
+- `ruflo/` runtime, `bin/`, `package.json`, `package-lock.json`, `tsconfig.json`, `tests/`, `archive/`, `verification.md`, `verification-results.md`, `verification-inventory.json`, `ruflo-plugins.gif` (~5.5 MB) — runtime/build state, not vendor scope.
+- `.claude/`, `.agents/`, `.githooks/`, `.github/`, `.gitignore`, `.npmignore` — repo metadata.
+- Root `CLAUDE.md`, `CLAUDE.local.md`, `AGENTS.md` (top level) — auto-load contamination risk; the plugin's own files don't include these.
+- Top-level `README.md`, `CHANGELOG.md`, `SECURITY.md` — not the plugin's; the plugin has its own README.md.
+
+## Carried-in negative prompts (P-MAG Rule 3)
+
+> Will NOT repeat: collapsing Obra and CI superpowers — `ruflo-swarm` is its own snapshot, parallel to obra/superpowers, oh-my-claudecode, and addy-agent-skills. Four distinct snapshots. None bundled, none loaded.
+>
+> Will NOT repeat: vendoring the full monorepo when the user asked for one plugin. Scope is `plugins/ruflo-swarm/` only; the plan and OUR_NOTES.md explicitly call out the 31 excluded plugins so future readers don't think this is a partial copy of the whole.
+>
+> Will NOT repeat: `git add .` / `-A` — every snapshot file is staged by explicit path. Lockfile drift from `npm install` (if any) is discarded before stage.
+>
+> Will NOT repeat: bundled concerns — vendoring (this PR) ships alone. The `bin/refresh-third-party.mjs` driver SNAPSHOTS entry remains parked (deferred follow-up #1) until either ruflo-swarm or a 4th-snapshot trigger makes it load-bearing.
+>
+> Will NOT repeat: claiming integration. This PR vendors. Integration of any specific idea (e.g., porting a swarm pattern into our `dispatching-parallel-agents` flow) is its own future single-concern PR.
+
+## Step plan
+
+| Step | Action | Verification |
+|---|---|---|
+| 1 | Worktree `third-party/ruflo-swarm` off `origin/main@4a6727c` | `git worktree list` + clean status |
+| 2 | This plan doc | merged into the same single-concern PR |
+| 3 (baseline) | `npm run typecheck` + `npm run test` on clean main inside worktree | both green before any vendor add |
+| 4a | Shallow-clone upstream, verify HEAD matches pinned SHA, copy `plugins/ruflo-swarm/` subtree verbatim, copy repo-root `LICENSE`, strip every `CLAUDE.md` inside snapshot | `find third-party/ruflo-swarm -name CLAUDE.md` returns empty |
+| 4b | Append `### ruvnet/ruflo (plugins/ruflo-swarm slice)` block to `third-party/MANIFEST.md` (SHA, scope, recipe, exclusions) | manual diff vs. addy/obra/OMC entries — same shape |
+| 4c | Author `third-party/ruflo-swarm/OUR_NOTES.md` (overlap matrix vs. Obra `dispatching-parallel-agents` and our `/loop`, integration candidates, NOT-integrated banner, refresh pointer) | matches OUR_NOTES.md shape |
+| 5 (verify-after) | `npm run typecheck` + `npm run test` again | both green after vendor add |
+| 6 | code-reviewer + security-reviewer agents in parallel on the worktree diff | review reports attached to PR |
+| 7 | finishing-a-development-branch — squash-merge ready check, ahead-of-origin baseline check, no drive-by changes | branch ready for single squash commit |
+| 8 | Open PR vs `main` — `chore(third-party): vendor ruvnet/ruflo (ruflo-swarm slice) @ addb5cd` | single concern, MANIFEST pinned, OUR_NOTES.md populated |
+
+## Integration candidates (recorded here, NOT acted on in this PR)
+
+These are the surfaces in `ruflo-swarm` most likely to inform a future port. Each port is a separate single-concern PR, only after a concrete user-pain trigger:
+
+| Upstream surface | Gap in our 7 Laws | Trigger to port |
+|---|---|---|
+| `agents/coordinator.md` | We dispatch parallel agents via `superpowers:dispatching-parallel-agents` but have no explicit coordinator role with a stage-pipeline contract | A workflow needing typed stage hand-off (plan → exec → verify) where a single Claude session can't keep all stages in head |
+| `agents/architect.md` | Our `architect` is a built-in subagent; ruflo-swarm's is shaped specifically for swarm contracts | A plan-doc that requires structural ADR output before delegation |
+| `commands/swarm.md` | No equivalent slash command for fanning out a single objective across N specialized roles | A repeated user request to "run this 3 ways in parallel" that today is hand-rolled per session |
+| `commands/watch.md` + `skills/monitor-stream/` | Our agents return one final result; we have no streamed-progress observation surface | A user reporting that long agent runs feel opaque; Monitor stream pattern would close the loop |
+| `skills/swarm-init/` | Initialization contract for a multi-agent run (worktrees, base ref, role list) | Repeated need to bootstrap a parallel-agent run; today this is freehand |
+
+## Deferred follow-ups (explicit list, NOT in this PR)
+
+- **#1 (carried over)** — `bin/refresh-third-party.mjs` SNAPSHOTS entry. Now covers two parked snapshots (addy + ruflo-swarm). Re-evaluate trigger: when a 4th snapshot lands, OR when an upstream refresh fails because the recipe drifted from the driver. Separate PR.
+- **#2 (carried over)** — Generic third-party shape invariant (every `third-party/<name>/` has `OUR_NOTES.md`, `LICENSE`, matching `### <heading>` row in `MANIFEST.md` with 40-char SHA). Re-evaluate trigger: 4 snapshots is the threshold per the prior plan. With this PR we hit 4 (oh-my-claudecode, superpowers, addy-agent-skills, ruflo-swarm). Re-assess after this lands.
+- **#3 — Port a specific swarm idea into our `dispatching-parallel-agents` workflow.** Held until a concrete user-pain trigger from the candidates table above.
+
+## Risks
+
+- **License posture.** Upstream is MIT (Copyright 2024-2026 ruvnet). Files copied verbatim; annotations only in sibling `OUR_NOTES.md`. Repo-root `LICENSE` copied to the snapshot path because the plugin slice has no own LICENSE. Standard MIT attribution.
+- **CLAUDE.md leakage.** Upstream ships `CLAUDE.md`, `CLAUDE.local.md`, and a top-level `AGENTS.md` (~21 KB) at the repo root. None are inside `plugins/ruflo-swarm/` so the subtree copy will not pull them. Post-copy `find ... -name CLAUDE.md -delete` runs anyway as a safety belt.
+- **Misleading snapshot path.** Anyone scanning `third-party/ruflo-swarm/` could assume the full ruflo monorepo lives here. Mitigation: `OUR_NOTES.md` opens with a "this is ONE plugin from a 32-plugin monorepo" disclaimer.
+- **Drift across snapshots.** Refresh cadence (first business day of each month) applies. Recorded in MANIFEST.md.
+- **Plugin overlap with Obra/CI.** `coordinator.md`, `architect.md`, `swarm.md`, `monitor-stream/`, `swarm-init/` all overlap with surfaces in `superpowers:dispatching-parallel-agents` and our continuous-improvement loop. Cold-storage is safe; integration would require explicit conflict resolution per the OUR_NOTES.md matrix.
+
+## Out of scope (explicit)
+
+- The other 31 ruflo plugins (`ruflo-core`, `ruflo-loop-workers`, `ruflo-autopilot`, `ruflo-intelligence`, `ruflo-rag-memory`, `ruflo-agentdb`, `ruflo-cost-tracker`, `ruflo-adr`, `ruflo-aidefence`, `ruflo-browser`, `ruflo-jujutsu`, `ruflo-wasm`, `ruflo-workflows`, `ruflo-daa`, `ruflo-ruvllm`, `ruflo-rvf`, `ruflo-plugin-creator`, `ruflo-goals`, `ruflo-cost-tracker`, `ruflo-ddd`, `ruflo-federation`, `ruflo-iot-cognitum`, `ruflo-knowledge-graph`, `ruflo-market-data`, `ruflo-migrations`, `ruflo-neural-trader`, `ruflo-observability`, `ruflo-ruvector`, `ruflo-sparc`, `ruflo-security-audit`, `ruflo-testgen`)
+- The ruflo runtime (`ruflo/`, `bin/`, `package.json`)
+- Driver integration in `bin/refresh-third-party.mjs` (deferred #1)
+- Generic third-party shape invariant check (deferred #2)
+- Any port of ruflo-swarm content into `skills/`, `agents/`, `commands/`, or `plugins/continuous-improvement/`
+- Any registration of ruflo-swarm in our `.claude-plugin/marketplace.json`
+- Any edits to upstream files beyond `find -name CLAUDE.md -delete` post-copy

--- a/third-party/MANIFEST.md
+++ b/third-party/MANIFEST.md
@@ -177,6 +177,65 @@ find third-party/addy-agent-skills -name CLAUDE.md -type f -delete
 
 > **Driver integration deferred.** Adding an `addy-agent-skills` SNAPSHOTS entry to `bin/refresh-third-party.mjs` is tracked as a follow-up PR — see `docs/plans/2026-05-07-addy-agent-skills-vendor.md` § "Deferred follow-ups". The recipe above is the source of truth in the meantime.
 
+### ruvnet/ruflo (plugins/ruflo-swarm slice)
+
+| Field | Value |
+|---|---|
+| Upstream | https://github.com/ruvnet/ruflo |
+| License | MIT |
+| Pinned SHA | `addb5cd3f30c4e9eef9b25084419bd1c5015e169` |
+| Snapshot date | 2026-05-07 |
+| Snapshot size | ~36 KB, 11 files |
+| Upstream version at SHA | 3.7.0-alpha.11 (monorepo); plugin slice `ruflo-swarm` |
+| Local path | `third-party/ruflo-swarm/` |
+
+Cherry-picked **single plugin** from a 32-plugin monorepo, addressing the agent-orchestration / agent-swarm gap. Cold-storage only — **not** loaded by `plugins/continuous-improvement/` and **not** registered in `.claude-plugin/marketplace.json`. Surface overlaps `superpowers:dispatching-parallel-agents` (Obra) and our `/loop`; the OUR_NOTES.md matrix records the per-asset comparison. The snapshot path is named `ruflo-swarm`, not `ruflo`, to make the cherry-pick scope explicit — readers should not assume the full monorepo lives here.
+
+**Selective scope (verbatim from upstream `plugins/ruflo-swarm/` subtree, plus repo-root LICENSE for attribution):**
+
+- `agents/architect.md`, `agents/coordinator.md` — 2 agent definitions
+- `commands/swarm.md`, `commands/watch.md` — 2 commands
+- `skills/swarm-init/SKILL.md`, `skills/monitor-stream/SKILL.md` — 2 skills
+- `docs/adrs/0001-swarm-contract.md` — 1 architecture decision record
+- `scripts/smoke.sh` — smoke test script
+- `.claude-plugin/plugin.json` — plugin manifest (read-only; not registered in our marketplace)
+- `README.md` — plugin overview
+- `LICENSE` — copied from upstream **repo root** (the plugin slice has no own LICENSE; required for MIT attribution)
+
+**Excluded from snapshot (not vendored):**
+
+- The other **31 ruflo plugins** (`ruflo-core`, `ruflo-loop-workers`, `ruflo-autopilot`, `ruflo-intelligence`, `ruflo-rag-memory`, `ruflo-agentdb`, `ruflo-cost-tracker`, `ruflo-adr`, `ruflo-aidefence`, `ruflo-browser`, `ruflo-jujutsu`, `ruflo-wasm`, `ruflo-workflows`, `ruflo-daa`, `ruflo-ruvllm`, `ruflo-rvf`, `ruflo-plugin-creator`, `ruflo-goals`, `ruflo-ddd`, `ruflo-federation`, `ruflo-iot-cognitum`, `ruflo-knowledge-graph`, `ruflo-market-data`, `ruflo-migrations`, `ruflo-neural-trader`, `ruflo-observability`, `ruflo-ruvector`, `ruflo-sparc`, `ruflo-security-audit`, `ruflo-testgen`, `ruflo-docs`) — out of cherry-pick scope.
+- The ruflo runtime, `ruflo/`, `bin/`, `package.json`, `package-lock.json`, `tsconfig.json`, `archive/`, `tests/`, `verification.md`, `verification-results.md`, `verification-inventory.json`, `ruflo-plugins.gif` (~5.5 MB).
+- `.claude/`, `.agents/`, `.githooks/`, `.github/`, `.gitignore`, `.npmignore` — repo metadata.
+- Root `CLAUDE.md`, `CLAUDE.local.md`, top-level `AGENTS.md` (~21 KB) — auto-load contamination risk; none live inside `plugins/ruflo-swarm/` so the subtree copy doesn't pull them. Post-copy `find -name CLAUDE.md -delete` runs anyway as a safety belt.
+- Top-level `README.md`, `CHANGELOG.md`, `SECURITY.md` — these are the monorepo's, not the plugin's (the plugin has its own `README.md` which IS vendored).
+
+**Refresh recipe:**
+
+```bash
+# 1. Pin the new SHA in this file under "Pinned SHA" above
+# 2. Shallow clone outside the repo
+git clone --depth 1 https://github.com/ruvnet/ruflo.git \
+  /tmp/ruflo-refresh
+git -C /tmp/ruflo-refresh rev-parse HEAD  # confirm matches Pinned SHA
+
+# 3. Wipe + re-copy the selective surface (plugin slice + repo-root LICENSE)
+rm -rf third-party/ruflo-swarm
+mkdir -p third-party/ruflo-swarm
+cp -r /tmp/ruflo-refresh/plugins/ruflo-swarm/. \
+  third-party/ruflo-swarm/
+cp /tmp/ruflo-refresh/LICENSE \
+  third-party/ruflo-swarm/
+
+# Remove every CLAUDE.md inside the snapshot — they auto-load as session context.
+find third-party/ruflo-swarm -name CLAUDE.md -type f -delete
+
+# 4. Single-concern commit:
+#    chore(third-party): refresh ruvnet/ruflo (ruflo-swarm slice) @ <new-sha>
+```
+
+> **Driver integration deferred.** Adding a `ruflo-swarm` SNAPSHOTS entry to `bin/refresh-third-party.mjs` is tracked as the same follow-up PR as `addy-agent-skills` — see `docs/plans/2026-05-07-ruflo-swarm-vendor.md` § "Deferred follow-ups". The recipe above is the source of truth in the meantime.
+
 ---
 
 ## Pending snapshots (not yet vendored — listed for transparency)

--- a/third-party/ruflo-swarm/.claude-plugin/plugin.json
+++ b/third-party/ruflo-swarm/.claude-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "ruflo-swarm",
+  "description": "Agent teams, swarm coordination, Monitor streams, and worktree isolation — wraps 4 swarm_* + 8 agent_* MCP tools (12 total) plus 6 topologies (hierarchical / mesh / hierarchical-mesh / ring / star / adaptive)",
+  "version": "0.2.0",
+  "author": {
+    "name": "ruvnet",
+    "url": "https://github.com/ruvnet"
+  },
+  "homepage": "https://github.com/ruvnet/ruflo",
+  "license": "MIT",
+  "keywords": [
+    "ruflo",
+    "swarm",
+    "agents",
+    "teams",
+    "monitor",
+    "mcp",
+    "topologies",
+    "worktree-isolation",
+    "monitor-stream"
+  ]
+}

--- a/third-party/ruflo-swarm/LICENSE
+++ b/third-party/ruflo-swarm/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024-2026 ruvnet
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third-party/ruflo-swarm/OUR_NOTES.md
+++ b/third-party/ruflo-swarm/OUR_NOTES.md
@@ -1,0 +1,78 @@
+# OUR_NOTES.md — ruflo-swarm (cherry-picked from ruvnet/ruflo)
+
+Our annotations on the vendored snapshot. Authored by us, not copied from upstream.
+
+## Read this first: this is ONE plugin from a 32-plugin monorepo
+
+`ruvnet/ruflo` is a 32-plugin monorepo. We vendored **only** the `plugins/ruflo-swarm/` slice. The other 31 plugins (`ruflo-core`, `ruflo-loop-workers`, `ruflo-autopilot`, `ruflo-intelligence`, `ruflo-rag-memory`, `ruflo-agentdb`, `ruflo-cost-tracker`, `ruflo-adr`, `ruflo-aidefence`, `ruflo-browser`, `ruflo-jujutsu`, `ruflo-wasm`, `ruflo-workflows`, `ruflo-daa`, `ruflo-ruvllm`, `ruflo-rvf`, `ruflo-plugin-creator`, `ruflo-goals`, `ruflo-ddd`, `ruflo-federation`, `ruflo-iot-cognitum`, `ruflo-knowledge-graph`, `ruflo-market-data`, `ruflo-migrations`, `ruflo-neural-trader`, `ruflo-observability`, `ruflo-ruvector`, `ruflo-sparc`, `ruflo-security-audit`, `ruflo-testgen`, `ruflo-docs`) are explicitly **out of scope**. They overlap heavily with our continuous-improvement learning systems and our 7 Laws plugin; pulling them in would collapse the very Obra-vs-CI distinction our session contract preserves.
+
+If you came here looking for ruflo's neural trader, RAG memory, swarm intelligence, federation, or any other plugin, install ruflo from upstream the normal way — do not assume any of it is here.
+
+## Why we vendored this slice
+
+The user identified a specific gap: **agent orchestration and agent swarm**. `ruflo-swarm` is the upstream surface that most directly addresses it — it ships agent-team coordination contracts, Monitor stream-based observation, and worktree isolation patterns. Vendoring as cold-storage lets us:
+
+- Read the swarm contracts side-by-side with `superpowers:dispatching-parallel-agents` (Obra) without round-trips.
+- Track upstream changes against pinned SHA.
+- Decide later, on a per-surface basis, whether to port any specific idea into our parallel-agent dispatch flow — explicitly, with attribution.
+
+## Status: NOT integrated
+
+This snapshot is **not loaded by `plugins/continuous-improvement/`**. It is **not registered in `.claude-plugin/marketplace.json`**. Users who want ruflo should install it from upstream the normal way (`/plugin marketplace add ruvnet/ruflo`) — and accept that doing so installs all 32 plugins and their MCP servers, which can collide with our learning system, our `/loop`, and our PARA memory.
+
+If you want to experiment locally with just `ruflo-swarm`, point Claude Code at this snapshot path directly — but understand that doing so installs upstream's hooks, agents, and skills, which will collide with our routing.
+
+## Activation hazards (INFO from security review)
+
+The snapshot is safe as cold-storage. The two items below are **inert while files are not loaded by Claude Code** — they only matter if a developer points Claude Code at this path.
+
+1. **Unpinned `npx @claude-flow/cli@latest` in every operational asset.** All five agent/skill/command files (`agents/{architect,coordinator}.md`, `commands/{swarm,watch}.md`, `skills/{swarm-init,monitor-stream}/SKILL.md`) instruct Claude to run `npx @claude-flow/cli@latest`. Activation would resolve `@latest` against whatever the npm dist-tag points to at runtime — supply-chain risk if the `@claude-flow/cli` package is ever compromised or shadowed by a typosquat. If we ever port any of these surfaces, pin to a specific version at port time.
+2. **`mcp__claude-flow__*` tools in `allowed-tools` frontmatter.** Activation would attempt MCP calls into whichever server the developer's `.mcp.json` binds `claude-flow` to. No hardcoded URL is embedded; the routing is local. Inert here, but worth knowing if you ever wire a `claude-flow` MCP server in your own config and read these files.
+
+## Overlap with the 7 Laws (read this before integrating anything)
+
+| Upstream surface | 7 Laws / Obra equivalent | Notes |
+|---|---|---|
+| `commands/swarm.md` | (no direct equivalent) | Slash command for fanning out a single objective across N specialized roles. We dispatch in-session via `superpowers:dispatching-parallel-agents` but have no slash-command surface for it. **Genuine gap.** |
+| `commands/watch.md` | (no direct equivalent) | Real-time observation of a running swarm. Our agents return one final result; no streamed-progress surface today. **Genuine gap.** |
+| `skills/swarm-init/SKILL.md` | partial: `superpowers:dispatching-parallel-agents` covers fan-out shape, but not the bootstrap (worktrees, base ref, role list, contract pinning) | Fills a "before-fan-out" surface we don't formalize today. |
+| `skills/monitor-stream/SKILL.md` | (no direct equivalent) | Stream-based observation. Our `/loop` polls; this is push. **Genuine gap.** |
+| `agents/architect.md` | built-in `architect` subagent; `superpowers:writing-plans` (Law 2) | Loose overlap. Upstream's is shaped specifically for swarm contracts (structural ADR output before delegation); ours is general-purpose. |
+| `agents/coordinator.md` | (no direct equivalent) | Stage-pipeline coordinator role. Same gap that surfaced earlier in `third-party/oh-my-claudecode/OUR_NOTES.md` for `omc/team`; ruflo's take is contract-driven and lighter than OMC's. **Worth diffing against OMC if/when we ever port a coordinator.** |
+| `docs/adrs/0001-swarm-contract.md` | (no direct equivalent) | Architecture decision record describing the swarm-contract shape. Read-only reference that anchors the rest of the slice. |
+| `scripts/smoke.sh` | (no direct equivalent) | Smoke-test script for the plugin. Cold-storage; not run. |
+| `.claude-plugin/plugin.json` | (read-only reference) | Do **not** register `ruflo-swarm` in our `.claude-plugin/marketplace.json`. |
+
+## Integration candidates (recorded here, NOT acted on in this PR)
+
+These are the surfaces most likely to inform a future port. Each port is a separate single-concern PR, only after a concrete user-pain trigger:
+
+| Upstream surface | Gap in our 7 Laws | Trigger to port |
+|---|---|---|
+| `commands/swarm.md` | No slash command for "run this objective across N specialized roles in parallel" — today this is hand-rolled per session | A repeated user request to fan out the same objective to multiple roles |
+| `commands/watch.md` + `skills/monitor-stream/` | Long agent runs feel opaque — single final result, no streamed progress | A user report that long parallel runs feel blind, where Monitor stream pattern would close the loop |
+| `skills/swarm-init/` | Bootstrapping a parallel-agent run is freehand: worktrees + base ref + role list assembled per session | Repeated need to bootstrap a parallel-agent run, where contract-pinning would prevent role drift |
+| `agents/coordinator.md` | We have no coordinator role to broker stage hand-off (plan → exec → verify) when stages can't fit in one Claude session | A workflow needing typed stage hand-off where a single Claude session can't keep all stages in head |
+| `docs/adrs/0001-swarm-contract.md` (pattern, not content) | We have ADR support via `architecture-decision-records` skill but no *swarm-contract* shape | When porting any of the above, the contract shape should anchor the implementation |
+
+## What is intentionally NOT integrated (and why)
+
+1. **The other 31 ruflo plugins.** All explicitly out of scope. Multiple direct overlaps with our continuous-improvement learning system, our `/loop`, our `/ralph`, our PARA memory, and our 7 Laws routing. Adopting wholesale collapses the Obra-vs-CI distinction.
+2. **Upstream's `plugin.json` and any marketplace registration.** Read-only reference only.
+3. **`scripts/smoke.sh`.** Cold-storage; not wired to any test runner. If we ever port it, the path/runner conventions would have to change to match our `bin/` layout.
+4. **`commands/swarm.md` and `commands/watch.md` as live slash commands.** These are upstream Claude Code slash commands for ruflo's own runtime. Importing them as-is would shadow nothing today (we don't have `/swarm` or `/watch`), but their contracts assume ruflo's MCP servers are running. Don't import without porting their dependencies or rewriting the contract to be MCP-free.
+5. **Any auto-loading file** (`CLAUDE.md`, `CLAUDE.local.md`). None live inside the slice; if any future refresh introduces one, the refresh recipe's `find -name CLAUDE.md -delete` strips it.
+
+## Ported into the 7 Laws
+
+Nothing yet. This row stays empty until a concrete port lands. When one does, append a row with:
+
+- Date
+- Source path inside the snapshot (with the upstream SHA at port time)
+- Target path in our repo
+- Commit SHA
+- One-line summary of what was ported and what was rejected
+
+## Refresh
+
+See `third-party/MANIFEST.md` for the pinned SHA and the exact selective-copy recipe. Refresh cadence is the same as for other snapshots: first business day of each month, only on meaningful upstream change. The cherry-pick scope (`plugins/ruflo-swarm/` only) does not change unless this OUR_NOTES.md is updated alongside the SHA bump.

--- a/third-party/ruflo-swarm/README.md
+++ b/third-party/ruflo-swarm/README.md
@@ -1,0 +1,86 @@
+# ruflo-swarm
+
+Agent teams, swarm coordination, Monitor streams, and worktree isolation.
+
+## Install
+
+```
+/plugin marketplace add ruvnet/ruflo
+/plugin install ruflo-swarm@ruflo
+```
+
+## What's Included
+
+- **Agent Teams**: TeamCreate, SendMessage, and Task tool integration for multi-agent coordination
+- **Topologies**: hierarchical, mesh, hierarchical-mesh, ring, star, adaptive
+- **Monitor Streams**: Real-time swarm status via `Monitor("npx @claude-flow/cli@latest swarm watch --stream")`
+- **Worktree Isolation**: Each agent works in its own git worktree to avoid conflicts
+- **Hive-Mind Consensus**: Byzantine, Raft, Gossip, CRDT, and Quorum strategies
+- **Anti-Drift**: hierarchical topology with specialized strategy for tight coordination
+
+## Requires
+
+- `ruflo-core` plugin (provides MCP server)
+
+## Compatibility
+
+- **CLI:** pinned to `@claude-flow/cli` v3.6 major+minor.
+- **Verification:** `bash plugins/ruflo-swarm/scripts/smoke.sh` is the contract.
+
+## MCP surface (12 tools)
+
+| Family | Count | Tools |
+|--------|------:|-------|
+| `swarm_*` | 4 | `swarm_init`, `swarm_status`, `swarm_shutdown`, `swarm_health` |
+| `agent_*` | 8 | `agent_spawn`, `agent_execute`, `agent_terminate`, `agent_status`, `agent_list`, `agent_pool`, `agent_health`, `agent_update` |
+
+Sources: `v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts:71, 145, 208, 270` and `agent-tools.ts:182, 287, 319, 356, 395, 451, 573, 651`.
+
+## Built-in Claude Code coordination tools
+
+This plugin pairs with Claude Code's native multi-agent tools (no MCP needed):
+
+| Tool | Purpose |
+|------|---------|
+| `Task` | Spawn a sub-agent (use `name:` for addressability + `run_in_background: true` for parallel execution) |
+| `SendMessage` | Inter-agent comms (named agents only) |
+| `TaskCreate / TaskList / TaskGet / TaskUpdate / TaskOutput / TaskStop` | Shared task tracker for swarm pipelines |
+| `Monitor` | Live-stream events from a long-running process (`persistent: true`) — primary wake signal for /loop |
+| `EnterWorktree / ExitWorktree` | Git worktree isolation per agent |
+
+## Anti-drift defaults (per CLAUDE.md)
+
+For coding swarms, the canonical defaults that prevent agent drift:
+
+| Setting | Value | Rationale |
+|---------|-------|-----------|
+| `topology` | `hierarchical` | Coordinator catches divergence |
+| `maxAgents` | 6–8 | Smaller team = less drift |
+| `strategy` | `specialized` | Clear roles, no overlap |
+| `consensus` | `raft` | Leader maintains authoritative state |
+| `memory` | `hybrid` | SQLite + AgentDB for both fast + durable |
+
+For 10+ agent teams, use `hierarchical-mesh` (queen + peer communication).
+
+## Namespace coordination
+
+This plugin owns the `swarm-state` AgentDB namespace (kebab-case, follows the convention from [ruflo-agentdb ADR-0001 §"Namespace convention"](../ruflo-agentdb/docs/adrs/0001-agentdb-optimization.md)). Reserved namespaces (`pattern`, `claude-memories`, `default`) MUST NOT be shadowed.
+
+`swarm-state` indexes active swarms, agent assignments, and topology snapshots. Accessed via `memory_*` (namespace-routed).
+
+## Verification
+
+```bash
+bash plugins/ruflo-swarm/scripts/smoke.sh
+# Expected: "11 passed, 0 failed"
+```
+
+## Architecture Decisions
+
+- [`ADR-0001` — ruflo-swarm plugin contract (12-tool MCP surface, anti-drift defaults, Monitor streaming, smoke as contract)](./docs/adrs/0001-swarm-contract.md)
+
+## Related Plugins
+
+- `ruflo-agentdb` — namespace convention owner
+- `ruflo-autopilot` — owns the 270s cache-aware /loop heartbeat for long-running swarms
+- `ruflo-intelligence` — `hooks_route` powers swarm agent recommendation per task

--- a/third-party/ruflo-swarm/agents/architect.md
+++ b/third-party/ruflo-swarm/agents/architect.md
@@ -1,0 +1,39 @@
+---
+name: architect
+description: System architect for designing implementation approaches, API contracts, and module boundaries
+model: sonnet
+---
+You are a system architect within a Ruflo-coordinated swarm. Design implementation approaches before coders begin work.
+
+### Workflow
+
+1. **Retrieve prior designs**: `npx @claude-flow/cli@latest memory search --query "research-TOPIC" --namespace tasks`
+2. **Define boundaries**: Module interfaces, data flow, domain entities
+3. **Specify contracts**: Typed interfaces, API schemas, error handling patterns
+4. **Assess risks**: Security, performance, backwards compatibility, migration paths
+5. **Store decisions**: `npx @claude-flow/cli@latest memory store --key "design-FEATURE" --value "DECISIONS" --namespace tasks`
+6. **Report**: `npx @claude-flow/cli@latest hooks post-task --task-id "TASK_ID" --success true`
+
+### Design Principles
+
+| Principle | Application |
+|-----------|------------|
+| DDD bounded contexts | One module per domain concept |
+| SOLID | Single responsibility, dependency injection |
+| KISS / YAGNI | No premature abstraction |
+| Composition over inheritance | Favor interfaces + delegation |
+| Files < 500 lines | Split when approaching limit |
+| Testability | Constructor injection, interface boundaries |
+
+### Tools
+
+- `Read`, `Grep`, `Glob` — analyze existing architecture
+- `npx @claude-flow/cli@latest memory search` — retrieve prior designs and patterns
+- `npx @claude-flow/cli@latest memory store` — persist design decisions
+
+### Neural Learning
+
+After completing tasks, store successful patterns:
+```bash
+npx @claude-flow/cli@latest hooks post-task --task-id "TASK_ID" --success true --train-neural true
+```

--- a/third-party/ruflo-swarm/agents/coordinator.md
+++ b/third-party/ruflo-swarm/agents/coordinator.md
@@ -1,0 +1,31 @@
+---
+name: coordinator
+description: Swarm coordinator that manages agent lifecycle, task assignment, and anti-drift enforcement
+model: sonnet
+---
+You are the swarm coordinator within a Ruflo hierarchical topology. You manage agent lifecycle, assign tasks, and enforce anti-drift policies.
+
+Responsibilities:
+1. Initialize the swarm: `npx @claude-flow/cli@latest swarm init --topology hierarchical --max-agents 8 --strategy specialized`
+2. Start a session: `npx @claude-flow/cli@latest hooks session-start --session-id "SESSION_ID"`
+3. Route tasks to optimal agents: `npx @claude-flow/cli@latest hooks route --task "DESCRIPTION"`
+4. Monitor progress and reassign stalled work.
+5. End session with metrics: `npx @claude-flow/cli@latest hooks session-end --export-metrics true`
+
+Anti-drift rules:
+- Keep agent count at 6-8 for tight coordination.
+- Use specialized strategy so roles do not overlap.
+- Run `post-task` hooks after every task completion for learning.
+- Store coordination decisions in memory namespace "swarm".
+
+### Related Plugins
+
+- **ruflo-goals**: GOAP planning for complex multi-session objectives that swarms execute
+- **ruflo-autopilot**: Autonomous /loop execution of swarm-coordinated work
+
+### Neural Learning
+
+After completing a swarm cycle, feed the coordination outcome learning so topology + role choices compound:
+```bash
+npx @claude-flow/cli@latest hooks post-task --task-id "TASK_ID" --success true --train-neural true
+```

--- a/third-party/ruflo-swarm/commands/swarm.md
+++ b/third-party/ruflo-swarm/commands/swarm.md
@@ -1,0 +1,16 @@
+---
+name: swarm
+description: Initialize, monitor, and manage multi-agent swarms
+---
+$ARGUMENTS
+
+Swarm lifecycle management.
+
+**Init**: `npx @claude-flow/cli@latest swarm init --topology hierarchical --max-agents 8 --strategy specialized`
+**Status**: `npx @claude-flow/cli@latest swarm status`
+**Health**: `npx @claude-flow/cli@latest swarm health`
+**Shutdown**: `npx @claude-flow/cli@latest swarm shutdown`
+
+Parse $ARGUMENTS to determine the subcommand. If no arguments, show swarm status.
+
+After init, spawn agents via Claude Code's Task tool with `run_in_background: true` for parallel execution.

--- a/third-party/ruflo-swarm/commands/watch.md
+++ b/third-party/ruflo-swarm/commands/watch.md
@@ -1,0 +1,13 @@
+---
+name: watch
+description: Live-stream swarm events and agent activity in real time
+---
+$ARGUMENTS
+
+Start a live event stream for the active swarm. Use the Monitor tool to run:
+
+`npx @claude-flow/cli@latest swarm watch --stream`
+
+Each line is an NDJSON event (agent spawn, task update, memory write, health ping). Notifications arrive as events occur -- no polling needed.
+
+For one-shot status checks, use `/status` or `npx @claude-flow/cli@latest swarm status` instead.

--- a/third-party/ruflo-swarm/docs/adrs/0001-swarm-contract.md
+++ b/third-party/ruflo-swarm/docs/adrs/0001-swarm-contract.md
@@ -1,0 +1,50 @@
+---
+id: ADR-0001
+title: ruflo-swarm plugin contract — pinning, namespace coordination, MCP surface (4 swarm_* + 8 agent_*), Monitor streaming, smoke as contract
+status: Proposed
+date: 2026-05-04
+authors:
+  - reviewer (Claude Code)
+tags: [plugin, swarm, agents, monitor, namespace, smoke-test]
+---
+
+## Context
+
+`ruflo-swarm` (v0.1.0) — multi-agent swarm coordination, Monitor streams, worktree isolation. 2 agents (`coordinator`, `architect`), 2 skills (`swarm-init`, `monitor-stream`), 2 commands (`/swarm`, `/watch`).
+
+Wraps **12 MCP tools** across two families:
+
+| Family | Count | Source |
+|--------|-------|--------|
+| `swarm_*` | 4 (`init`, `status`, `shutdown`, `health`) | `v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts:71, 145, 208, 270` |
+| `agent_*` | 8 (`spawn`, `execute`, `terminate`, `status`, `list`, `pool`, `health`, `update`) | `v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts:182, 287, 319, 356, 395, 451, 573, 651` |
+
+Plus the Monitor + Task tools from Claude Code (built-in: `Task`, `TaskList`, `TaskGet`, `TaskUpdate`, `Monitor`, etc.) which pair with this plugin for live streaming.
+
+## Decision
+
+1. Add this ADR (Proposed).
+2. README augment: Compatibility (pin v3.6); 12-tool MCP surface table; Monitor/Task built-in cross-reference; Anti-drift guidance (hierarchical topology, max 8 agents per CLAUDE.md); Namespace coordination (claims `swarm-state`); Verification + Architecture Decisions sections.
+3. Bump `0.1.0 → 0.2.0`. Keywords add `mcp`, `topologies`, `worktree-isolation`, `monitor-stream`.
+4. `scripts/smoke.sh` — 11 structural checks: version + keywords; both skills + 2 agents + 2 commands; all 4 `swarm_*` tools referenced; all 8 `agent_*` tools referenced; v3.6 pin; namespace coordination; anti-drift defaults documented (hierarchical/specialized/raft); Monitor/Task built-in cross-reference; ADR Proposed; no wildcard tools.
+
+## Consequences
+
+**Positive:** plugin joins the cadence. The 12-tool surface is now contractually documented. Anti-drift defaults from CLAUDE.md are smoke-checked.
+
+**Negative:** none material.
+
+## Verification
+
+```bash
+bash plugins/ruflo-swarm/scripts/smoke.sh
+# Expected: "11 passed, 0 failed"
+```
+
+## Related
+
+- `plugins/ruflo-agentdb/docs/adrs/0001-agentdb-optimization.md` — namespace convention
+- `plugins/ruflo-autopilot/docs/adrs/0001-autopilot-contract.md` — 270s cache-aware /loop heartbeat for swarm coordination
+- `plugins/ruflo-intelligence/docs/adrs/0001-intelligence-surface-completeness.md` — `hooks_route` powers swarm agent recommendation
+- `v3/@claude-flow/cli/src/mcp-tools/swarm-tools.ts` — 4 `swarm_*` tools
+- `v3/@claude-flow/cli/src/mcp-tools/agent-tools.ts` — 8 `agent_*` tools

--- a/third-party/ruflo-swarm/scripts/smoke.sh
+++ b/third-party/ruflo-swarm/scripts/smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -u
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+step() { printf "→ %s ... " "$1"; }
+ok()   { printf "PASS\n"; PASS=$((PASS+1)); }
+bad()  { printf "FAIL: %s\n" "$1"; FAIL=$((FAIL+1)); }
+
+step "1. plugin.json declares 0.2.0 with new keywords"
+v=$(grep -E '"version"' "$ROOT/.claude-plugin/plugin.json" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+if [[ "$v" != "0.2.0" ]]; then bad "expected 0.2.0, got '$v'"; else
+  miss=""
+  for k in mcp topologies worktree-isolation monitor-stream; do
+    grep -q "\"$k\"" "$ROOT/.claude-plugin/plugin.json" || miss="$miss $k"
+  done
+  [[ -z "$miss" ]] && ok || bad "missing keywords:$miss"
+fi
+
+step "2. both skills + 2 agents + 2 commands present with valid frontmatter"
+miss=""
+for s in swarm-init monitor-stream; do
+  f="$ROOT/skills/$s/SKILL.md"
+  [[ -f "$f" ]] || { miss="$miss missing-$s"; continue; }
+  for k in 'name:' 'description:'; do
+    grep -q "^$k" "$f" || miss="$miss $s-no-$k"
+  done
+done
+for a in coordinator architect; do
+  [[ -f "$ROOT/agents/$a.md" ]] || miss="$miss missing-agent-$a"
+done
+[[ -f "$ROOT/commands/swarm.md" ]] || miss="$miss missing-swarm-cmd"
+[[ -f "$ROOT/commands/watch.md" ]] || miss="$miss missing-watch-cmd"
+[[ -z "$miss" ]] && ok || bad "$miss"
+
+step "3. all 4 swarm_* MCP tools referenced"
+miss=""
+for t in swarm_init swarm_status swarm_shutdown swarm_health; do
+  grep -rq "$t" "$ROOT" --include='*.md' || miss="$miss $t"
+done
+[[ -z "$miss" ]] && ok || bad "undocumented:$miss"
+
+step "4. all 8 agent_* MCP tools referenced"
+miss=""
+for t in agent_spawn agent_execute agent_terminate agent_status agent_list agent_pool agent_health agent_update; do
+  grep -rq "$t" "$ROOT" --include='*.md' || miss="$miss $t"
+done
+[[ -z "$miss" ]] && ok || bad "undocumented:$miss"
+
+step "5. README pins @claude-flow/cli to v3.6"
+grep -qE "@claude-flow/cli.*v3\.6|v3\.6.*claude-flow/cli" "$ROOT/README.md" \
+  && ok || bad "v3.6 pin missing"
+
+step "6. README defers to ruflo-agentdb namespace convention"
+grep -q "ruflo-agentdb" "$ROOT/README.md" \
+  && grep -q "Namespace convention" "$ROOT/README.md" \
+  && ok || bad "namespace coordination block incomplete"
+
+step "7. swarm-state namespace claimed"
+grep -q "swarm-state" "$ROOT/README.md" \
+  && ok || bad "swarm-state namespace not claimed"
+
+step "8. anti-drift defaults documented (hierarchical/specialized/raft + maxAgents 6-8)"
+F="$ROOT/README.md"
+miss=""
+grep -q "hierarchical" "$F" || miss="$miss hierarchical"
+grep -q "specialized" "$F" || miss="$miss specialized"
+grep -q "raft" "$F" || miss="$miss raft"
+grep -qE "6.{0,3}8|6 to 8|6-8" "$F" || miss="$miss maxAgents"
+[[ -z "$miss" ]] && ok || bad "$miss"
+
+step "9. 6 topologies documented (hierarchical/mesh/hierarchical-mesh/ring/star/adaptive)"
+F="$ROOT/README.md"
+miss=""
+for top in hierarchical mesh hierarchical-mesh ring star adaptive; do
+  grep -q "$top" "$F" || miss="$miss $top"
+done
+[[ -z "$miss" ]] && ok || bad "missing topologies:$miss"
+
+step "10. ADR-0001 exists with status Proposed"
+ADR="$ROOT/docs/adrs/0001-swarm-contract.md"
+[[ -f "$ADR" ]] && grep -qE "^status:[[:space:]]*Proposed" "$ADR" \
+  && ok || bad "ADR missing or status != Proposed"
+
+step "11. no wildcard tool grants in skills"
+bad_skills=""
+for f in "$ROOT"/skills/*/SKILL.md; do
+  grep -q '^allowed-tools:[[:space:]]*\*' "$f" && bad_skills="$bad_skills $(basename $(dirname "$f"))"
+done
+[[ -z "$bad_skills" ]] && ok || bad "wildcard:$bad_skills"
+
+printf "\n%s passed, %s failed\n" "$PASS" "$FAIL"
+[[ $FAIL -eq 0 ]] || exit 1

--- a/third-party/ruflo-swarm/skills/monitor-stream/SKILL.md
+++ b/third-party/ruflo-swarm/skills/monitor-stream/SKILL.md
@@ -1,0 +1,15 @@
+---
+name: monitor-stream
+description: Stream live swarm events using the Monitor tool for real-time observability
+argument-hint: ""
+allowed-tools: Bash(npx *) mcp__claude-flow__swarm_status mcp__claude-flow__swarm_health Monitor
+---
+Use the Monitor tool to stream swarm events in real time instead of polling:
+
+Run via Monitor: `npx @claude-flow/cli@latest swarm watch --stream`
+
+This streams NDJSON events for agent spawns, task completions, memory writes, and health checks. Each stdout line triggers a notification.
+
+For one-shot status, use MCP: `mcp__claude-flow__swarm_status` or `mcp__claude-flow__swarm_health`.
+
+Prefer Monitor over polling `swarm status` in a loop. See ADR-091 for rationale.

--- a/third-party/ruflo-swarm/skills/swarm-init/SKILL.md
+++ b/third-party/ruflo-swarm/skills/swarm-init/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: swarm-init
+description: Initialize a multi-agent swarm with anti-drift configuration
+argument-hint: "[--topology hierarchical|mesh|ring]"
+allowed-tools: Bash(npx *) mcp__claude-flow__swarm_init mcp__claude-flow__swarm_status Agent
+---
+Initialize a hierarchical swarm for coordinated multi-agent work.
+
+Via MCP: `mcp__claude-flow__swarm_init({ topology: "hierarchical", maxAgents: 8, strategy: "specialized" })`
+
+Or via CLI:
+```bash
+npx @claude-flow/cli@latest swarm init --topology hierarchical --max-agents 8 --strategy specialized
+```
+
+Then create a Claude Code team via `TeamCreate` and spawn agents using the `Agent` tool with `isolation: "worktree"` for git-safe parallel work. Use `SendMessage` for inter-agent coordination.
+
+For larger teams (10+), use hierarchical-mesh topology:
+```bash
+npx @claude-flow/cli@latest swarm init --topology hierarchical-mesh --max-agents 15 --strategy specialized
+```


### PR DESCRIPTION
## Summary

Cold-storage snapshot of **one plugin slice** from [`ruvnet/ruflo`](https://github.com/ruvnet/ruflo) — specifically `plugins/ruflo-swarm/` — at `third-party/ruflo-swarm/`. Cherry-picked from a 32-plugin monorepo at SHA `addb5cd3f30c4e9eef9b25084419bd1c5015e169` (2026-05-06). Mirrors the existing playbook from [`third-party/superpowers/`](https://github.com/naimkatiman/continuous-improvement/pull/56), [`third-party/oh-my-claudecode/`](https://github.com/naimkatiman/continuous-improvement/pull/63), and the just-merged [`third-party/addy-agent-skills/`](https://github.com/naimkatiman/continuous-improvement/pull/79).

**This is the 4th third-party snapshot.** It addresses the explicit agent-orchestration / agent-swarm gap.

## Why one plugin, not the whole monorepo

`ruvnet/ruflo` ships 32 plugins covering swarm, RAG memory, neural trader, IoT, federation, etc. Vendoring all of it would:

- Pull in 30+ plugins with no current need (high blast radius).
- Compete with our continuous-improvement learning system, `/loop`, `/ralph`, and PARA memory — `ruflo-autopilot`, `ruflo-intelligence`, `ruflo-loop-workers`, `ruflo-rag-memory`, `ruflo-agentdb`, `ruflo-rvf` all overlap directly.
- Bring in MCP servers and TS source we have explicitly excluded from prior snapshots.

Cherry-picking `ruflo-swarm` only:

- Surface area is 11 files, ~36 KB.
- Directly addresses the stated gap: agent-team coordination (coordinator + architect agents), Monitor stream-based observation (watch + monitor-stream), worktree-isolated bootstrap (swarm-init).
- Parallel-readable against `superpowers:dispatching-parallel-agents` (Obra) — alternative take, not replacement.

**Snapshot path is `third-party/ruflo-swarm/`, not `third-party/ruflo/`.** Path = scope. Anyone scanning the dir should not infer the full monorepo lives here.

## Scope (verbatim from upstream `plugins/ruflo-swarm/`)

- `agents/architect.md`, `agents/coordinator.md`
- `commands/swarm.md`, `commands/watch.md`
- `skills/swarm-init/SKILL.md`, `skills/monitor-stream/SKILL.md`
- `docs/adrs/0001-swarm-contract.md`
- `scripts/smoke.sh`
- `.claude-plugin/plugin.json`
- `README.md`
- `LICENSE` — copied from upstream **repo root** (the slice has no own LICENSE)

## Excluded (explicit)

The other 31 ruflo plugins (full list in [plan doc](https://github.com/naimkatiman/continuous-improvement/blob/third-party/ruflo-swarm/docs/plans/2026-05-07-ruflo-swarm-vendor.md) and `third-party/MANIFEST.md`), the ruflo runtime (`ruflo/`, `bin/`, `package.json`, `tsconfig.json`, `tests/`, `archive/`, `verification.md`, `ruflo-plugins.gif` ~5.5 MB), repo metadata (`.claude/`, `.agents/`, `.githooks/`, `.github/`), and root `CLAUDE.md` / `CLAUDE.local.md` / `AGENTS.md` (auto-load contamination risk; none are inside the slice anyway, but the post-copy `find -name CLAUDE.md -delete` runs as a safety belt).

## OUR_NOTES.md highlights

- Leads with a "Read this first: ONE plugin from a 32-plugin monorepo" disclaimer.
- 9-row overlap matrix vs. our 7 Laws and Obra's `dispatching-parallel-agents`.
- 5 integration candidates flagged for future per-surface ports — each port lands as its own single-concern PR after a concrete user-pain trigger. **This PR ports nothing.**
- New section: **"Activation hazards"** documenting the 2 INFO-level findings from security review (unpinned `npx @claude-flow/cli@latest` + `mcp__claude-flow__*` allowed-tools) — both inert in cold-storage, relevant only if a developer accidentally activates the snapshot.

## Deferred follow-ups (NOT in this PR)

- **#1 (carried over)** — `bin/refresh-third-party.mjs` SNAPSHOTS entry. Now covers TWO parked snapshots (addy + ruflo-swarm). Re-evaluate trigger reached: **4 snapshots**. Separate PR.
- **#2 (carried over)** — Generic third-party shape invariant check. With this PR we hit 4 snapshots, the original re-evaluate threshold. Separate decision after merge.
- **#3 — Port any specific swarm idea** into our `dispatching-parallel-agents` workflow. Held until a concrete user-pain trigger.

## Plan doc

[`docs/plans/2026-05-07-ruflo-swarm-vendor.md`](https://github.com/naimkatiman/continuous-improvement/blob/third-party/ruflo-swarm/docs/plans/2026-05-07-ruflo-swarm-vendor.md) — cherry-pick rationale, all 31 excluded plugins enumerated, P-MAG negative prompts, integration-candidate matrix, deferred follow-ups, explicit out-of-scope declarations.

## Test plan

- [x] Pinned SHA verified at clone time — `git rev-parse HEAD` matches `addb5cd3f30c4e9eef9b25084419bd1c5015e169`
- [x] `find third-party/ruflo-swarm -name CLAUDE.md` returns empty
- [x] No `AGENTS.md`, `CLAUDE.local.md`, or other auto-loading files inside the snapshot
- [x] `npm run typecheck` — 0 errors before and after vendor add
- [x] `npm test` — 479/479 pass before and after vendor add
- [x] `code-reviewer` agent — pass on all 8 checks (license, purity, cherry-pick discipline, no-leak, MANIFEST shape, OUR_NOTES shape, single-concern, plan-doc); 1 CRITICAL on `package-lock.json` drift discarded before stage
- [x] `security-reviewer` agent — 0 CRITICAL/HIGH/MEDIUM/LOW; 2 INFO recorded in OUR_NOTES.md § "Activation hazards"
- [x] `package-lock.json` drift discarded before stage (single-concern protection — same pattern as PR #79)
- [x] No changes outside `third-party/ruflo-swarm/`, `third-party/MANIFEST.md`, `docs/plans/`
- [ ] Reviewer to confirm the cherry-pick path naming (`ruflo-swarm`, not `ruflo`) reads correctly from the path alone

## Refresh cadence

First business day of each month per `third-party/README.md`. The cherry-pick scope (`plugins/ruflo-swarm/` only) does not change unless OUR_NOTES.md is updated alongside the SHA bump.