### PR TITLE
feat(superpowers): require a stacked-PR plan for ≥3-file changes (PR B of train)

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -166,6 +166,17 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md", pattern: "core.autocrlf", source: "docs-substrings-manifest:workspace-surface-audit-environment-grain" },
     { file: "skills/workspace-surface-audit.md", pattern: "Parallel-actor expectation", source: "docs-substrings-manifest:workspace-surface-audit-environment-grain" },
     { file: "plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md", pattern: "Parallel-actor expectation", source: "docs-substrings-manifest:workspace-surface-audit-environment-grain" },
+    // superpowers Stacked-PR Plan Precondition — locked 2026-05-07 (PR B of second-release train).
+    // The dispatcher gained a non-negotiable rule for ≥3-file changes: produce a stacked-PR plan
+    // (per-PR table, dependency graph, worktree-per-PR, out-of-scope) before the first edit. The
+    // rule excludes markdown-only / lockfile-only / generated-only / vendor-refresh / skill-mirror
+    // changes. Each assertion below catches a specific class of regression:
+    //   - "## Stacked-PR Plan Precondition (≥3 files)" → removing the whole rule heading
+    //   - "Per-PR table"                                → losing the required-output enumeration
+    { file: "skills/superpowers.md", pattern: "## Stacked-PR Plan Precondition (≥3 files)", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+    { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "## Stacked-PR Plan Precondition (≥3 files)", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+    { file: "skills/superpowers.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+    { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
     // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
     // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
     { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },

--- a/plugins/continuous-improvement/skills/superpowers/SKILL.md
+++ b/plugins/continuous-improvement/skills/superpowers/SKILL.md
@@ -28,6 +28,31 @@ AI agents skip steps, guess, and declare "done" without verifying. Superpowers b
 
 The agent checks for relevant skills before any task. These are mandatory workflows, not suggestions.
 
+## Stacked-PR Plan Precondition (≥3 files)
+
+Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan **before** the first edit lands. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.
+
+The required plan output has four components, in this order:
+
+1. **Per-PR table** — title, scope (files), test strategy, merge order. One row per PR.
+2. **Dependency graph** — which PRs depend on which (or "independent" if none).
+3. **Worktree per PR** — branch name + base commit. Sequential by default; parallel only when items share no state.
+4. **Out-of-scope list** — anything explicitly NOT in the train. Drive-by temptations get logged here, not implemented.
+
+The plan ships as the FIRST commit of the train's first PR (under `docs/plans/YYYY-MM-DD-<slug>.md`) and is cited by every subsequent commit it produces.
+
+### When this rule does NOT fire
+
+The threshold targets multi-concern feature work, not high-volume mechanical changes. The rule does NOT fire on:
+
+- **Markdown-only commits** — README, CHANGELOG, docs/ updates that touch many files but ship one concern.
+- **Lockfile-only commits** — `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, etc. updated in isolation by a dependency bump.
+- **Generated-only commits** — output of `npm run build`, `tsc`, codemod sweeps, or any tool whose input is one source file and whose output is many derived files. The source change is what counts toward the threshold; the regenerated artifacts ride free.
+- **Vendor-snapshot refreshes** — `third-party/<name>/` updated by a documented `bin/refresh-third-party.mjs` driver. The single source of change is the upstream SHA bump.
+- **Skill-mirror sync commits** — `skills/<name>.md` + `plugins/continuous-improvement/skills/<name>/SKILL.md` count as one file pair, not two, since the CONTRIBUTING.md skill mirror rule treats them as the same concern.
+
+If you are unsure whether the rule applies, the fall-through default is to write the plan. A 30-line plan doc is cheap; a stranded big-bang edit is expensive.
+
 ## Skill Library
 
 ### Testing

--- a/plugins/continuous-improvement/skills/superpowers/SKILL.md
+++ b/plugins/continuous-improvement/skills/superpowers/SKILL.md
@@ -30,7 +30,7 @@ The agent checks for relevant skills before any task. These are mandatory workfl
 
 ## Stacked-PR Plan Precondition (≥3 files)
 
-Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan **before** the first edit lands. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.
+Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan as a precondition to the first edit landing. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.
 
 The required plan output has four components, in this order:
 

--- a/skills/superpowers.md
+++ b/skills/superpowers.md
@@ -28,6 +28,31 @@ AI agents skip steps, guess, and declare "done" without verifying. Superpowers b
 
 The agent checks for relevant skills before any task. These are mandatory workflows, not suggestions.
 
+## Stacked-PR Plan Precondition (≥3 files)
+
+Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan **before** the first edit lands. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.
+
+The required plan output has four components, in this order:
+
+1. **Per-PR table** — title, scope (files), test strategy, merge order. One row per PR.
+2. **Dependency graph** — which PRs depend on which (or "independent" if none).
+3. **Worktree per PR** — branch name + base commit. Sequential by default; parallel only when items share no state.
+4. **Out-of-scope list** — anything explicitly NOT in the train. Drive-by temptations get logged here, not implemented.
+
+The plan ships as the FIRST commit of the train's first PR (under `docs/plans/YYYY-MM-DD-<slug>.md`) and is cited by every subsequent commit it produces.
+
+### When this rule does NOT fire
+
+The threshold targets multi-concern feature work, not high-volume mechanical changes. The rule does NOT fire on:
+
+- **Markdown-only commits** — README, CHANGELOG, docs/ updates that touch many files but ship one concern.
+- **Lockfile-only commits** — `package-lock.json`, `pnpm-lock.yaml`, `Cargo.lock`, etc. updated in isolation by a dependency bump.
+- **Generated-only commits** — output of `npm run build`, `tsc`, codemod sweeps, or any tool whose input is one source file and whose output is many derived files. The source change is what counts toward the threshold; the regenerated artifacts ride free.
+- **Vendor-snapshot refreshes** — `third-party/<name>/` updated by a documented `bin/refresh-third-party.mjs` driver. The single source of change is the upstream SHA bump.
+- **Skill-mirror sync commits** — `skills/<name>.md` + `plugins/continuous-improvement/skills/<name>/SKILL.md` count as one file pair, not two, since the CONTRIBUTING.md skill mirror rule treats them as the same concern.
+
+If you are unsure whether the rule applies, the fall-through default is to write the plan. A 30-line plan doc is cheap; a stranded big-bang edit is expensive.
+
 ## Skill Library
 
 ### Testing

--- a/skills/superpowers.md
+++ b/skills/superpowers.md
@@ -30,7 +30,7 @@ The agent checks for relevant skills before any task. These are mandatory workfl
 
 ## Stacked-PR Plan Precondition (≥3 files)
 
-Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan **before** the first edit lands. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.
+Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan as a precondition to the first edit landing. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.
 
 The required plan output has four components, in this order:
 

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -194,6 +194,18 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "skills/workspace-surface-audit.md", pattern: "Parallel-actor expectation", source: "docs-substrings-manifest:workspace-surface-audit-environment-grain" },
   { file: "plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md", pattern: "Parallel-actor expectation", source: "docs-substrings-manifest:workspace-surface-audit-environment-grain" },
 
+  // superpowers Stacked-PR Plan Precondition — locked 2026-05-07 (PR B of second-release train).
+  // The dispatcher gained a non-negotiable rule for ≥3-file changes: produce a stacked-PR plan
+  // (per-PR table, dependency graph, worktree-per-PR, out-of-scope) before the first edit. The
+  // rule excludes markdown-only / lockfile-only / generated-only / vendor-refresh / skill-mirror
+  // changes. Each assertion below catches a specific class of regression:
+  //   - "## Stacked-PR Plan Precondition (≥3 files)" → removing the whole rule heading
+  //   - "Per-PR table"                                → losing the required-output enumeration
+  { file: "skills/superpowers.md", pattern: "## Stacked-PR Plan Precondition (≥3 files)", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+  { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "## Stacked-PR Plan Precondition (≥3 files)", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+  { file: "skills/superpowers.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+  { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+
   // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
   // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
   { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },


### PR DESCRIPTION
## Summary
PR B of the second-release train. Plan doc at `docs/plans/2026-05-07-second-release-train.md` (landed in PR #85). PR A (`workspace-surface-audit` Environment Grain) merged as `e7fe080`.

The report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.

Add a **Stacked-PR Plan Precondition** section between the Basic Workflow table and the Skill Library, naming four required outputs:

1. **Per-PR table** — title, scope (files), test strategy, merge order
2. **Dependency graph** — which PRs depend on which (or "independent")
3. **Worktree per PR** — branch name + base commit
4. **Out-of-scope list** — drive-by temptations get logged here, not implemented

The rule explicitly does NOT fire on:

- markdown-only / lockfile-only / generated-only commits
- vendor-snapshot refreshes via a documented `bin/refresh-third-party.mjs` driver
- skill-mirror sync commits (standalone + plugin = one concern, not two)

Plan doc ships as the FIRST commit of the train's first PR (per global CLAUDE.md `docs/plans/YYYY-MM-DD-<slug>.md` rule) and is cited by every subsequent commit it produces.

## Lockdown

Two docs-substring assertions × 2 mirrors = 4 new lint assertions:

- `## Stacked-PR Plan Precondition (≥3 files)` — catches whole-rule removal
- `Per-PR table` — catches loss of the required-output enumeration

## Verification

```
npm run verify:all    # 7/7 gates green; docs-substrings 126 -> 130 (+4)
npm run build         # no .mjs drift after regeneration
```

## Files (4 — exactly plan-scoped)

| File | Change |
|---|---|
| `skills/superpowers.md` | +25 lines: Stacked-PR Plan Precondition section |
| `plugins/continuous-improvement/skills/superpowers/SKILL.md` | byte-identical mirror |
| `src/bin/check-docs-substrings.mts` | +12 lines: 4 lockdown assertions |
| `bin/check-docs-substrings.mjs` | regenerated by `tsc` |

## Test plan
- [ ] `npm run verify:all` reports 130 docs-substring assertions, all matching
- [ ] `npm run build && git diff --exit-code -- bin test lib plugins` exits 0 (no drift)
- [ ] Standalone + plugin mirror are byte-identical
- [ ] The exclusions list (markdown-only, lockfile-only, generated-only, vendor-refresh, skill-mirror) is exhaustive enough to prevent friction on routine commits

## Train context
Next: **PR C** — `feat(verification-loop): per-project ladder via .claude/verify-ladder.json`. PR C's worktree opens only after this merges.