### PR TITLE
feat(verification-loop): per-project ladder via .claude/verify-ladder.json (PR C of train)

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -177,6 +177,23 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "## Stacked-PR Plan Precondition (≥3 files)", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
     { file: "skills/superpowers.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
     { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
+    // verification-loop per-project ladder — locked 2026-05-07 (PR C of second-release train).
+    // Phase 0 (Ladder Resolution) was added so Phases 1–6 read the project's actual build/typecheck/
+    // lint/test/security/deploy_receipt invocations from .claude/verify-ladder.json (or sniff /
+    // ask fallback) instead of hardcoded npm run X. Phase 8 wires deploy-receipt (PR #83) for
+    // auto-deploy projects. Each assertion below catches a specific class of regression:
+    //   - "### Phase 0: Resolve the Ladder" → removing the whole resolution phase
+    //   - ".claude/verify-ladder.json"      → renaming or moving the manifest path
+    //   - "verify-ladder (resolved):"       → losing the resolved-ladder output contract
+    //   - "### Phase 8: Deploy Receipt"     → losing the cross-skill integration with PR #83
+    { file: "skills/verification-loop.md", pattern: "### Phase 0: Resolve the Ladder", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "### Phase 0: Resolve the Ladder", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "skills/verification-loop.md", pattern: ".claude/verify-ladder.json", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: ".claude/verify-ladder.json", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "skills/verification-loop.md", pattern: "verify-ladder (resolved):", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "verify-ladder (resolved):", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "skills/verification-loop.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
     // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
     // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
     { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },

--- a/plugins/continuous-improvement/skills/verification-loop/SKILL.md
+++ b/plugins/continuous-improvement/skills/verification-loop/SKILL.md
@@ -19,12 +19,49 @@ Invoke this skill:
 
 ## Verification Phases
 
+### Phase 0: Resolve the Ladder
+
+Every project has its own actual invocation for build / typecheck / lint / test / security / deploy-receipt. Hardcoding `npm run build` and `npm run test` works when the project happens to use those exact scripts; for everything else (pnpm, yarn, cargo, go, mise, just, custom scripts, monorepos with workspace-scoped commands) it returns "deps not installed" or "config not found" misreads from the wrong invocation. Phase 0 runs first so Phases 1–6 never have to guess.
+
+**Resolution priority** (first match wins):
+
+1. **`.claude/verify-ladder.json` manifest** at the repo root. Schema:
+   ```json
+   {
+     "build":          "npm run build",
+     "typecheck":      "tsc -p tsconfig.json --noEmit",
+     "lint":           "npm run lint",
+     "test":           "npm test",
+     "security":       "npm audit --audit-level=high",
+     "deploy_receipt": "npx wrangler deployments list --json"
+   }
+   ```
+   Any field omitted falls through to step 2 for that field only. A field set to the literal string `null` means "skip this phase for this project."
+2. **Sniff `package.json` `scripts`** for `build`, `typecheck` or `tsc`, `lint`, `test`, `audit` or `security`. Tie-breaker when multiple scripts could match a phase: prefer `verify:<phase>` over `<phase>` over `<phase>:*`. Do NOT pick `test` when `verify:test` exists; the operator's explicit verification surface always wins over the convenience alias.
+3. **Sniff per-language toolchain files** if `package.json` is absent: `Cargo.toml` → `cargo build` / `cargo test`, `go.mod` → `go build ./...` / `go test ./...`, `pyproject.toml` → `pytest` / `ruff check`, `Gemfile` → `bundle exec rspec`, etc.
+4. **Ask the operator** if none of the above resolves the field. Do not invent.
+
+**Output the resolved ladder** as a single fenced block before running any phase, so the operator can spot a wrong resolution before it costs a misread:
+
+```
+verify-ladder (resolved):
+  build:           npm run build
+  typecheck:       npx tsc --noEmit  (sniff: package.json scripts.typecheck)
+  lint:            npm run lint
+  test:            npm test
+  security:        (skipped — no script defined)
+  deploy_receipt:  npx wrangler deployments list --json  (manifest)
+```
+
+Each row shows the resolved command + its source (manifest, sniff, or skipped). The fenced block is the contract surface — every later phase reads from this resolved ladder, never from a hardcoded fallback.
+
+A starter manifest is provided at `templates/verify-ladder.example.json`; copy it to `.claude/verify-ladder.json` and trim per project.
+
 ### Phase 1: Build Verification
+Run the `build` command from the resolved ladder. Example for a default Node project:
 ```bash
-# Check if project builds
+# Resolved from package.json scripts.build:
 npm run build 2>&1 | tail -20
-# OR
-pnpm build 2>&1 | tail -20
 ```
 
 If build fails, STOP and fix before continuing.
@@ -103,6 +140,12 @@ Enumerate every step you said you would do — the recommendation list, the plan
 Both gates are independent: `Yes` on goal alone means a half-complete checklist that may break later; `Yes` on completeness alone means busywork that didn't deliver. Both must be `Yes` — even if the previous six phases all pass — or the work isn't done.
 
 If either is `No`, the verification report goes back to the operator with the explicit gap, not on to PR. The operator decides whether the gap is acceptable to ship as-is or whether more work is required first. Never silently downgrade to "ready" because the mechanism phases looked good.
+
+### Phase 8: Deploy Receipt (auto-deploy projects only)
+
+For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or whose sniff path detects an auto-deploy target (Railway, Cloudflare Workers, Vercel, Netlify, Fly.io) — the verify is not complete until the deployed SHA matches the merge SHA and a healthcheck returns 200. Hand off to the `deploy-receipt` skill (Law 4 deploy-seam companion landed in PR #83) and treat its `Receipt status: COMPLETE` as the gate.
+
+INCOMPLETE receipts move to "Immediate operator action" in the close, never to "ready". Library-only / package-published repos skip this phase entirely (no deploy seam exists).
 
 ## Output Format
 

--- a/skills/verification-loop.md
+++ b/skills/verification-loop.md
@@ -19,12 +19,49 @@ Invoke this skill:
 
 ## Verification Phases
 
+### Phase 0: Resolve the Ladder
+
+Every project has its own actual invocation for build / typecheck / lint / test / security / deploy-receipt. Hardcoding `npm run build` and `npm run test` works when the project happens to use those exact scripts; for everything else (pnpm, yarn, cargo, go, mise, just, custom scripts, monorepos with workspace-scoped commands) it returns "deps not installed" or "config not found" misreads from the wrong invocation. Phase 0 runs first so Phases 1–6 never have to guess.
+
+**Resolution priority** (first match wins):
+
+1. **`.claude/verify-ladder.json` manifest** at the repo root. Schema:
+   ```json
+   {
+     "build":          "npm run build",
+     "typecheck":      "tsc -p tsconfig.json --noEmit",
+     "lint":           "npm run lint",
+     "test":           "npm test",
+     "security":       "npm audit --audit-level=high",
+     "deploy_receipt": "npx wrangler deployments list --json"
+   }
+   ```
+   Any field omitted falls through to step 2 for that field only. A field set to the literal string `null` means "skip this phase for this project."
+2. **Sniff `package.json` `scripts`** for `build`, `typecheck` or `tsc`, `lint`, `test`, `audit` or `security`. Tie-breaker when multiple scripts could match a phase: prefer `verify:<phase>` over `<phase>` over `<phase>:*`. Do NOT pick `test` when `verify:test` exists; the operator's explicit verification surface always wins over the convenience alias.
+3. **Sniff per-language toolchain files** if `package.json` is absent: `Cargo.toml` → `cargo build` / `cargo test`, `go.mod` → `go build ./...` / `go test ./...`, `pyproject.toml` → `pytest` / `ruff check`, `Gemfile` → `bundle exec rspec`, etc.
+4. **Ask the operator** if none of the above resolves the field. Do not invent.
+
+**Output the resolved ladder** as a single fenced block before running any phase, so the operator can spot a wrong resolution before it costs a misread:
+
+```
+verify-ladder (resolved):
+  build:           npm run build
+  typecheck:       npx tsc --noEmit  (sniff: package.json scripts.typecheck)
+  lint:            npm run lint
+  test:            npm test
+  security:        (skipped — no script defined)
+  deploy_receipt:  npx wrangler deployments list --json  (manifest)
+```
+
+Each row shows the resolved command + its source (manifest, sniff, or skipped). The fenced block is the contract surface — every later phase reads from this resolved ladder, never from a hardcoded fallback.
+
+A starter manifest is provided at `templates/verify-ladder.example.json`; copy it to `.claude/verify-ladder.json` and trim per project.
+
 ### Phase 1: Build Verification
+Run the `build` command from the resolved ladder. Example for a default Node project:
 ```bash
-# Check if project builds
+# Resolved from package.json scripts.build:
 npm run build 2>&1 | tail -20
-# OR
-pnpm build 2>&1 | tail -20
 ```
 
 If build fails, STOP and fix before continuing.
@@ -103,6 +140,12 @@ Enumerate every step you said you would do — the recommendation list, the plan
 Both gates are independent: `Yes` on goal alone means a half-complete checklist that may break later; `Yes` on completeness alone means busywork that didn't deliver. Both must be `Yes` — even if the previous six phases all pass — or the work isn't done.
 
 If either is `No`, the verification report goes back to the operator with the explicit gap, not on to PR. The operator decides whether the gap is acceptable to ship as-is or whether more work is required first. Never silently downgrade to "ready" because the mechanism phases looked good.
+
+### Phase 8: Deploy Receipt (auto-deploy projects only)
+
+For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or whose sniff path detects an auto-deploy target (Railway, Cloudflare Workers, Vercel, Netlify, Fly.io) — the verify is not complete until the deployed SHA matches the merge SHA and a healthcheck returns 200. Hand off to the `deploy-receipt` skill (Law 4 deploy-seam companion landed in PR #83) and treat its `Receipt status: COMPLETE` as the gate.
+
+INCOMPLETE receipts move to "Immediate operator action" in the close, never to "ready". Library-only / package-published repos skip this phase entirely (no deploy seam exists).
 
 ## Output Format
 

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -206,6 +206,24 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "skills/superpowers.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
   { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "Per-PR table", source: "docs-substrings-manifest:superpowers-stacked-pr-precondition" },
 
+  // verification-loop per-project ladder — locked 2026-05-07 (PR C of second-release train).
+  // Phase 0 (Ladder Resolution) was added so Phases 1–6 read the project's actual build/typecheck/
+  // lint/test/security/deploy_receipt invocations from .claude/verify-ladder.json (or sniff /
+  // ask fallback) instead of hardcoded npm run X. Phase 8 wires deploy-receipt (PR #83) for
+  // auto-deploy projects. Each assertion below catches a specific class of regression:
+  //   - "### Phase 0: Resolve the Ladder" → removing the whole resolution phase
+  //   - ".claude/verify-ladder.json"      → renaming or moving the manifest path
+  //   - "verify-ladder (resolved):"       → losing the resolved-ladder output contract
+  //   - "### Phase 8: Deploy Receipt"     → losing the cross-skill integration with PR #83
+  { file: "skills/verification-loop.md", pattern: "### Phase 0: Resolve the Ladder", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "### Phase 0: Resolve the Ladder", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "skills/verification-loop.md", pattern: ".claude/verify-ladder.json", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: ".claude/verify-ladder.json", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "skills/verification-loop.md", pattern: "verify-ladder (resolved):", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "verify-ladder (resolved):", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "skills/verification-loop.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+  { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+
   // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
   // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
   { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },

--- a/templates/verify-ladder.example.json
+++ b/templates/verify-ladder.example.json
@@ -1,0 +1,47 @@
+{
+  "_doc": [
+    "Per-project verification ladder for the verification-loop skill.",
+    "Copy this file to .claude/verify-ladder.json at your repo root and trim per project.",
+    "Phase 0 of verification-loop reads this manifest first, then sniffs package.json scripts,",
+    "then per-language toolchain files (Cargo.toml, go.mod, pyproject.toml, etc.), then asks.",
+    "Set any field to the literal null to skip that phase for this project.",
+    "",
+    "Three starter shapes are provided below — pick one, delete the others, then trim."
+  ],
+
+  "_typescript_node_example": {
+    "build":          "npm run build",
+    "typecheck":      "npx tsc --noEmit",
+    "lint":           "npm run lint",
+    "test":           "npm test",
+    "security":       "npm audit --audit-level=high",
+    "deploy_receipt": null
+  },
+
+  "_rust_cargo_example": {
+    "build":          "cargo build --release",
+    "typecheck":      "cargo check --all-targets",
+    "lint":           "cargo clippy --all-targets -- -D warnings",
+    "test":           "cargo test --all-features",
+    "security":       "cargo audit",
+    "deploy_receipt": null
+  },
+
+  "_python_uv_example": {
+    "build":          null,
+    "typecheck":      "uv run pyright",
+    "lint":           "uv run ruff check .",
+    "test":           "uv run pytest",
+    "security":       "uv run pip-audit",
+    "deploy_receipt": null
+  },
+
+  "_cloudflare_worker_example": {
+    "build":          "npm run build",
+    "typecheck":      "npx tsc --noEmit",
+    "lint":           "npm run lint",
+    "test":           "npm test",
+    "security":       "npm audit --audit-level=high",
+    "deploy_receipt": "npx wrangler deployments list --json"
+  }
+}


### PR DESCRIPTION
## Summary
PR C of the second-release train. Plan doc at `docs/plans/2026-05-07-second-release-train.md` (landed in PR #85). PR A (`workspace-surface-audit` Environment Grain) merged as `e7fe080`; PR B (`superpowers` stacked-PR precondition) merged as `47b2b39`.

The report's "tsc from the wrong CWD" / "deps not installed" misreads all root in `verification-loop` hardcoding `npm run build` / `npm run test`. Projects on pnpm, yarn, cargo, go, mise, just, custom scripts, or monorepo workspace-scoped commands return false-negative misreads when the verifier guesses wrong.

Add **Phase 0: Resolve the Ladder** before existing Phase 1 with a 4-step resolution priority:

1. `.claude/verify-ladder.json` manifest at repo root
2. Sniff `package.json` `scripts` (`verify:<phase>` wins over `<phase>`)
3. Sniff per-language toolchain (`Cargo.toml`, `go.mod`, `pyproject.toml`)
4. Ask the operator

Output the resolved ladder as a single fenced block before any phase runs so the operator can spot wrong resolution before it costs a misread. Each row shows command + source (manifest, sniff, or skipped).

Add **Phase 8: Deploy Receipt** for auto-deploy projects — hands off to the `deploy-receipt` skill from PR #83 and treats its `COMPLETE` receipt as the gate. Library-only repos skip this phase entirely.

Add `templates/verify-ladder.example.json` with four starter shapes (TypeScript+Node, Rust+Cargo, Python+uv, Cloudflare Worker). Operator copies to `.claude/verify-ladder.json` and trims per project.

## Lockdown

Four docs-substring assertions × 2 mirrors = 8 new lint assertions:

- `### Phase 0: Resolve the Ladder` — catches phase removal
- `.claude/verify-ladder.json` — catches manifest path rename
- `verify-ladder (resolved):` — catches output-contract loss
- `### Phase 8: Deploy Receipt` — catches PR #83 integration loss

## Verification

```
npm run verify:all    # 7/7 gates green; docs-substrings 130 -> 138 (+8)
npm run build         # no .mjs drift after regeneration
```

## Files (5 — exactly plan-scoped)

| File | Change |
|---|---|
| `skills/verification-loop.md` | +49 lines: Phase 0 + Phase 8 |
| `plugins/continuous-improvement/skills/verification-loop/SKILL.md` | byte-identical mirror |
| `templates/verify-ladder.example.json` | +47 lines: 4 starter shapes |
| `src/bin/check-docs-substrings.mts` | +18 lines: 8 lockdown assertions |
| `bin/check-docs-substrings.mjs` | regenerated by `tsc` |

## Test plan
- [ ] `npm run verify:all` reports 138 docs-substring assertions, all matching
- [ ] `npm run build && git diff --exit-code -- bin test lib plugins` exits 0
- [ ] Standalone + plugin mirror byte-identical
- [ ] Phase 0 resolution priority is explicit (manifest > sniff > toolchain-sniff > ask)
- [ ] Phase 8 only fires for auto-deploy projects (library-only path documented)

## Train context
Next: **PR D (trimmed)** — `feat(continuous-learning): harvest friction events into typed instincts (classifier + test only)`. ~220 LOC, 4 files, TDD RED-first. Slash command + Law-7 SKILL.md prose deferred to a follow-up PR after the classifier lands.