### PR TITLE
feat(p-mag): lock the third surface under docs-substrings + test

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -137,6 +137,20 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Will NOT repeat:", source: "past-mistake-gate.test.mts" },
     { file: "skills/proceed-with-the-recommendation.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
     { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
+    // P-MAG third surface (auto-memory feedback_*.md) — locked 2026-05-07 after PR #83.
+    // Rule 1 of Phase 0 was upgraded from scanning two surfaces to scanning three so
+    // the operator's named past-mistake corrections (which live in
+    // ~/.claude/projects/<hash>/memory/feedback_*.md) cannot be silently skipped.
+    // Each assertion below catches a specific class of regression:
+    //   - "Scan three surfaces"           → reverting the surface count back to two
+    //   - "memory/feedback_*.md"          → dropping the glob pattern entirely
+    //   - "feedback_past_mistake_gate.md" → generic rewording that loses the concrete anchor
+    { file: "skills/proceed-with-the-recommendation.md", pattern: "Scan three surfaces", source: "past-mistake-gate.test.mts" },
+    { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Scan three surfaces", source: "past-mistake-gate.test.mts" },
+    { file: "skills/proceed-with-the-recommendation.md", pattern: "memory/feedback_*.md", source: "past-mistake-gate.test.mts" },
+    { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "memory/feedback_*.md", source: "past-mistake-gate.test.mts" },
+    { file: "skills/proceed-with-the-recommendation.md", pattern: "feedback_past_mistake_gate.md", source: "past-mistake-gate.test.mts" },
+    { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "feedback_past_mistake_gate.md", source: "past-mistake-gate.test.mts" },
     // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
     // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
     { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -163,6 +163,21 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "skills/proceed-with-the-recommendation.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
   { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Prior-mistake residue still present", source: "past-mistake-gate.test.mts" },
 
+  // P-MAG third surface (auto-memory feedback_*.md) — locked 2026-05-07 after PR #83.
+  // Rule 1 of Phase 0 was upgraded from scanning two surfaces to scanning three so
+  // the operator's named past-mistake corrections (which live in
+  // ~/.claude/projects/<hash>/memory/feedback_*.md) cannot be silently skipped.
+  // Each assertion below catches a specific class of regression:
+  //   - "Scan three surfaces"           → reverting the surface count back to two
+  //   - "memory/feedback_*.md"          → dropping the glob pattern entirely
+  //   - "feedback_past_mistake_gate.md" → generic rewording that loses the concrete anchor
+  { file: "skills/proceed-with-the-recommendation.md", pattern: "Scan three surfaces", source: "past-mistake-gate.test.mts" },
+  { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Scan three surfaces", source: "past-mistake-gate.test.mts" },
+  { file: "skills/proceed-with-the-recommendation.md", pattern: "memory/feedback_*.md", source: "past-mistake-gate.test.mts" },
+  { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "memory/feedback_*.md", source: "past-mistake-gate.test.mts" },
+  { file: "skills/proceed-with-the-recommendation.md", pattern: "feedback_past_mistake_gate.md", source: "past-mistake-gate.test.mts" },
+  { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "feedback_past_mistake_gate.md", source: "past-mistake-gate.test.mts" },
+
   // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
   // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
   { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },

--- a/src/test/past-mistake-gate.test.mts
+++ b/src/test/past-mistake-gate.test.mts
@@ -10,6 +10,9 @@ const REPO_ROOT = join(__dirname, "..");
 const PHASE_0_HEADING = "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)";
 const NEGATIVE_PROMPT_FIELD = "Will NOT repeat:";
 const STOP_CONDITION_BULLET = "Prior-mistake residue still present";
+const THREE_SURFACES_DECLARATION = "Scan three surfaces";
+const FEEDBACK_GLOB_PATTERN = "memory/feedback_*.md";
+const FEEDBACK_EXAMPLE_ANCHOR = "feedback_past_mistake_gate.md";
 
 const MIRRORS: ReadonlyArray<{ path: string; label: string }> = [
   {
@@ -34,6 +37,18 @@ const REQUIRED_LITERALS: ReadonlyArray<{ literal: string; reason: string }> = [
   {
     literal: STOP_CONDITION_BULLET,
     reason: "Stop Conditions bullet — Rule 2 clearance gate is enumerated as a hard halt via this line.",
+  },
+  {
+    literal: THREE_SURFACES_DECLARATION,
+    reason: "Rule 1 surface count — must read 'three surfaces', not 'two'. Reverting to two silently drops the auto-memory feedback_*.md surface (PR #83).",
+  },
+  {
+    literal: FEEDBACK_GLOB_PATTERN,
+    reason: "Auto-memory feedback file pattern — Rule 1 must reference memory/feedback_*.md as a scanned surface. The operator's named corrections live there; without this glob the gate cannot quote them.",
+  },
+  {
+    literal: FEEDBACK_EXAMPLE_ANCHOR,
+    reason: "Concrete example anchor — Rule 1 names feedback_past_mistake_gate.md as a real instance so the rule cannot be rationalized into ignoring the surface. Generic rewording loses this anchor.",
   },
 ];
 

--- a/test/past-mistake-gate.test.mjs
+++ b/test/past-mistake-gate.test.mjs
@@ -8,6 +8,9 @@ const REPO_ROOT = join(__dirname, "..");
 const PHASE_0_HEADING = "Phase 0: Acknowledge (Past Mistake Acknowledgment Gate / P-MAG)";
 const NEGATIVE_PROMPT_FIELD = "Will NOT repeat:";
 const STOP_CONDITION_BULLET = "Prior-mistake residue still present";
+const THREE_SURFACES_DECLARATION = "Scan three surfaces";
+const FEEDBACK_GLOB_PATTERN = "memory/feedback_*.md";
+const FEEDBACK_EXAMPLE_ANCHOR = "feedback_past_mistake_gate.md";
 const MIRRORS = [
     {
         path: "skills/proceed-with-the-recommendation.md",
@@ -30,6 +33,18 @@ const REQUIRED_LITERALS = [
     {
         literal: STOP_CONDITION_BULLET,
         reason: "Stop Conditions bullet — Rule 2 clearance gate is enumerated as a hard halt via this line.",
+    },
+    {
+        literal: THREE_SURFACES_DECLARATION,
+        reason: "Rule 1 surface count — must read 'three surfaces', not 'two'. Reverting to two silently drops the auto-memory feedback_*.md surface (PR #83).",
+    },
+    {
+        literal: FEEDBACK_GLOB_PATTERN,
+        reason: "Auto-memory feedback file pattern — Rule 1 must reference memory/feedback_*.md as a scanned surface. The operator's named corrections live there; without this glob the gate cannot quote them.",
+    },
+    {
+        literal: FEEDBACK_EXAMPLE_ANCHOR,
+        reason: "Concrete example anchor — Rule 1 names feedback_past_mistake_gate.md as a real instance so the rule cannot be rationalized into ignoring the surface. Generic rewording loses this anchor.",
     },
 ];
 describe("proceed-with-the-recommendation past-mistake-gate (P-MAG)", () => {


### PR DESCRIPTION
## Summary
Follow-up to PR #83. The previous PR upgraded P-MAG Rule 1 from scanning two surfaces to three (adding the auto-memory `~/.claude/projects/<hash>/memory/feedback_*.md` surface so the operator's named past-mistake corrections cannot be silently skipped). That edit had no automated guard — a future session could quietly revert the surface count back to two, or reword the glob into a generic phrase that loses the canonical anchor.

This PR locks three literals into the past-mistake-gate test + the docs-substrings lint manifest, on both the standalone skill and the plugin mirror:

- `Scan three surfaces` — catches a revert to "two surfaces"
- `memory/feedback_*.md` — catches deletion of the glob pattern
- `feedback_past_mistake_gate.md` — catches generic rewording that loses the concrete anchor

`docs-substrings` now reports **120 assertions** (was 114). The full test suite reports **498 / 498 passing**.

## Why this matters
The lesson from PR #83's session: skill-mirror caught my drift on first try, but only after a reset+resplit. A literal-substring lint is a faster-cheaper guard that catches the same class of regression at lint speed before the test suite runs. Ship this assertion BEFORE the second-release train (items 4+6+7+8) so the same surface that the next session might touch is already lockedown.

## Verification

```
npm run build            # regenerate .mjs from .mts
npm run verify:all       # 7/7 gates green (docs-substrings now 120 / 120)
npm test                 # 498 tests pass, 0 fail
```

Edits the `.mts` source; matching `.mjs` files regenerated by `npm run build` per the `.mts-is-source` rule. Both `bin/check-docs-substrings.mjs` and `test/past-mistake-gate.test.mjs` are committed alongside their `.mts` sources so `verify:generated` (`git diff --exit-code -- bin test lib plugins`) stays clean.

## Test plan
- [ ] Confirm `npm run verify:all` reports 120 docs-substring assertions, all matching
- [ ] Confirm `npm test` reports 498 / 498 passing
- [ ] Confirm both standalone and plugin-mirror P-MAG files are checked (the test loops over MIRRORS)
- [ ] Confirm the three new REQUIRED_LITERALS (lines 14–16 of `src/test/past-mistake-gate.test.mts`) generate 6 new test assertions in the output

## What's deferred
Items 4 + 6 + 7 + 8 (workspace-surface-audit grain, stacked-PR default, verification-loop ladder, continuous-learning friction harvest) — held until this lockdown lands so they can be added on a guard-equipped surface.