### PR TITLE
feat(invariant): fail verify when third-party snapshot is missing OUR_NOTES.md, LICENSE, or MANIFEST pin

### DIFF
--- a/bin/check-third-party-shape.mjs
+++ b/bin/check-third-party-shape.mjs
@@ -1,0 +1,202 @@
+#!/usr/bin/env node
+/**
+ * Third-Party Snapshot Shape Invariant
+ *
+ * Verifies that every `third-party/<name>/` snapshot directory conforms to the
+ * vendor playbook documented in `third-party/README.md`. For each snapshot
+ * directory the check asserts:
+ *
+ *   1. `OUR_NOTES.md` exists and is non-empty
+ *   2. `LICENSE` exists
+ *   3. `third-party/MANIFEST.md` has at least one `### <heading>` block whose
+ *      `Local path` row points at this snapshot directory
+ *   4. The matching MANIFEST entry has a `Pinned SHA` row containing a
+ *      40-char lowercase hex string wrapped in backticks
+ *
+ * The mapping between snapshot directory and MANIFEST heading is NOT identity
+ * (e.g. dir `superpowers` <-> heading `obra/superpowers`). The check looks up
+ * by `Local path`, not by name.
+ *
+ * Usage:
+ *   node bin/check-third-party-shape.mjs              # check the current repo
+ *   node bin/check-third-party-shape.mjs <repo-root>  # check a specific repo root
+ *
+ * Exit codes:
+ *   0 - every snapshot is shape-compliant
+ *   1 - at least one drift found
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const THIRD_PARTY_DIR = "third-party";
+const MANIFEST_FILENAME = "MANIFEST.md";
+const OUR_NOTES_FILENAME = "OUR_NOTES.md";
+const LICENSE_FILENAME = "LICENSE";
+const SHA_RE = /^[0-9a-f]{40}$/;
+export function discoverSnapshots(repoRoot) {
+    const dir = join(repoRoot, THIRD_PARTY_DIR);
+    let entries;
+    try {
+        entries = readdirSync(dir);
+    }
+    catch {
+        return [];
+    }
+    const snapshots = [];
+    for (const name of entries) {
+        const full = join(dir, name);
+        let entryStat;
+        try {
+            entryStat = statSync(full);
+        }
+        catch {
+            continue;
+        }
+        if (!entryStat.isDirectory())
+            continue;
+        snapshots.push({
+            name,
+            hasOurNotes: hasNonEmptyFile(join(full, OUR_NOTES_FILENAME)),
+            hasLicense: fileExists(join(full, LICENSE_FILENAME)),
+        });
+    }
+    return snapshots;
+}
+function fileExists(path) {
+    try {
+        return statSync(path).isFile();
+    }
+    catch {
+        return false;
+    }
+}
+function hasNonEmptyFile(path) {
+    try {
+        const s = statSync(path);
+        return s.isFile() && s.size > 0;
+    }
+    catch {
+        return false;
+    }
+}
+export function parseManifestEntries(manifestText) {
+    const lines = manifestText.split(/\r?\n/);
+    const entries = [];
+    let current = null;
+    const flush = () => {
+        if (current && current.localPath !== null)
+            entries.push(current);
+        current = null;
+    };
+    for (const line of lines) {
+        const headingMatch = line.match(/^###\s+(.+?)\s*$/);
+        if (headingMatch) {
+            flush();
+            current = { heading: headingMatch[1], pinnedSha: null, localPath: null };
+            continue;
+        }
+        if (line.match(/^##\s+/) || line.match(/^#\s+/)) {
+            flush();
+            continue;
+        }
+        if (!current)
+            continue;
+        const shaRow = line.match(/^\|\s*Pinned SHA\s*\|\s*`?([0-9a-fA-F]+)`?\s*\|/);
+        if (shaRow) {
+            current.pinnedSha = shaRow[1].toLowerCase();
+            continue;
+        }
+        const pathRow = line.match(/^\|\s*Local path\s*\|\s*`?([^`|]+?)`?\s*\|/);
+        if (pathRow) {
+            current.localPath = pathRow[1].trim();
+            continue;
+        }
+    }
+    flush();
+    return entries;
+}
+function normalizeLocalPath(p) {
+    let out = p.replace(/\\/g, "/").replace(/\/+$/, "");
+    if (out.startsWith("./"))
+        out = out.slice(2);
+    return out;
+}
+export function checkThirdPartyShape(repoRoot) {
+    const snapshots = discoverSnapshots(repoRoot);
+    const manifestPath = join(repoRoot, THIRD_PARTY_DIR, MANIFEST_FILENAME);
+    let manifestText = "";
+    try {
+        manifestText = readFileSync(manifestPath, "utf8");
+    }
+    catch {
+        /* no manifest at all - every snapshot will fail no-manifest-entry */
+    }
+    const entries = parseManifestEntries(manifestText);
+    const entryByLocalPath = new Map();
+    for (const e of entries) {
+        if (e.localPath)
+            entryByLocalPath.set(normalizeLocalPath(e.localPath), e);
+    }
+    const drifts = [];
+    for (const snap of snapshots) {
+        if (!snap.hasOurNotes) {
+            drifts.push({
+                kind: "missing-our-notes",
+                snapshot: snap.name,
+                detail: `expected non-empty ${OUR_NOTES_FILENAME} at ${THIRD_PARTY_DIR}/${snap.name}/`,
+            });
+        }
+        if (!snap.hasLicense) {
+            drifts.push({
+                kind: "missing-license",
+                snapshot: snap.name,
+                detail: `expected ${LICENSE_FILENAME} at ${THIRD_PARTY_DIR}/${snap.name}/`,
+            });
+        }
+        const expectedPath = `${THIRD_PARTY_DIR}/${snap.name}`;
+        const entry = entryByLocalPath.get(expectedPath);
+        if (!entry) {
+            drifts.push({
+                kind: "no-manifest-entry",
+                snapshot: snap.name,
+                detail: `no MANIFEST.md ### block has Local path \`${expectedPath}/\``,
+            });
+            continue;
+        }
+        if (!entry.pinnedSha || !SHA_RE.test(entry.pinnedSha)) {
+            drifts.push({
+                kind: "invalid-sha",
+                snapshot: snap.name,
+                detail: `MANIFEST entry "${entry.heading}" has Pinned SHA "${entry.pinnedSha ?? "(none)"}" - expected 40-char lowercase hex`,
+            });
+        }
+    }
+    return {
+        drifts,
+        snapshotCount: snapshots.length,
+        manifestEntryCount: entries.length,
+    };
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const { drifts, snapshotCount, manifestEntryCount } = checkThirdPartyShape(repoRoot);
+    if (drifts.length === 0) {
+        console.log(`OK third-party-shape: all ${snapshotCount} snapshot(s) compliant ` +
+            `(${manifestEntryCount} MANIFEST entr${manifestEntryCount === 1 ? "y" : "ies"} with Local path).`);
+        exit(0);
+    }
+    console.error(`FAIL third-party-shape: ${drifts.length} drift(s) across ${snapshotCount} snapshot(s).\n`);
+    for (const d of drifts) {
+        console.error(`  - [${d.kind}] ${d.snapshot}`);
+        if (d.detail)
+            console.error(`      ${d.detail}`);
+    }
+    console.error(`\nFix: see third-party/README.md "Layout" + third-party/MANIFEST.md ` +
+        `existing entries for the playbook shape (OUR_NOTES.md, LICENSE, ` +
+        `### <heading> block with Pinned SHA + Local path rows).`);
+    exit(1);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-third-party-shape.mjs")) {
+    main();
+}

