### PR TITLE
docs(readme): add In the wild section with pm-skills #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,18 @@ Every skill description leads with `Enforces Law N (...)` so the discipline tag 
 
 ---
 
+## In the wild
+
+Workflows from this repo, applied to real open-source contributions:
+
+### pm-skills (product-on-purpose, 189 stars, Apache 2.0)
+
+[F-07 discover-market-sizing](https://github.com/product-on-purpose/pm-skills/pull/141) - new domain skill in the Discover phase covering TAM/SAM/SOM market sizing for the [pm-skills](https://github.com/product-on-purpose/pm-skills) library.
+
+Authored end-to-end with `/superpowers` and `/proceed-with-the-recommendation`: surface audit before any code, brainstorm gate with WILD/RISA framing, branch isolation off the upstream fork, single-skill PR scope per the upstream maintainer's curated-contributions model, count cascade across 23 docs files, and 9 local validators green before push (`lint-skills-frontmatter`, `validate-agents-md`, `validate-commands`, `check-count-consistency`, `check-nav-completeness`, `check-generated-content-untouched`, `check-generated-freshness`, `validate-meeting-skills-family`, `validate-plugin-install`).
+
+---
+
 ## More
 
 - [QUICKSTART.md](QUICKSTART.md) — 2-minute setup


### PR DESCRIPTION
## Summary

Adds a new \`## In the wild\` section to README.md showcasing real open-source contributions authored using this repo's workflow.

First entry: [F-07 discover-market-sizing on product-on-purpose/pm-skills](https://github.com/product-on-purpose/pm-skills/pull/141) - new domain skill covering TAM/SAM/SOM market sizing, shipped to a 189-star Apache 2.0 PM skills library.

The entry documents the workflow chain end-to-end: surface audit, WILD/RISA brainstorm, branch isolation, count cascade across 23 docs files, and 9 local validators green before push. Future contributions can append below this one without restructuring the section.

## Why this lives in README, not a docs page

- Discoverability for the home-repo readers most likely to give a star
- Single source of truth: README is the front door for both new users and curious maintainers
- Kept short (12-line section) so it does not bloat the README

## Test plan

- [ ] Verify the new section renders correctly on GitHub at https://github.com/naimkatiman/continuous-improvement/blob/docs/in-the-wild-pm-skills-141/README.md
- [ ] Confirm no existing README links break (this is a pure append)
- [ ] Confirm the pm-skills #141 link resolves