--- a/docs/plans/2026-05-07-third-party-shape-invariant.md
+++ b/docs/plans/2026-05-07-third-party-shape-invariant.md
@@ -1,0 +1,64 @@
+# 2026-05-07 — Third-party shape invariant check
+
+Plan for the deferred follow-up #2 from the addy-agent-skills (#79) and ruflo-swarm (#80) vendor PRs. Single-concern PR. TDD RED → GREEN → REFACTOR.
+
+## Goal
+
+Add a CI invariant that fails when any `third-party/<name>/` snapshot drifts out of the playbook shape. The threshold the original plans named (4 snapshots) is now reached: `oh-my-claudecode`, `superpowers`, `addy-agent-skills`, `ruflo-swarm`. With four snapshots the failure mode is real — a future vendor PR could ship without `OUR_NOTES.md`, without `LICENSE`, without a matching `MANIFEST.md` row, or with a non-pinned SHA, and nothing in CI would catch it.
+
+## Invariant rules
+
+For each `third-party/<name>/` directory (excluding regular files at the `third-party/` root, namely `MANIFEST.md` and `README.md`):
+
+1. **`OUR_NOTES.md`** exists and is non-empty.
+2. **`LICENSE`** exists.
+3. **`third-party/MANIFEST.md`** has at least one `### <heading>` block whose `Local path` row points at this snapshot directory.
+4. That MANIFEST entry has a **`Pinned SHA`** row containing a **40-char lowercase hex string** wrapped in backticks (matches the existing convention).
+
+The mapping between snapshot directory and MANIFEST heading is **NOT identity** (e.g., dir `superpowers` ↔ heading `obra/superpowers`; dir `addy-agent-skills` ↔ heading `addyosmani/agent-skills`; dir `ruflo-swarm` ↔ heading `ruvnet/ruflo (plugins/ruflo-swarm slice)`). The check must look up by `Local path`, not by name.
+
+A snapshot dir without a matching MANIFEST entry — or a MANIFEST entry without a corresponding snapshot dir — is also a drift to flag.
+
+## Step plan
+
+| Step | Action | Verification |
+|---|---|---|
+| 1 | Worktree `feat/third-party-shape-invariant` off `origin/main@6c73103` | `git worktree list` + clean status |
+| 2 | This plan doc | merged into the same single-concern PR |
+| 3 (RED) | Write `src/test/check-third-party-shape.test.mts` covering the 4 invariant rules; the test imports from `../bin/check-third-party-shape.mjs` which does not exist yet | `npm test` fails with module-not-found at the import line |
+| 4 (GREEN) | Write `src/bin/check-third-party-shape.mts`: discover snapshots, parse MANIFEST.md, validate shape; print `OK` / `FAIL` lines like `bin/check-routing-targets.mjs` does | `npm test` passes; `node bin/check-third-party-shape.mjs` exits 0 against current 4 snapshots |
+| 5 (REFACTOR) | Tidy duplicated logic, confirm 0 type errors, run full `npm test` (existing 479 + new tests) | typecheck + tests both green |
+| 6 | code-reviewer agent on the diff (TDD discipline, no over-engineering, single-concern) | review report attached to PR |
+| 7 | finishing-a-development-branch — squash-merge ready check, ahead-of-origin baseline check, no drive-by changes | branch ready for single squash commit |
+| 8 | Open PR vs `main` — `feat(invariant): fail verify when third-party snapshot is missing OUR_NOTES.md, LICENSE, or MANIFEST pin` | single concern, no edits to vendored content |
+
+## Wiring decision
+
+The check runs as part of `npm test` automatically because `package.json` already does `node --test test/*.test.mjs` and `tsc` emits `test/check-third-party-shape.test.mjs` from the `.mts` source. **No `package.json` edit needed.** Keeping the wiring change out of this PR is single-concern protection.
+
+A future PR can add an explicit `npm run verify:third-party` script if a separate gate is wanted; not done here.
+
+## Carried-in negative prompts (P-MAG Rule 3)
+
+> Will NOT repeat: editing `.mjs` directly. The source lives at `src/bin/check-third-party-shape.mts` and `src/test/check-third-party-shape.test.mts`. `tsc` emits the `.mjs` artifacts.
+>
+> Will NOT repeat: bundled concerns. This PR ships **only** the new invariant check — its source files, its test, the plan doc. No `package.json` edit. No driver entry (deferred #1 still parked). No edits to existing snapshots. No edits to `MANIFEST.md` itself (the check reads MANIFEST.md, doesn't modify it).
+>
+> Will NOT repeat: `git add .` / `-A`. Stage by explicit path. Discard `package-lock.json` drift before stage if `npm install` exposes the version-field drift again.
+>
+> Will NOT repeat: skipping RED. The test file lands first and is committed to fail (or runs once with a broken import to confirm it fails) before the implementation source is written.
+
+## Risks
+
+- **Heading-to-dir mapping ambiguity.** Three of the four current MANIFEST headings differ from the dir name. The check must look up by `Local path`, not by name. The test will cover at least one snapshot whose heading != dir name (e.g., `superpowers` ↔ `obra/superpowers`).
+- **Unused MANIFEST entries.** The "Pending snapshots (not yet vendored)" section at the bottom of MANIFEST.md (`HKUDS/CLI-Anything`, `phuryn/pm-skills`) has `### <heading>` blocks but no `Local path` rows. The check must treat absence of `Local path` as "not a vendored entry, skip" rather than as drift.
+- **False positive on `third-party/.gitkeep` or stray files.** Defensive: only iterate over directories at `third-party/`, not regular files.
+- **Test isolation.** Test must use `mkdtempSync` fixtures (same convention as `check-routing-targets.test.mts`) so it doesn't depend on the live `third-party/` state — that would couple the test to ongoing snapshot evolution.
+
+## Out of scope (explicit)
+
+- Wiring a new `npm run verify:third-party` script (test pickup is automatic; explicit script is over-engineering for one check)
+- Editing existing snapshots, even if the check exposes a real shape gap on them (any such fix is a separate PR)
+- Adding driver SNAPSHOTS entries to `bin/refresh-third-party.mjs` (deferred #1 — still parked)
+- Anything related to the ruflo or addy plugin contents
+- Any change to `third-party/MANIFEST.md` or any `OUR_NOTES.md`

--- a/src/bin/check-third-party-shape.mts
+++ b/src/bin/check-third-party-shape.mts
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+/**
+ * Third-Party Snapshot Shape Invariant
+ *
+ * Verifies that every `third-party/<name>/` snapshot directory conforms to the
+ * vendor playbook documented in `third-party/README.md`. For each snapshot
+ * directory the check asserts:
+ *
+ *   1. `OUR_NOTES.md` exists and is non-empty
+ *   2. `LICENSE` exists
+ *   3. `third-party/MANIFEST.md` has at least one `### <heading>` block whose
+ *      `Local path` row points at this snapshot directory
+ *   4. The matching MANIFEST entry has a `Pinned SHA` row containing a
+ *      40-char lowercase hex string wrapped in backticks
+ *
+ * The mapping between snapshot directory and MANIFEST heading is NOT identity
+ * (e.g. dir `superpowers` <-> heading `obra/superpowers`). The check looks up
+ * by `Local path`, not by name.
+ *
+ * Usage:
+ *   node bin/check-third-party-shape.mjs              # check the current repo
+ *   node bin/check-third-party-shape.mjs <repo-root>  # check a specific repo root
+ *
+ * Exit codes:
+ *   0 - every snapshot is shape-compliant
+ *   1 - at least one drift found
+ */
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const THIRD_PARTY_DIR = "third-party";
+const MANIFEST_FILENAME = "MANIFEST.md";
+const OUR_NOTES_FILENAME = "OUR_NOTES.md";
+const LICENSE_FILENAME = "LICENSE";
+const SHA_RE = /^[0-9a-f]{40}$/;
+
+export interface SnapshotShape {
+  name: string;
+  hasOurNotes: boolean;
+  hasLicense: boolean;
+}
+
+export interface ManifestEntry {
+  heading: string;
+  pinnedSha: string | null;
+  localPath: string | null;
+}
+
+export type DriftKind =
+  | "missing-our-notes"
+  | "missing-license"
+  | "no-manifest-entry"
+  | "invalid-sha";
+
+export interface ShapeDrift {
+  kind: DriftKind;
+  snapshot: string;
+  detail?: string;
+}
+
+export interface CheckResult {
+  drifts: ShapeDrift[];
+  snapshotCount: number;
+  manifestEntryCount: number;
+}
+
+export function discoverSnapshots(repoRoot: string): SnapshotShape[] {
+  const dir = join(repoRoot, THIRD_PARTY_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch {
+    return [];
+  }
+  const snapshots: SnapshotShape[] = [];
+  for (const name of entries) {
+    const full = join(dir, name);
+    let entryStat;
+    try {
+      entryStat = statSync(full);
+    } catch {
+      continue;
+    }
+    if (!entryStat.isDirectory()) continue;
+    snapshots.push({
+      name,
+      hasOurNotes: hasNonEmptyFile(join(full, OUR_NOTES_FILENAME)),
+      hasLicense: fileExists(join(full, LICENSE_FILENAME)),
+    });
+  }
+  return snapshots;
+}
+
+function fileExists(path: string): boolean {
+  try {
+    return statSync(path).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function hasNonEmptyFile(path: string): boolean {
+  try {
+    const s = statSync(path);
+    return s.isFile() && s.size > 0;
+  } catch {
+    return false;
+  }
+}
+
+export function parseManifestEntries(manifestText: string): ManifestEntry[] {
+  const lines = manifestText.split(/\r?\n/);
+  const entries: ManifestEntry[] = [];
+  let current: ManifestEntry | null = null;
+  const flush = () => {
+    if (current && current.localPath !== null) entries.push(current);
+    current = null;
+  };
+  for (const line of lines) {
+    const headingMatch = line.match(/^###\s+(.+?)\s*$/);
+    if (headingMatch) {
+      flush();
+      current = { heading: headingMatch[1], pinnedSha: null, localPath: null };
+      continue;
+    }
+    if (line.match(/^##\s+/) || line.match(/^#\s+/)) {
+      flush();
+      continue;
+    }
+    if (!current) continue;
+    const shaRow = line.match(/^\|\s*Pinned SHA\s*\|\s*`?([0-9a-fA-F]+)`?\s*\|/);
+    if (shaRow) {
+      current.pinnedSha = shaRow[1].toLowerCase();
+      continue;
+    }
+    const pathRow = line.match(/^\|\s*Local path\s*\|\s*`?([^`|]+?)`?\s*\|/);
+    if (pathRow) {
+      current.localPath = pathRow[1].trim();
+      continue;
+    }
+  }
+  flush();
+  return entries;
+}
+
+function normalizeLocalPath(p: string): string {
+  let out = p.replace(/\\/g, "/").replace(/\/+$/, "");
+  if (out.startsWith("./")) out = out.slice(2);
+  return out;
+}
+
+export function checkThirdPartyShape(repoRoot: string): CheckResult {
+  const snapshots = discoverSnapshots(repoRoot);
+  const manifestPath = join(repoRoot, THIRD_PARTY_DIR, MANIFEST_FILENAME);
+  let manifestText = "";
+  try {
+    manifestText = readFileSync(manifestPath, "utf8");
+  } catch {
+    /* no manifest at all - every snapshot will fail no-manifest-entry */
+  }
+  const entries = parseManifestEntries(manifestText);
+
+  const entryByLocalPath = new Map<string, ManifestEntry>();
+  for (const e of entries) {
+    if (e.localPath) entryByLocalPath.set(normalizeLocalPath(e.localPath), e);
+  }
+
+  const drifts: ShapeDrift[] = [];
+  for (const snap of snapshots) {
+    if (!snap.hasOurNotes) {
+      drifts.push({
+        kind: "missing-our-notes",
+        snapshot: snap.name,
+        detail: `expected non-empty ${OUR_NOTES_FILENAME} at ${THIRD_PARTY_DIR}/${snap.name}/`,
+      });
+    }
+    if (!snap.hasLicense) {
+      drifts.push({
+        kind: "missing-license",
+        snapshot: snap.name,
+        detail: `expected ${LICENSE_FILENAME} at ${THIRD_PARTY_DIR}/${snap.name}/`,
+      });
+    }
+    const expectedPath = `${THIRD_PARTY_DIR}/${snap.name}`;
+    const entry = entryByLocalPath.get(expectedPath);
+    if (!entry) {
+      drifts.push({
+        kind: "no-manifest-entry",
+        snapshot: snap.name,
+        detail: `no MANIFEST.md ### block has Local path \`${expectedPath}/\``,
+      });
+      continue;
+    }
+    if (!entry.pinnedSha || !SHA_RE.test(entry.pinnedSha)) {
+      drifts.push({
+        kind: "invalid-sha",
+        snapshot: snap.name,
+        detail: `MANIFEST entry "${entry.heading}" has Pinned SHA "${entry.pinnedSha ?? "(none)"}" - expected 40-char lowercase hex`,
+      });
+    }
+  }
+
+  return {
+    drifts,
+    snapshotCount: snapshots.length,
+    manifestEntryCount: entries.length,
+  };
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const { drifts, snapshotCount, manifestEntryCount } =
+    checkThirdPartyShape(repoRoot);
+  if (drifts.length === 0) {
+    console.log(
+      `OK third-party-shape: all ${snapshotCount} snapshot(s) compliant ` +
+        `(${manifestEntryCount} MANIFEST entr${manifestEntryCount === 1 ? "y" : "ies"} with Local path).`,
+    );
+    exit(0);
+  }
+  console.error(
+    `FAIL third-party-shape: ${drifts.length} drift(s) across ${snapshotCount} snapshot(s).\n`,
+  );
+  for (const d of drifts) {
+    console.error(`  - [${d.kind}] ${d.snapshot}`);
+    if (d.detail) console.error(`      ${d.detail}`);
+  }
+  console.error(
+    `\nFix: see third-party/README.md "Layout" + third-party/MANIFEST.md ` +
+      `existing entries for the playbook shape (OUR_NOTES.md, LICENSE, ` +
+      `### <heading> block with Pinned SHA + Local path rows).`,
+  );
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-third-party-shape.mjs")) {
+  main();
+}

--- a/src/test/check-third-party-shape.test.mts
+++ b/src/test/check-third-party-shape.test.mts
@@ -1,0 +1,317 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  checkThirdPartyShape,
+  discoverSnapshots,
+  parseManifestEntries,
+} from "../bin/check-third-party-shape.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-third-party-shape.mjs");
+
+const SHA_40 = "f2cbfbefebbfef77321e4c9abc9e949826bea9d7";
+const SHA_40_ALT = "742dca58ae557bc67afec9ea8e6de59c085f0534";
+
+function setupFixture(): string {
+  const root = mkdtempSync(join(tmpdir(), "third-party-shape-test-"));
+  mkdirSync(join(root, "third-party"), { recursive: true });
+  return root;
+}
+
+function writeSnapshot(
+  root: string,
+  name: string,
+  options: {
+    ourNotes?: string | null;
+    license?: string | null;
+  } = {},
+): void {
+  const dir = join(root, "third-party", name);
+  mkdirSync(dir, { recursive: true });
+  if (options.ourNotes !== null) {
+    writeFileSync(
+      join(dir, "OUR_NOTES.md"),
+      options.ourNotes ?? `# OUR_NOTES — ${name}\nNon-empty.`,
+    );
+  }
+  if (options.license !== null) {
+    writeFileSync(
+      join(dir, "LICENSE"),
+      options.license ?? "MIT License\n\nCopyright (c) test\n",
+    );
+  }
+}
+
+function writeManifest(
+  root: string,
+  entries: Array<{
+    heading: string;
+    pinnedSha: string | null;
+    localPath: string | null;
+  }>,
+): void {
+  const blocks = entries.map((e) => {
+    const rows: string[] = [`### ${e.heading}`, "", "| Field | Value |", "|---|---|"];
+    if (e.pinnedSha !== null) {
+      rows.push(`| Pinned SHA | \`${e.pinnedSha}\` |`);
+    }
+    if (e.localPath !== null) {
+      rows.push(`| Local path | \`${e.localPath}\` |`);
+    }
+    return rows.join("\n");
+  });
+  const body = ["# third-party/MANIFEST.md", "", ...blocks, ""].join("\n\n");
+  writeFileSync(join(root, "third-party", "MANIFEST.md"), body);
+}
+
+describe("check-third-party-shape — pure functions", () => {
+  it("discoverSnapshots returns snapshot dir names, ignoring files at third-party/ root", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "alpha");
+      writeSnapshot(root, "beta");
+      writeFileSync(join(root, "third-party", "MANIFEST.md"), "# manifest\n");
+      writeFileSync(join(root, "third-party", "README.md"), "# readme\n");
+
+      const names = discoverSnapshots(root)
+        .map((s) => s.name)
+        .sort();
+      assert.deepEqual(names, ["alpha", "beta"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("discoverSnapshots reports OUR_NOTES.md and LICENSE presence per snapshot", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "complete"); // has both
+      writeSnapshot(root, "no-notes", { ourNotes: null });
+      writeSnapshot(root, "no-license", { license: null });
+
+      const map = new Map(discoverSnapshots(root).map((s) => [s.name, s]));
+      assert.equal(map.get("complete")?.hasOurNotes, true);
+      assert.equal(map.get("complete")?.hasLicense, true);
+      assert.equal(map.get("no-notes")?.hasOurNotes, false);
+      assert.equal(map.get("no-license")?.hasLicense, false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("parseManifestEntries extracts heading + pinnedSha + localPath", () => {
+    const text = [
+      "# manifest",
+      "",
+      "### foo",
+      "",
+      "| Pinned SHA | `" + SHA_40 + "` |",
+      "| Local path | `third-party/foo/` |",
+      "",
+      "### bar/qux",
+      "",
+      "| Pinned SHA | `" + SHA_40_ALT + "` |",
+      "| Local path | `third-party/bar-qux/` |",
+      "",
+    ].join("\n");
+    const entries = parseManifestEntries(text);
+    assert.equal(entries.length, 2);
+    const byHeading = new Map(entries.map((e) => [e.heading, e]));
+    assert.equal(byHeading.get("foo")?.pinnedSha, SHA_40);
+    assert.equal(byHeading.get("foo")?.localPath, "third-party/foo/");
+    assert.equal(byHeading.get("bar/qux")?.pinnedSha, SHA_40_ALT);
+    assert.equal(byHeading.get("bar/qux")?.localPath, "third-party/bar-qux/");
+  });
+
+  it("parseManifestEntries omits entries without a Local path (pending snapshots)", () => {
+    const text = [
+      "# manifest",
+      "",
+      "### vendored-thing",
+      "",
+      "| Pinned SHA | `" + SHA_40 + "` |",
+      "| Local path | `third-party/vendored-thing/` |",
+      "",
+      "## Pending snapshots",
+      "",
+      "### pending-thing",
+      "- License audited: MIT",
+      "- decline to vendor.",
+      "",
+    ].join("\n");
+    const entries = parseManifestEntries(text);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0].heading, "vendored-thing");
+  });
+});
+
+describe("check-third-party-shape — checkThirdPartyShape", () => {
+  it("reports zero drifts when all snapshots have OUR_NOTES.md, LICENSE, and a matching pinned MANIFEST entry", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "alpha");
+      writeSnapshot(root, "obra-superpowers");
+      writeManifest(root, [
+        {
+          heading: "alpha",
+          pinnedSha: SHA_40,
+          localPath: "third-party/alpha/",
+        },
+        {
+          heading: "obra/superpowers",
+          pinnedSha: SHA_40_ALT,
+          localPath: "third-party/obra-superpowers/",
+        },
+      ]);
+
+      const result = checkThirdPartyShape(root);
+      assert.deepEqual(result.drifts, []);
+      assert.equal(result.snapshotCount, 2);
+      assert.equal(result.manifestEntryCount, 2);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a missing OUR_NOTES.md", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "alpha", { ourNotes: null });
+      writeManifest(root, [
+        { heading: "alpha", pinnedSha: SHA_40, localPath: "third-party/alpha/" },
+      ]);
+      const result = checkThirdPartyShape(root);
+      assert.equal(result.drifts.length, 1);
+      assert.equal(result.drifts[0].kind, "missing-our-notes");
+      assert.equal(result.drifts[0].snapshot, "alpha");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a missing LICENSE", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "alpha", { license: null });
+      writeManifest(root, [
+        { heading: "alpha", pinnedSha: SHA_40, localPath: "third-party/alpha/" },
+      ]);
+      const result = checkThirdPartyShape(root);
+      assert.equal(result.drifts.length, 1);
+      assert.equal(result.drifts[0].kind, "missing-license");
+      assert.equal(result.drifts[0].snapshot, "alpha");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a snapshot dir with no matching MANIFEST entry", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "orphan");
+      writeManifest(root, []);
+      const result = checkThirdPartyShape(root);
+      assert.equal(result.drifts.length, 1);
+      assert.equal(result.drifts[0].kind, "no-manifest-entry");
+      assert.equal(result.drifts[0].snapshot, "orphan");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags a non-40-char or non-hex Pinned SHA", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "shorty");
+      writeSnapshot(root, "non-hex");
+      writeManifest(root, [
+        {
+          heading: "shorty",
+          pinnedSha: "abc1234", // 7 chars
+          localPath: "third-party/shorty/",
+        },
+        {
+          heading: "non-hex",
+          pinnedSha: "g".repeat(40), // 40 chars, not hex
+          localPath: "third-party/non-hex/",
+        },
+      ]);
+      const result = checkThirdPartyShape(root);
+      assert.equal(result.drifts.length, 2);
+      const kinds = result.drifts.map((d) => d.kind).sort();
+      assert.deepEqual(kinds, ["invalid-sha", "invalid-sha"]);
+      const names = result.drifts.map((d) => d.snapshot).sort();
+      assert.deepEqual(names, ["non-hex", "shorty"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("handles heading != dir name (looks up by Local path, not by heading)", () => {
+    const root = setupFixture();
+    try {
+      // realistic case: dir is "superpowers", heading is "obra/superpowers"
+      writeSnapshot(root, "superpowers");
+      writeManifest(root, [
+        {
+          heading: "obra/superpowers",
+          pinnedSha: SHA_40,
+          localPath: "third-party/superpowers/",
+        },
+      ]);
+      const result = checkThirdPartyShape(root);
+      assert.deepEqual(result.drifts, []);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("flags an empty OUR_NOTES.md as missing-our-notes", () => {
+    const root = setupFixture();
+    try {
+      writeSnapshot(root, "alpha", { ourNotes: "" });
+      writeManifest(root, [
+        { heading: "alpha", pinnedSha: SHA_40, localPath: "third-party/alpha/" },
+      ]);
+      const result = checkThirdPartyShape(root);
+      assert.equal(result.drifts.length, 1);
+      assert.equal(result.drifts[0].kind, "missing-our-notes");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-third-party-shape — live repo acceptance gate", () => {
+  it("the four current snapshots all pass the shape invariant", () => {
+    const result = checkThirdPartyShape(REPO_ROOT);
+    assert.deepEqual(
+      result.drifts,
+      [],
+      `live repo drifts: ${JSON.stringify(result.drifts, null, 2)}`,
+    );
+    assert.ok(
+      result.snapshotCount >= 4,
+      `expected at least 4 snapshots, found ${result.snapshotCount}`,
+    );
+  });
+
+  it("the CLI exits 0 against the live repo", () => {
+    const stdout = execFileSync("node", [CHECKER, REPO_ROOT], {
+      encoding: "utf8",
+    });
+    assert.match(stdout, /^OK third-party-shape:/);
+  });
+});

--- a/test/check-third-party-shape.test.mjs
+++ b/test/check-third-party-shape.test.mjs
@@ -1,0 +1,268 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { checkThirdPartyShape, discoverSnapshots, parseManifestEntries, } from "../bin/check-third-party-shape.mjs";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-third-party-shape.mjs");
+const SHA_40 = "f2cbfbefebbfef77321e4c9abc9e949826bea9d7";
+const SHA_40_ALT = "742dca58ae557bc67afec9ea8e6de59c085f0534";
+function setupFixture() {
+    const root = mkdtempSync(join(tmpdir(), "third-party-shape-test-"));
+    mkdirSync(join(root, "third-party"), { recursive: true });
+    return root;
+}
+function writeSnapshot(root, name, options = {}) {
+    const dir = join(root, "third-party", name);
+    mkdirSync(dir, { recursive: true });
+    if (options.ourNotes !== null) {
+        writeFileSync(join(dir, "OUR_NOTES.md"), options.ourNotes ?? `# OUR_NOTES — ${name}\nNon-empty.`);
+    }
+    if (options.license !== null) {
+        writeFileSync(join(dir, "LICENSE"), options.license ?? "MIT License\n\nCopyright (c) test\n");
+    }
+}
+function writeManifest(root, entries) {
+    const blocks = entries.map((e) => {
+        const rows = [`### ${e.heading}`, "", "| Field | Value |", "|---|---|"];
+        if (e.pinnedSha !== null) {
+            rows.push(`| Pinned SHA | \`${e.pinnedSha}\` |`);
+        }
+        if (e.localPath !== null) {
+            rows.push(`| Local path | \`${e.localPath}\` |`);
+        }
+        return rows.join("\n");
+    });
+    const body = ["# third-party/MANIFEST.md", "", ...blocks, ""].join("\n\n");
+    writeFileSync(join(root, "third-party", "MANIFEST.md"), body);
+}
+describe("check-third-party-shape — pure functions", () => {
+    it("discoverSnapshots returns snapshot dir names, ignoring files at third-party/ root", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "alpha");
+            writeSnapshot(root, "beta");
+            writeFileSync(join(root, "third-party", "MANIFEST.md"), "# manifest\n");
+            writeFileSync(join(root, "third-party", "README.md"), "# readme\n");
+            const names = discoverSnapshots(root)
+                .map((s) => s.name)
+                .sort();
+            assert.deepEqual(names, ["alpha", "beta"]);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("discoverSnapshots reports OUR_NOTES.md and LICENSE presence per snapshot", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "complete"); // has both
+            writeSnapshot(root, "no-notes", { ourNotes: null });
+            writeSnapshot(root, "no-license", { license: null });
+            const map = new Map(discoverSnapshots(root).map((s) => [s.name, s]));
+            assert.equal(map.get("complete")?.hasOurNotes, true);
+            assert.equal(map.get("complete")?.hasLicense, true);
+            assert.equal(map.get("no-notes")?.hasOurNotes, false);
+            assert.equal(map.get("no-license")?.hasLicense, false);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("parseManifestEntries extracts heading + pinnedSha + localPath", () => {
+        const text = [
+            "# manifest",
+            "",
+            "### foo",
+            "",
+            "| Pinned SHA | `" + SHA_40 + "` |",
+            "| Local path | `third-party/foo/` |",
+            "",
+            "### bar/qux",
+            "",
+            "| Pinned SHA | `" + SHA_40_ALT + "` |",
+            "| Local path | `third-party/bar-qux/` |",
+            "",
+        ].join("\n");
+        const entries = parseManifestEntries(text);
+        assert.equal(entries.length, 2);
+        const byHeading = new Map(entries.map((e) => [e.heading, e]));
+        assert.equal(byHeading.get("foo")?.pinnedSha, SHA_40);
+        assert.equal(byHeading.get("foo")?.localPath, "third-party/foo/");
+        assert.equal(byHeading.get("bar/qux")?.pinnedSha, SHA_40_ALT);
+        assert.equal(byHeading.get("bar/qux")?.localPath, "third-party/bar-qux/");
+    });
+    it("parseManifestEntries omits entries without a Local path (pending snapshots)", () => {
+        const text = [
+            "# manifest",
+            "",
+            "### vendored-thing",
+            "",
+            "| Pinned SHA | `" + SHA_40 + "` |",
+            "| Local path | `third-party/vendored-thing/` |",
+            "",
+            "## Pending snapshots",
+            "",
+            "### pending-thing",
+            "- License audited: MIT",
+            "- decline to vendor.",
+            "",
+        ].join("\n");
+        const entries = parseManifestEntries(text);
+        assert.equal(entries.length, 1);
+        assert.equal(entries[0].heading, "vendored-thing");
+    });
+});
+describe("check-third-party-shape — checkThirdPartyShape", () => {
+    it("reports zero drifts when all snapshots have OUR_NOTES.md, LICENSE, and a matching pinned MANIFEST entry", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "alpha");
+            writeSnapshot(root, "obra-superpowers");
+            writeManifest(root, [
+                {
+                    heading: "alpha",
+                    pinnedSha: SHA_40,
+                    localPath: "third-party/alpha/",
+                },
+                {
+                    heading: "obra/superpowers",
+                    pinnedSha: SHA_40_ALT,
+                    localPath: "third-party/obra-superpowers/",
+                },
+            ]);
+            const result = checkThirdPartyShape(root);
+            assert.deepEqual(result.drifts, []);
+            assert.equal(result.snapshotCount, 2);
+            assert.equal(result.manifestEntryCount, 2);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a missing OUR_NOTES.md", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "alpha", { ourNotes: null });
+            writeManifest(root, [
+                { heading: "alpha", pinnedSha: SHA_40, localPath: "third-party/alpha/" },
+            ]);
+            const result = checkThirdPartyShape(root);
+            assert.equal(result.drifts.length, 1);
+            assert.equal(result.drifts[0].kind, "missing-our-notes");
+            assert.equal(result.drifts[0].snapshot, "alpha");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a missing LICENSE", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "alpha", { license: null });
+            writeManifest(root, [
+                { heading: "alpha", pinnedSha: SHA_40, localPath: "third-party/alpha/" },
+            ]);
+            const result = checkThirdPartyShape(root);
+            assert.equal(result.drifts.length, 1);
+            assert.equal(result.drifts[0].kind, "missing-license");
+            assert.equal(result.drifts[0].snapshot, "alpha");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a snapshot dir with no matching MANIFEST entry", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "orphan");
+            writeManifest(root, []);
+            const result = checkThirdPartyShape(root);
+            assert.equal(result.drifts.length, 1);
+            assert.equal(result.drifts[0].kind, "no-manifest-entry");
+            assert.equal(result.drifts[0].snapshot, "orphan");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags a non-40-char or non-hex Pinned SHA", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "shorty");
+            writeSnapshot(root, "non-hex");
+            writeManifest(root, [
+                {
+                    heading: "shorty",
+                    pinnedSha: "abc1234", // 7 chars
+                    localPath: "third-party/shorty/",
+                },
+                {
+                    heading: "non-hex",
+                    pinnedSha: "g".repeat(40), // 40 chars, not hex
+                    localPath: "third-party/non-hex/",
+                },
+            ]);
+            const result = checkThirdPartyShape(root);
+            assert.equal(result.drifts.length, 2);
+            const kinds = result.drifts.map((d) => d.kind).sort();
+            assert.deepEqual(kinds, ["invalid-sha", "invalid-sha"]);
+            const names = result.drifts.map((d) => d.snapshot).sort();
+            assert.deepEqual(names, ["non-hex", "shorty"]);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("handles heading != dir name (looks up by Local path, not by heading)", () => {
+        const root = setupFixture();
+        try {
+            // realistic case: dir is "superpowers", heading is "obra/superpowers"
+            writeSnapshot(root, "superpowers");
+            writeManifest(root, [
+                {
+                    heading: "obra/superpowers",
+                    pinnedSha: SHA_40,
+                    localPath: "third-party/superpowers/",
+                },
+            ]);
+            const result = checkThirdPartyShape(root);
+            assert.deepEqual(result.drifts, []);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("flags an empty OUR_NOTES.md as missing-our-notes", () => {
+        const root = setupFixture();
+        try {
+            writeSnapshot(root, "alpha", { ourNotes: "" });
+            writeManifest(root, [
+                { heading: "alpha", pinnedSha: SHA_40, localPath: "third-party/alpha/" },
+            ]);
+            const result = checkThirdPartyShape(root);
+            assert.equal(result.drifts.length, 1);
+            assert.equal(result.drifts[0].kind, "missing-our-notes");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+describe("check-third-party-shape — live repo acceptance gate", () => {
+    it("the four current snapshots all pass the shape invariant", () => {
+        const result = checkThirdPartyShape(REPO_ROOT);
+        assert.deepEqual(result.drifts, [], `live repo drifts: ${JSON.stringify(result.drifts, null, 2)}`);
+        assert.ok(result.snapshotCount >= 4, `expected at least 4 snapshots, found ${result.snapshotCount}`);
+    });
+    it("the CLI exits 0 against the live repo", () => {
+        const stdout = execFileSync("node", [CHECKER, REPO_ROOT], {
+            encoding: "utf8",
+        });
+        assert.match(stdout, /^OK third-party-shape:/);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a CI invariant that fails when any `third-party/<name>/` snapshot drifts out of the vendor playbook documented in [`third-party/README.md`](https://github.com/naimkatiman/continuous-improvement/blob/main/third-party/README.md). With four snapshots now landed (`oh-my-claudecode`, `superpowers`, `addy-agent-skills`, `ruflo-swarm`) the failure mode the check prevents is real: a future vendor PR could ship without `OUR_NOTES.md`, without `LICENSE`, without a matching `MANIFEST.md` row, or with a non-pinned SHA, and nothing in CI would catch it today.

This implements **deferred follow-up #2** from PR [#79](https://github.com/naimkatiman/continuous-improvement/pull/79) and PR [#80](https://github.com/naimkatiman/continuous-improvement/pull/80).

## Invariant rules

For each `third-party/<name>/` directory:

1. `OUR_NOTES.md` exists and is non-empty
2. `LICENSE` exists
3. `third-party/MANIFEST.md` has at least one `### <heading>` block whose `Local path` row points at this snapshot
4. The matching MANIFEST entry has a `Pinned SHA` row containing a 40-char lowercase hex string

The mapping between snapshot directory and MANIFEST heading is **NOT identity** for 3 of the 4 current snapshots:

- dir `superpowers` ↔ heading `obra/superpowers`
- dir `addy-agent-skills` ↔ heading `addyosmani/agent-skills`
- dir `ruflo-swarm` ↔ heading `ruvnet/ruflo (plugins/ruflo-swarm slice)`

So the lookup is by `Local path`, not by name. The "Pending snapshots" section at the bottom of `MANIFEST.md` is correctly skipped — entries without a `Local path` are not vendored.

## TDD discipline

RED-GREEN-REFACTOR honored:

1. **RED:** `src/test/check-third-party-shape.test.mts` landed first. Typecheck failed at the import (`../bin/check-third-party-shape.mjs` did not exist).
2. **GREEN:** `src/bin/check-third-party-shape.mts` written. Typecheck passed. All 13 new tests passed.
3. **REFACTOR:** Clean rebuild verified idempotent build artifacts. Full suite 492/492 (was 479; +13 from this PR). 110 suites (was 107; +3 from this PR).

## Files (5 new, no edits to existing files)

- `src/bin/check-third-party-shape.mts` — invariant source (~244 LOC including JSDoc header)
- `src/test/check-third-party-shape.test.mts` — test source (13 cases across 3 describes)
- `bin/check-third-party-shape.mjs` — `tsc` build output (committed per project convention, matches `bin/check-routing-targets.mjs` pattern)
- `test/check-third-party-shape.test.mjs` — `tsc` build output
- `docs/plans/2026-05-07-third-party-shape-invariant.md` — plan doc

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm test` — 492/492 (479 baseline + 13 new)
- [x] All 13 new tests pass in isolation: `node --test test/check-third-party-shape.test.mjs`
- [x] `node bin/check-third-party-shape.mjs` against current main — prints `OK third-party-shape: all 4 snapshot(s) compliant (4 MANIFEST entries with Local path).` exit 0
- [x] `typescript-reviewer` agent — 0 CRITICAL, 0 HIGH, 0 MEDIUM, 2 LOW (informational, below action threshold)
- [x] Build determinism — `npm run clean && npm run build` produces identical `.mjs` artifacts
- [x] Test fixtures use `mkdtempSync` (matches `check-routing-targets.test.mts` convention) — no live-repo coupling for unit tests
- [x] Live-repo acceptance gate — function-level + CLI-level test against the 4 current snapshots
- [x] Single-concern: no edits to `MANIFEST.md`, `OUR_NOTES.md`, `package.json`, `.gitignore`, `README.md`, existing source, or `bin/refresh-third-party.mjs`
- [x] `package-lock.json` drift discarded before stage
- [ ] Reviewer to confirm the parser correctly handles all 4 live MANIFEST headings, especially the parenthesized one (`ruvnet/ruflo (plugins/ruflo-swarm slice)`)

## Wiring decision

The check runs as part of `npm test` automatically because `package.json` already does `node --test test/*.test.mjs` and `tsc` emits `test/check-third-party-shape.test.mjs` from the `.mts` source. **No `package.json` edit needed** — keeping the wiring change out of this PR is single-concern protection.

A future PR can add an explicit `npm run verify:third-party` script if a separate gate is wanted; not done here.

## Out of scope

- Editing existing snapshots (none of the 4 trigger any drift today)
- Driver SNAPSHOTS entries in `bin/refresh-third-party.mjs` (deferred follow-up #1, still parked)
- An explicit `npm run verify:third-party` script (over-engineering for one check)
- Anything related to the addy or ruflo plugin contents

## Plan doc

[`docs/plans/2026-05-07-third-party-shape-invariant.md`](https://github.com/naimkatiman/continuous-improvement/blob/feat/third-party-shape-invariant/docs/plans/2026-05-07-third-party-shape-invariant.md) — invariant rules, P-MAG negative prompts, step plan, wiring decision, risks, explicit out-of-scope.