### PR TITLE
feat(continuous-learning): friction-harvest classifier — TDD (PR D of train, trimmed)

### DIFF
--- a/bin/harvest-friction.mjs
+++ b/bin/harvest-friction.mjs
@@ -1,0 +1,279 @@
+#!/usr/bin/env node
+/**
+ * Friction Harvest — turn observation rows into typed instincts.
+ *
+ * PR D of the second-release train (item 8 from the 28-day usage report).
+ *
+ * Reads `~/.claude/instincts/<project-hash>/observations.jsonl` produced by
+ * the Mulahazah hook (see `hooks/observe.sh` and `src/lib/observe-event.mts`),
+ * classifies failure rows into typed instincts, aggregates by deduplication
+ * key, scores confidence with a recency-weighted decay, and appends new
+ * instincts to `<project-hash>/instincts.jsonl`. Idempotent: re-running on
+ * the same observations does not duplicate previously-written instincts.
+ *
+ * Schema awareness:
+ *   - Rich-schema rows (input_summary + output_summary present) are the
+ *     contract surface. The classifier reads output_summary to detect
+ *     command-not-found, permission-denied, file-not-read, etc.
+ *   - Thin-schema rows (no input/output fields — emitted by the bash
+ *     fallback when jq is missing AND the Node observer is not on PATH)
+ *     return null from classifyObservation. The CLI reports the gap
+ *     explicitly rather than misclassifying.
+ *
+ * Slash-command wrapper (commands/harvest.md), Law-7 SKILL.md prose, and
+ * a scheduled trigger are explicitly out of scope for this PR. The trim
+ * is documented in docs/plans/2026-05-07-second-release-train.md.
+ *
+ * Usage:
+ *   node bin/harvest-friction.mjs                # current project
+ *   node bin/harvest-friction.mjs <project-hash> # specific project
+ *   node bin/harvest-friction.mjs --list         # show classifications without writing
+ */
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const SUMMARY_TRUNCATE = 120;
+const DEDUP_KEY_INPUT_TRUNCATE = 120;
+/**
+ * Stable deduplication key. Truncates summary at 120 chars before hashing so
+ * minor output variance (timestamps, retry counts, paths) past the boundary
+ * does not split the same friction event into multiple instincts.
+ */
+export function computeDedupKey(c) {
+    const truncated = c.summary.length > DEDUP_KEY_INPUT_TRUNCATE
+        ? c.summary.slice(0, DEDUP_KEY_INPUT_TRUNCATE)
+        : c.summary;
+    return createHash("sha1").update(`${c.type}|${c.tool}|${truncated}`).digest("hex");
+}
+/**
+ * Classify a single observation row. Returns null when:
+ *   - The row is not a tool_complete event (no failure signal yet)
+ *   - The row lacks output_summary (thin-schema row — gap, not classifiable)
+ *   - The output does not match any known friction pattern (success row)
+ *
+ * Heuristics are deliberately specific to keep false-positive rate low.
+ * Each branch matches a documented failure mode the operator hit on this
+ * host in the last 28 days.
+ */
+export function classifyObservation(row) {
+    if (row.event !== "tool_complete")
+        return null;
+    const out = row.output_summary;
+    if (out === undefined || out === "")
+        return null;
+    const tool = row.tool;
+    const summary = out.length > SUMMARY_TRUNCATE ? out.slice(0, SUMMARY_TRUNCATE) : out;
+    // env_issue — missing tooling, wrong shell flavor, missing env var.
+    // Match before permission_block because "command not found" is a stronger signal
+    // than the generic "Permission denied" tail of the output.
+    if (/command not found/i.test(out) ||
+        /not recognized as (?:an internal|the name)/i.test(out) ||
+        /is not recognized as a cmdlet/i.test(out)) {
+        return build("env_issue", tool, summary, row.ts);
+    }
+    // permission_block — harness, sandbox, or OS denied the action.
+    if (/permission denied/i.test(out) ||
+        /harness[- ]blocked/i.test(out) ||
+        /sandbox/i.test(out) ||
+        /operation not permitted/i.test(out)) {
+        return build("permission_block", tool, summary, row.ts);
+    }
+    // wrong_approach — agent acted on stale state. The "file changed since last
+    // read" signal is the canonical case (parallel actor or skipped Read).
+    if (/file changed since last read/i.test(out) ||
+        /modified by (?:another session|the user)/i.test(out)) {
+        return build("wrong_approach", tool, summary, row.ts);
+    }
+    // buggy_code — agent's own input was malformed for the tool contract.
+    // Includes Edit-without-Read, ambiguous old_string, file-too-large, etc.
+    if (/file has not been read/i.test(out) ||
+        /old_string is not unique/i.test(out) ||
+        /string_to_replace not found/i.test(out) ||
+        /file too large/i.test(out)) {
+        return build("buggy_code", tool, summary, row.ts);
+    }
+    return null;
+}
+function build(type, tool, summary, evidence_ts) {
+    return {
+        type,
+        tool,
+        summary,
+        evidence_ts,
+        dedup_key: computeDedupKey({ type, tool, summary }),
+    };
+}
+/**
+ * Aggregate classifications by dedup_key into Instincts with frequency and
+ * recency-weighted confidence.
+ *
+ * Confidence model (deliberately simple for the first cut; tune in a follow-up
+ * once the operator has confirmed the classifier output is plausible):
+ *   confidence = min(1.0, log10(occurrence_count + 1) * recency_factor)
+ *   recency_factor = 0.5 + 0.5 * exp(-days_since_last_seen / 14)
+ *
+ * A single occurrence today: confidence ≈ log10(2) * 1.0 ≈ 0.30.
+ * Ten occurrences today:     confidence ≈ log10(11) * 1.0 ≈ 1.04 → clamp 1.0.
+ * One occurrence 30 days ago: confidence ≈ log10(2) * (0.5 + 0.5 * 0.118) ≈ 0.17.
+ */
+export function aggregateInstincts(classified) {
+    if (classified.length === 0)
+        return [];
+    const groups = new Map();
+    for (const c of classified) {
+        const list = groups.get(c.dedup_key) ?? [];
+        list.push(c);
+        groups.set(c.dedup_key, list);
+    }
+    const now = Date.now();
+    const instincts = [];
+    for (const [, group] of groups) {
+        const sorted = [...group].sort((a, b) => a.evidence_ts.localeCompare(b.evidence_ts));
+        const first = sorted[0];
+        const last = sorted[sorted.length - 1];
+        const occurrence_count = group.length;
+        const lastSeenMs = Date.parse(last.evidence_ts);
+        const daysSince = isFinite(lastSeenMs) ? (now - lastSeenMs) / 86400000 : 0;
+        const recency_factor = 0.5 + 0.5 * Math.exp(-Math.max(0, daysSince) / 14);
+        const raw = Math.log10(occurrence_count + 1) * recency_factor;
+        const confidence = Math.max(0, Math.min(1, raw));
+        instincts.push({
+            type: first.type,
+            tool: first.tool,
+            summary: first.summary,
+            evidence_ts: last.evidence_ts,
+            dedup_key: first.dedup_key,
+            confidence,
+            occurrence_count,
+            first_seen: first.evidence_ts,
+            last_seen: last.evidence_ts,
+        });
+    }
+    return instincts.sort((a, b) => b.confidence - a.confidence);
+}
+/**
+ * Read existing instincts.jsonl and return the set of dedup keys already
+ * recorded. Missing file is treated as empty (idempotent first run).
+ * Malformed lines are skipped silently — a partially-written instincts.jsonl
+ * should not block the next harvest.
+ */
+export function loadExistingDedupKeys(instinctsJsonlPath) {
+    if (!existsSync(instinctsJsonlPath))
+        return new Set();
+    const keys = new Set();
+    const content = readFileSync(instinctsJsonlPath, "utf8");
+    for (const line of content.split("\n")) {
+        if (line.trim() === "")
+            continue;
+        try {
+            const obj = JSON.parse(line);
+            if (typeof obj.dedup_key === "string")
+                keys.add(obj.dedup_key);
+        }
+        catch {
+            // Skip malformed line.
+        }
+    }
+    return keys;
+}
+export function harvest(observationsPath, instinctsPath) {
+    if (!existsSync(observationsPath)) {
+        return { totalRows: 0, toolCompleteRows: 0, classifiedRows: 0, thinSchemaRows: 0, newInstincts: [], skippedExisting: 0 };
+    }
+    const content = readFileSync(observationsPath, "utf8");
+    const lines = content.split("\n").filter((l) => l.trim() !== "");
+    const classified = [];
+    let toolCompleteRows = 0;
+    let thinSchemaRows = 0;
+    for (const line of lines) {
+        let row;
+        try {
+            row = JSON.parse(line);
+        }
+        catch {
+            continue;
+        }
+        if (row.event === "tool_complete") {
+            toolCompleteRows++;
+            if (row.output_summary === undefined || row.output_summary === "") {
+                thinSchemaRows++;
+                continue;
+            }
+        }
+        const c = classifyObservation(row);
+        if (c)
+            classified.push(c);
+    }
+    const allInstincts = aggregateInstincts(classified);
+    const existing = loadExistingDedupKeys(instinctsPath);
+    const newInstincts = allInstincts.filter((i) => !existing.has(i.dedup_key));
+    return {
+        totalRows: lines.length,
+        toolCompleteRows,
+        classifiedRows: classified.length,
+        thinSchemaRows,
+        newInstincts,
+        skippedExisting: allInstincts.length - newInstincts.length,
+    };
+}
+function defaultProjectHash() {
+    // Mirror the bash hook's hashing rule: sha256(project_root) → first 12 hex chars.
+    // Keeps the CLI compatible with whatever directory the bash hook was already
+    // populating, without re-implementing project-root detection here.
+    const root = cwd();
+    return createHash("sha256").update(root).digest("hex").slice(0, 12);
+}
+function main() {
+    const args = argv.slice(2);
+    const listOnly = args.includes("--list");
+    const positional = args.filter((a) => !a.startsWith("--"));
+    const projectHash = positional[0] ?? defaultProjectHash();
+    const projectDir = join(homedir(), ".claude", "instincts", projectHash);
+    const observationsPath = join(projectDir, "observations.jsonl");
+    const instinctsPath = join(projectDir, "instincts.jsonl");
+    const result = harvest(observationsPath, instinctsPath);
+    console.log(`harvest-friction project=${projectHash}`);
+    console.log(`  observations rows:    ${result.totalRows}`);
+    console.log(`  tool_complete rows:   ${result.toolCompleteRows}`);
+    console.log(`  classified failures:  ${result.classifiedRows}`);
+    console.log(`  thin-schema rows:     ${result.thinSchemaRows}`);
+    console.log(`  new instincts:        ${result.newInstincts.length}`);
+    console.log(`  skipped (existing):   ${result.skippedExisting}`);
+    if (result.totalRows > 0 && result.toolCompleteRows === 0) {
+        console.log("");
+        console.log("WARNING: observations contain only tool_start events.");
+        console.log("  The bash fallback in hooks/observe.sh emits tool_start when jq is missing AND");
+        console.log("  the Node observer is not on PATH — never tool_complete with output_summary,");
+        console.log("  which is what the classifier needs.");
+        console.log("  Install jq (winget install jqlang.jq | brew install jq | apt install jq)");
+        console.log("  OR ensure hooks/bin/observe.mjs is reachable from the hook script.");
+    }
+    else if (result.thinSchemaRows > 0 && result.classifiedRows === 0) {
+        console.log("");
+        console.log("WARNING: tool_complete rows found but lack output_summary fields.");
+        console.log("  The classifier needs the rich-schema output_summary to detect failures.");
+        console.log("  Confirm the Node observer (src/bin/observe.mts) is the active hook.");
+    }
+    if (result.newInstincts.length === 0) {
+        return;
+    }
+    console.log("");
+    console.log("New instincts:");
+    for (const i of result.newInstincts) {
+        const conf = i.confidence.toFixed(2);
+        console.log(`  [${conf}] ${i.type} on ${i.tool} (×${i.occurrence_count}): ${i.summary}`);
+    }
+    if (listOnly)
+        return;
+    for (const i of result.newInstincts) {
+        appendFileSync(instinctsPath, JSON.stringify(i) + "\n");
+    }
+    console.log(`\nAppended ${result.newInstincts.length} instinct(s) to ${instinctsPath}`);
+}
+const invokedDirectly = argv[1]?.endsWith("harvest-friction.mjs");
+if (invokedDirectly) {
+    main();
+    exit(0);
+}

--- a/src/bin/harvest-friction.mts
+++ b/src/bin/harvest-friction.mts
@@ -1,0 +1,341 @@
+#!/usr/bin/env node
+/**
+ * Friction Harvest — turn observation rows into typed instincts.
+ *
+ * PR D of the second-release train (item 8 from the 28-day usage report).
+ *
+ * Reads `~/.claude/instincts/<project-hash>/observations.jsonl` produced by
+ * the Mulahazah hook (see `hooks/observe.sh` and `src/lib/observe-event.mts`),
+ * classifies failure rows into typed instincts, aggregates by deduplication
+ * key, scores confidence with a recency-weighted decay, and appends new
+ * instincts to `<project-hash>/instincts.jsonl`. Idempotent: re-running on
+ * the same observations does not duplicate previously-written instincts.
+ *
+ * Schema awareness:
+ *   - Rich-schema rows (input_summary + output_summary present) are the
+ *     contract surface. The classifier reads output_summary to detect
+ *     command-not-found, permission-denied, file-not-read, etc.
+ *   - Thin-schema rows (no input/output fields — emitted by the bash
+ *     fallback when jq is missing AND the Node observer is not on PATH)
+ *     return null from classifyObservation. The CLI reports the gap
+ *     explicitly rather than misclassifying.
+ *
+ * Slash-command wrapper (commands/harvest.md), Law-7 SKILL.md prose, and
+ * a scheduled trigger are explicitly out of scope for this PR. The trim
+ * is documented in docs/plans/2026-05-07-second-release-train.md.
+ *
+ * Usage:
+ *   node bin/harvest-friction.mjs                # current project
+ *   node bin/harvest-friction.mjs <project-hash> # specific project
+ *   node bin/harvest-friction.mjs --list         # show classifications without writing
+ */
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+export type FrictionType = "wrong_approach" | "buggy_code" | "env_issue" | "permission_block";
+
+export interface ObservationRow {
+  ts: string;
+  event: string;
+  session: string;
+  tool: string;
+  input_summary?: string;
+  output_summary?: string;
+  project_id: string;
+  project_name: string;
+}
+
+export interface ClassifiedFriction {
+  type: FrictionType;
+  tool: string;
+  summary: string;
+  evidence_ts: string;
+  dedup_key: string;
+}
+
+export interface Instinct extends ClassifiedFriction {
+  confidence: number;
+  occurrence_count: number;
+  first_seen: string;
+  last_seen: string;
+}
+
+const SUMMARY_TRUNCATE = 120;
+const DEDUP_KEY_INPUT_TRUNCATE = 120;
+
+/**
+ * Stable deduplication key. Truncates summary at 120 chars before hashing so
+ * minor output variance (timestamps, retry counts, paths) past the boundary
+ * does not split the same friction event into multiple instincts.
+ */
+export function computeDedupKey(c: { type: FrictionType; tool: string; summary: string }): string {
+  const truncated = c.summary.length > DEDUP_KEY_INPUT_TRUNCATE
+    ? c.summary.slice(0, DEDUP_KEY_INPUT_TRUNCATE)
+    : c.summary;
+  return createHash("sha1").update(`${c.type}|${c.tool}|${truncated}`).digest("hex");
+}
+
+/**
+ * Classify a single observation row. Returns null when:
+ *   - The row is not a tool_complete event (no failure signal yet)
+ *   - The row lacks output_summary (thin-schema row — gap, not classifiable)
+ *   - The output does not match any known friction pattern (success row)
+ *
+ * Heuristics are deliberately specific to keep false-positive rate low.
+ * Each branch matches a documented failure mode the operator hit on this
+ * host in the last 28 days.
+ */
+export function classifyObservation(row: ObservationRow): ClassifiedFriction | null {
+  if (row.event !== "tool_complete") return null;
+  const out = row.output_summary;
+  if (out === undefined || out === "") return null;
+
+  const tool = row.tool;
+  const summary = out.length > SUMMARY_TRUNCATE ? out.slice(0, SUMMARY_TRUNCATE) : out;
+
+  // env_issue — missing tooling, wrong shell flavor, missing env var.
+  // Match before permission_block because "command not found" is a stronger signal
+  // than the generic "Permission denied" tail of the output.
+  if (
+    /command not found/i.test(out) ||
+    /not recognized as (?:an internal|the name)/i.test(out) ||
+    /is not recognized as a cmdlet/i.test(out)
+  ) {
+    return build("env_issue", tool, summary, row.ts);
+  }
+
+  // permission_block — harness, sandbox, or OS denied the action.
+  if (
+    /permission denied/i.test(out) ||
+    /harness[- ]blocked/i.test(out) ||
+    /sandbox/i.test(out) ||
+    /operation not permitted/i.test(out)
+  ) {
+    return build("permission_block", tool, summary, row.ts);
+  }
+
+  // wrong_approach — agent acted on stale state. The "file changed since last
+  // read" signal is the canonical case (parallel actor or skipped Read).
+  if (
+    /file changed since last read/i.test(out) ||
+    /modified by (?:another session|the user)/i.test(out)
+  ) {
+    return build("wrong_approach", tool, summary, row.ts);
+  }
+
+  // buggy_code — agent's own input was malformed for the tool contract.
+  // Includes Edit-without-Read, ambiguous old_string, file-too-large, etc.
+  if (
+    /file has not been read/i.test(out) ||
+    /old_string is not unique/i.test(out) ||
+    /string_to_replace not found/i.test(out) ||
+    /file too large/i.test(out)
+  ) {
+    return build("buggy_code", tool, summary, row.ts);
+  }
+
+  return null;
+}
+
+function build(type: FrictionType, tool: string, summary: string, evidence_ts: string): ClassifiedFriction {
+  return {
+    type,
+    tool,
+    summary,
+    evidence_ts,
+    dedup_key: computeDedupKey({ type, tool, summary }),
+  };
+}
+
+/**
+ * Aggregate classifications by dedup_key into Instincts with frequency and
+ * recency-weighted confidence.
+ *
+ * Confidence model (deliberately simple for the first cut; tune in a follow-up
+ * once the operator has confirmed the classifier output is plausible):
+ *   confidence = min(1.0, log10(occurrence_count + 1) * recency_factor)
+ *   recency_factor = 0.5 + 0.5 * exp(-days_since_last_seen / 14)
+ *
+ * A single occurrence today: confidence ≈ log10(2) * 1.0 ≈ 0.30.
+ * Ten occurrences today:     confidence ≈ log10(11) * 1.0 ≈ 1.04 → clamp 1.0.
+ * One occurrence 30 days ago: confidence ≈ log10(2) * (0.5 + 0.5 * 0.118) ≈ 0.17.
+ */
+export function aggregateInstincts(classified: ClassifiedFriction[]): Instinct[] {
+  if (classified.length === 0) return [];
+
+  const groups = new Map<string, ClassifiedFriction[]>();
+  for (const c of classified) {
+    const list = groups.get(c.dedup_key) ?? [];
+    list.push(c);
+    groups.set(c.dedup_key, list);
+  }
+
+  const now = Date.now();
+  const instincts: Instinct[] = [];
+  for (const [, group] of groups) {
+    const sorted = [...group].sort((a, b) => a.evidence_ts.localeCompare(b.evidence_ts));
+    const first = sorted[0];
+    const last = sorted[sorted.length - 1];
+    const occurrence_count = group.length;
+
+    const lastSeenMs = Date.parse(last.evidence_ts);
+    const daysSince = isFinite(lastSeenMs) ? (now - lastSeenMs) / 86400000 : 0;
+    const recency_factor = 0.5 + 0.5 * Math.exp(-Math.max(0, daysSince) / 14);
+    const raw = Math.log10(occurrence_count + 1) * recency_factor;
+    const confidence = Math.max(0, Math.min(1, raw));
+
+    instincts.push({
+      type: first.type,
+      tool: first.tool,
+      summary: first.summary,
+      evidence_ts: last.evidence_ts,
+      dedup_key: first.dedup_key,
+      confidence,
+      occurrence_count,
+      first_seen: first.evidence_ts,
+      last_seen: last.evidence_ts,
+    });
+  }
+
+  return instincts.sort((a, b) => b.confidence - a.confidence);
+}
+
+/**
+ * Read existing instincts.jsonl and return the set of dedup keys already
+ * recorded. Missing file is treated as empty (idempotent first run).
+ * Malformed lines are skipped silently — a partially-written instincts.jsonl
+ * should not block the next harvest.
+ */
+export function loadExistingDedupKeys(instinctsJsonlPath: string): Set<string> {
+  if (!existsSync(instinctsJsonlPath)) return new Set();
+  const keys = new Set<string>();
+  const content = readFileSync(instinctsJsonlPath, "utf8");
+  for (const line of content.split("\n")) {
+    if (line.trim() === "") continue;
+    try {
+      const obj = JSON.parse(line) as { dedup_key?: unknown };
+      if (typeof obj.dedup_key === "string") keys.add(obj.dedup_key);
+    } catch {
+      // Skip malformed line.
+    }
+  }
+  return keys;
+}
+
+interface HarvestResult {
+  totalRows: number;
+  toolCompleteRows: number;
+  classifiedRows: number;
+  thinSchemaRows: number;
+  newInstincts: Instinct[];
+  skippedExisting: number;
+}
+
+export function harvest(observationsPath: string, instinctsPath: string): HarvestResult {
+  if (!existsSync(observationsPath)) {
+    return { totalRows: 0, toolCompleteRows: 0, classifiedRows: 0, thinSchemaRows: 0, newInstincts: [], skippedExisting: 0 };
+  }
+  const content = readFileSync(observationsPath, "utf8");
+  const lines = content.split("\n").filter((l) => l.trim() !== "");
+  const classified: ClassifiedFriction[] = [];
+  let toolCompleteRows = 0;
+  let thinSchemaRows = 0;
+  for (const line of lines) {
+    let row: ObservationRow;
+    try {
+      row = JSON.parse(line) as ObservationRow;
+    } catch {
+      continue;
+    }
+    if (row.event === "tool_complete") {
+      toolCompleteRows++;
+      if (row.output_summary === undefined || row.output_summary === "") {
+        thinSchemaRows++;
+        continue;
+      }
+    }
+    const c = classifyObservation(row);
+    if (c) classified.push(c);
+  }
+  const allInstincts = aggregateInstincts(classified);
+  const existing = loadExistingDedupKeys(instinctsPath);
+  const newInstincts = allInstincts.filter((i) => !existing.has(i.dedup_key));
+  return {
+    totalRows: lines.length,
+    toolCompleteRows,
+    classifiedRows: classified.length,
+    thinSchemaRows,
+    newInstincts,
+    skippedExisting: allInstincts.length - newInstincts.length,
+  };
+}
+
+function defaultProjectHash(): string {
+  // Mirror the bash hook's hashing rule: sha256(project_root) → first 12 hex chars.
+  // Keeps the CLI compatible with whatever directory the bash hook was already
+  // populating, without re-implementing project-root detection here.
+  const root = cwd();
+  return createHash("sha256").update(root).digest("hex").slice(0, 12);
+}
+
+function main(): void {
+  const args = argv.slice(2);
+  const listOnly = args.includes("--list");
+  const positional = args.filter((a) => !a.startsWith("--"));
+  const projectHash = positional[0] ?? defaultProjectHash();
+  const projectDir = join(homedir(), ".claude", "instincts", projectHash);
+  const observationsPath = join(projectDir, "observations.jsonl");
+  const instinctsPath = join(projectDir, "instincts.jsonl");
+
+  const result = harvest(observationsPath, instinctsPath);
+
+  console.log(`harvest-friction project=${projectHash}`);
+  console.log(`  observations rows:    ${result.totalRows}`);
+  console.log(`  tool_complete rows:   ${result.toolCompleteRows}`);
+  console.log(`  classified failures:  ${result.classifiedRows}`);
+  console.log(`  thin-schema rows:     ${result.thinSchemaRows}`);
+  console.log(`  new instincts:        ${result.newInstincts.length}`);
+  console.log(`  skipped (existing):   ${result.skippedExisting}`);
+
+  if (result.totalRows > 0 && result.toolCompleteRows === 0) {
+    console.log("");
+    console.log("WARNING: observations contain only tool_start events.");
+    console.log("  The bash fallback in hooks/observe.sh emits tool_start when jq is missing AND");
+    console.log("  the Node observer is not on PATH — never tool_complete with output_summary,");
+    console.log("  which is what the classifier needs.");
+    console.log("  Install jq (winget install jqlang.jq | brew install jq | apt install jq)");
+    console.log("  OR ensure hooks/bin/observe.mjs is reachable from the hook script.");
+  } else if (result.thinSchemaRows > 0 && result.classifiedRows === 0) {
+    console.log("");
+    console.log("WARNING: tool_complete rows found but lack output_summary fields.");
+    console.log("  The classifier needs the rich-schema output_summary to detect failures.");
+    console.log("  Confirm the Node observer (src/bin/observe.mts) is the active hook.");
+  }
+
+  if (result.newInstincts.length === 0) {
+    return;
+  }
+
+  console.log("");
+  console.log("New instincts:");
+  for (const i of result.newInstincts) {
+    const conf = i.confidence.toFixed(2);
+    console.log(`  [${conf}] ${i.type} on ${i.tool} (×${i.occurrence_count}): ${i.summary}`);
+  }
+
+  if (listOnly) return;
+
+  for (const i of result.newInstincts) {
+    appendFileSync(instinctsPath, JSON.stringify(i) + "\n");
+  }
+  console.log(`\nAppended ${result.newInstincts.length} instinct(s) to ${instinctsPath}`);
+}
+
+const invokedDirectly = argv[1]?.endsWith("harvest-friction.mjs");
+if (invokedDirectly) {
+  main();
+  exit(0);
+}

--- a/src/test/harvest-friction.test.mts
+++ b/src/test/harvest-friction.test.mts
@@ -1,0 +1,177 @@
+// harvest-friction.test.mts — TDD tests for the friction-harvest classifier.
+//
+// PR D of the second-release train (item 8). The classifier turns observation
+// rows from ~/.claude/instincts/<hash>/observations.jsonl into typed instincts
+// (wrong_approach, buggy_code, env_issue, permission_block) with confidence
+// scoring, idempotency on re-run, and explicit handling of the thin-vs-rich
+// schema split documented in src/lib/observe-event.mts.
+//
+// These tests run RED-first against an as-yet-unwritten src/bin/harvest-friction.mts.
+// The .mjs import below resolves only after `npm run build` regenerates the
+// emitted artifact — that is intentional. Per the .mts-is-source rule, never
+// edit the .mjs directly.
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  aggregateInstincts,
+  classifyObservation,
+  computeDedupKey,
+  type ObservationRow,
+} from "../bin/harvest-friction.mjs";
+
+const T0 = "2026-04-30T12:00:00Z";
+const T1 = "2026-05-05T12:00:00Z";
+const T2 = "2026-05-07T12:00:00Z";
+
+function row(partial: Partial<ObservationRow> & { tool: string }): ObservationRow {
+  return {
+    ts: T2,
+    event: "tool_complete",
+    session: "test-session",
+    input_summary: "",
+    output_summary: "",
+    project_id: "test-project",
+    project_name: "test",
+    ...partial,
+  };
+}
+
+describe("classifyObservation", () => {
+  it("classifies Bash 'command not found' as env_issue", () => {
+    const r = row({
+      tool: "Bash",
+      input_summary: "jq -r .deployments[0].sha",
+      output_summary: "bash: jq: command not found",
+    });
+    const c = classifyObservation(r);
+    assert.equal(c?.type, "env_issue");
+    assert.equal(c?.tool, "Bash");
+    assert.match(c?.summary ?? "", /command not found/);
+  });
+
+  it("classifies Bash 'Permission denied' / sandbox as permission_block", () => {
+    const r = row({
+      tool: "Bash",
+      input_summary: "git push origin main",
+      output_summary: "Permission denied: harness blocked direct push to main",
+    });
+    const c = classifyObservation(r);
+    assert.equal(c?.type, "permission_block");
+  });
+
+  it("classifies Edit 'file has not been read' as buggy_code", () => {
+    const r = row({
+      tool: "Edit",
+      input_summary: "skills/deploy-receipt.md",
+      output_summary: "Error: file has not been read yet",
+    });
+    const c = classifyObservation(r);
+    assert.equal(c?.type, "buggy_code");
+  });
+
+  it("classifies Edit 'file changed since last read' as wrong_approach", () => {
+    const r = row({
+      tool: "Edit",
+      input_summary: "skills/superpowers.md",
+      output_summary: "file changed since last read — possibly by another session",
+    });
+    const c = classifyObservation(r);
+    assert.equal(c?.type, "wrong_approach");
+  });
+
+  it("returns null for tool_start events (no failure signal yet)", () => {
+    const r = row({ tool: "Bash", event: "tool_start", output_summary: "" });
+    assert.equal(classifyObservation(r), null);
+  });
+
+  it("returns null for thin-schema rows (no input_summary/output_summary)", () => {
+    const r: ObservationRow = {
+      ts: T2,
+      event: "tool_complete",
+      session: "test-session",
+      tool: "Bash",
+      project_id: "test-project",
+      project_name: "test",
+    };
+    assert.equal(classifyObservation(r), null);
+  });
+
+  it("accepts historical rows with tool_response field (pre-PR #67 schema)", () => {
+    // observe-event.mts normalises tool_response -> tool_output at the boundary,
+    // so the classifier sees a unified output_summary field. The classifier MUST
+    // therefore classify a synthetic row identical to what the boundary emits
+    // for a pre-2026-05-06T00:38Z observation. This is the project_observer_field_name_bug.md
+    // compatibility lock.
+    const r = row({
+      tool: "Bash",
+      input_summary: "wrangler tail",
+      output_summary: "Permission denied: harness blocked wrangler tail",
+    });
+    const c = classifyObservation(r);
+    assert.equal(c?.type, "permission_block");
+  });
+});
+
+describe("computeDedupKey", () => {
+  it("is stable across re-runs for identical (type, tool, summary)", () => {
+    const a = computeDedupKey({
+      type: "env_issue",
+      tool: "Bash",
+      summary: "bash: jq: command not found",
+    });
+    const b = computeDedupKey({
+      type: "env_issue",
+      tool: "Bash",
+      summary: "bash: jq: command not found",
+    });
+    assert.equal(a, b);
+  });
+
+  it("differs when type differs", () => {
+    const a = computeDedupKey({ type: "env_issue", tool: "Bash", summary: "x" });
+    const b = computeDedupKey({ type: "buggy_code", tool: "Bash", summary: "x" });
+    assert.notEqual(a, b);
+  });
+
+  it("ignores summary text past 120 chars (truncation contract)", () => {
+    const long120 = "a".repeat(120);
+    const long500 = "a".repeat(500);
+    const a = computeDedupKey({ type: "env_issue", tool: "Bash", summary: long120 });
+    const b = computeDedupKey({ type: "env_issue", tool: "Bash", summary: long500 });
+    assert.equal(a, b);
+  });
+});
+
+describe("aggregateInstincts", () => {
+  it("merges duplicate (type, tool, summary) rows into one instinct with occurrence_count", () => {
+    const c = [
+      { type: "env_issue" as const, tool: "Bash", summary: "jq missing", evidence_ts: T0, dedup_key: "k" },
+      { type: "env_issue" as const, tool: "Bash", summary: "jq missing", evidence_ts: T1, dedup_key: "k" },
+      { type: "env_issue" as const, tool: "Bash", summary: "jq missing", evidence_ts: T2, dedup_key: "k" },
+    ];
+    const instincts = aggregateInstincts(c);
+    assert.equal(instincts.length, 1);
+    assert.equal(instincts[0].occurrence_count, 3);
+    assert.equal(instincts[0].first_seen, T0);
+    assert.equal(instincts[0].last_seen, T2);
+  });
+
+  it("weights confidence higher for recent than old (recency-decay)", () => {
+    const old = [
+      { type: "env_issue" as const, tool: "Bash", summary: "x", evidence_ts: T0, dedup_key: "old" },
+    ];
+    const fresh = [
+      { type: "env_issue" as const, tool: "Bash", summary: "y", evidence_ts: T2, dedup_key: "fresh" },
+    ];
+    const oldInstinct = aggregateInstincts(old)[0];
+    const freshInstinct = aggregateInstincts(fresh)[0];
+    assert.ok(freshInstinct.confidence > oldInstinct.confidence,
+      `recent confidence (${freshInstinct.confidence}) should exceed old confidence (${oldInstinct.confidence})`);
+  });
+
+  it("returns empty array for empty input (idempotent zero case)", () => {
+    assert.deepEqual(aggregateInstincts([]), []);
+  });
+});

--- a/test/harvest-friction.test.mjs
+++ b/test/harvest-friction.test.mjs
@@ -1,0 +1,154 @@
+// harvest-friction.test.mts — TDD tests for the friction-harvest classifier.
+//
+// PR D of the second-release train (item 8). The classifier turns observation
+// rows from ~/.claude/instincts/<hash>/observations.jsonl into typed instincts
+// (wrong_approach, buggy_code, env_issue, permission_block) with confidence
+// scoring, idempotency on re-run, and explicit handling of the thin-vs-rich
+// schema split documented in src/lib/observe-event.mts.
+//
+// These tests run RED-first against an as-yet-unwritten src/bin/harvest-friction.mts.
+// The .mjs import below resolves only after `npm run build` regenerates the
+// emitted artifact — that is intentional. Per the .mts-is-source rule, never
+// edit the .mjs directly.
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { aggregateInstincts, classifyObservation, computeDedupKey, } from "../bin/harvest-friction.mjs";
+const T0 = "2026-04-30T12:00:00Z";
+const T1 = "2026-05-05T12:00:00Z";
+const T2 = "2026-05-07T12:00:00Z";
+function row(partial) {
+    return {
+        ts: T2,
+        event: "tool_complete",
+        session: "test-session",
+        input_summary: "",
+        output_summary: "",
+        project_id: "test-project",
+        project_name: "test",
+        ...partial,
+    };
+}
+describe("classifyObservation", () => {
+    it("classifies Bash 'command not found' as env_issue", () => {
+        const r = row({
+            tool: "Bash",
+            input_summary: "jq -r .deployments[0].sha",
+            output_summary: "bash: jq: command not found",
+        });
+        const c = classifyObservation(r);
+        assert.equal(c?.type, "env_issue");
+        assert.equal(c?.tool, "Bash");
+        assert.match(c?.summary ?? "", /command not found/);
+    });
+    it("classifies Bash 'Permission denied' / sandbox as permission_block", () => {
+        const r = row({
+            tool: "Bash",
+            input_summary: "git push origin main",
+            output_summary: "Permission denied: harness blocked direct push to main",
+        });
+        const c = classifyObservation(r);
+        assert.equal(c?.type, "permission_block");
+    });
+    it("classifies Edit 'file has not been read' as buggy_code", () => {
+        const r = row({
+            tool: "Edit",
+            input_summary: "skills/deploy-receipt.md",
+            output_summary: "Error: file has not been read yet",
+        });
+        const c = classifyObservation(r);
+        assert.equal(c?.type, "buggy_code");
+    });
+    it("classifies Edit 'file changed since last read' as wrong_approach", () => {
+        const r = row({
+            tool: "Edit",
+            input_summary: "skills/superpowers.md",
+            output_summary: "file changed since last read — possibly by another session",
+        });
+        const c = classifyObservation(r);
+        assert.equal(c?.type, "wrong_approach");
+    });
+    it("returns null for tool_start events (no failure signal yet)", () => {
+        const r = row({ tool: "Bash", event: "tool_start", output_summary: "" });
+        assert.equal(classifyObservation(r), null);
+    });
+    it("returns null for thin-schema rows (no input_summary/output_summary)", () => {
+        const r = {
+            ts: T2,
+            event: "tool_complete",
+            session: "test-session",
+            tool: "Bash",
+            project_id: "test-project",
+            project_name: "test",
+        };
+        assert.equal(classifyObservation(r), null);
+    });
+    it("accepts historical rows with tool_response field (pre-PR #67 schema)", () => {
+        // observe-event.mts normalises tool_response -> tool_output at the boundary,
+        // so the classifier sees a unified output_summary field. The classifier MUST
+        // therefore classify a synthetic row identical to what the boundary emits
+        // for a pre-2026-05-06T00:38Z observation. This is the project_observer_field_name_bug.md
+        // compatibility lock.
+        const r = row({
+            tool: "Bash",
+            input_summary: "wrangler tail",
+            output_summary: "Permission denied: harness blocked wrangler tail",
+        });
+        const c = classifyObservation(r);
+        assert.equal(c?.type, "permission_block");
+    });
+});
+describe("computeDedupKey", () => {
+    it("is stable across re-runs for identical (type, tool, summary)", () => {
+        const a = computeDedupKey({
+            type: "env_issue",
+            tool: "Bash",
+            summary: "bash: jq: command not found",
+        });
+        const b = computeDedupKey({
+            type: "env_issue",
+            tool: "Bash",
+            summary: "bash: jq: command not found",
+        });
+        assert.equal(a, b);
+    });
+    it("differs when type differs", () => {
+        const a = computeDedupKey({ type: "env_issue", tool: "Bash", summary: "x" });
+        const b = computeDedupKey({ type: "buggy_code", tool: "Bash", summary: "x" });
+        assert.notEqual(a, b);
+    });
+    it("ignores summary text past 120 chars (truncation contract)", () => {
+        const long120 = "a".repeat(120);
+        const long500 = "a".repeat(500);
+        const a = computeDedupKey({ type: "env_issue", tool: "Bash", summary: long120 });
+        const b = computeDedupKey({ type: "env_issue", tool: "Bash", summary: long500 });
+        assert.equal(a, b);
+    });
+});
+describe("aggregateInstincts", () => {
+    it("merges duplicate (type, tool, summary) rows into one instinct with occurrence_count", () => {
+        const c = [
+            { type: "env_issue", tool: "Bash", summary: "jq missing", evidence_ts: T0, dedup_key: "k" },
+            { type: "env_issue", tool: "Bash", summary: "jq missing", evidence_ts: T1, dedup_key: "k" },
+            { type: "env_issue", tool: "Bash", summary: "jq missing", evidence_ts: T2, dedup_key: "k" },
+        ];
+        const instincts = aggregateInstincts(c);
+        assert.equal(instincts.length, 1);
+        assert.equal(instincts[0].occurrence_count, 3);
+        assert.equal(instincts[0].first_seen, T0);
+        assert.equal(instincts[0].last_seen, T2);
+    });
+    it("weights confidence higher for recent than old (recency-decay)", () => {
+        const old = [
+            { type: "env_issue", tool: "Bash", summary: "x", evidence_ts: T0, dedup_key: "old" },
+        ];
+        const fresh = [
+            { type: "env_issue", tool: "Bash", summary: "y", evidence_ts: T2, dedup_key: "fresh" },
+        ];
+        const oldInstinct = aggregateInstincts(old)[0];
+        const freshInstinct = aggregateInstincts(fresh)[0];
+        assert.ok(freshInstinct.confidence > oldInstinct.confidence, `recent confidence (${freshInstinct.confidence}) should exceed old confidence (${oldInstinct.confidence})`);
+    });
+    it("returns empty array for empty input (idempotent zero case)", () => {
+        assert.deepEqual(aggregateInstincts([]), []);
+    });
+});


### PR DESCRIPTION
## Summary
Final PR of the second-release train. Plan doc at `docs/plans/2026-05-07-second-release-train.md` (PR #85). Train so far: **PR A** `e7fe080`, **PR B** `47b2b39`, **PR C** `9c974eb`. PR D ships **trimmed** to classifier + test only (~220 LOC plan estimate, 4 files); slash command + SKILL.md prose deferred to a follow-up PR after the classifier is verified against live observations.

## What lands

`bin/harvest-friction.mjs` — reads `~/.claude/instincts/<hash>/observations.jsonl` produced by the Mulahazah hook, classifies `tool_complete` rows against four typed friction patterns, aggregates with idempotent dedup-key, scores confidence with frequency × recency-decay, and appends new instincts to `instincts.jsonl` alongside.

**Friction types:**

| Type | Pattern |
|---|---|
| `env_issue` | jq missing, command not found, not recognized as cmdlet |
| `permission_block` | sandbox / harness blocked, Permission denied |
| `wrong_approach` | file changed since last read (parallel-actor stale) |
| `buggy_code` | file not read first, old_string ambiguous, file too large |

**Confidence model:** `log10(occurrence_count + 1) * recency_factor` where `recency_factor = 0.5 + 0.5 * exp(-days_since_last_seen / 14)`. One occurrence today → 0.30. Ten occurrences today → clamped to 1.0. One occurrence 30 days ago → 0.17.

**Idempotency:** `dedup_key = sha1(type + tool + summary[:120])`. Re-running on the same observations does not duplicate previously-written instincts.

**Backwards compat:** the boundary in `src/lib/observe-event.mts` already normalises `tool_response` → `tool_output` per memory `project_observer_field_name_bug.md`; one test row exercises a synthetic post-boundary shape that mimics a pre-2026-05-06T00:38Z observation.

## Live smoke test

Run against this host's observations.jsonl:
```
harvest-friction project=0af156594b39
  observations rows:    9346
  tool_complete rows:   0
  classified failures:  0
  thin-schema rows:     0
  new instincts:        0
  skipped (existing):   0

WARNING: observations contain only tool_start events.
  The bash fallback in hooks/observe.sh emits tool_start when jq is missing AND
  the Node observer is not on PATH — never tool_complete with output_summary,
  which is what the classifier needs.
  Install jq (winget install jqlang.jq | brew install jq | apt install jq)
  OR ensure hooks/bin/observe.mjs is reachable from the hook script.
```

Classifier correctly emits **0 instincts** on a host whose observation pipeline is not capturing failure signals, and surfaces both remediation paths. No misclassification.

## Verification

```
npm run build         # tsc clean, .mjs regenerated, no drift
npm test              # 511 / 511 pass (was 498, +13 from harvest-friction.test.mts)
npm run verify:all    # 7/7 gates green; docs-substrings unchanged at 138 (no prose lockdown in this PR)
```

## Files (4 — exactly trimmed-plan-scoped)

| File | Change |
|---|---|
| `src/bin/harvest-friction.mts` | new, 341 lines: classifier + writer + CLI |
| `src/test/harvest-friction.test.mts` | new, 177 lines: 13 tests across 3 describe blocks |
| `bin/harvest-friction.mjs` | regenerated by `tsc` |
| `test/harvest-friction.test.mjs` | regenerated by `tsc` |

## Test plan
- [ ] `npm test` reports 511 passing (was 498)
- [ ] `npm run verify:all` reports all 7 gates green; docs-substrings unchanged at 138
- [ ] `npm run build && git diff --exit-code -- bin test lib plugins` exits 0
- [ ] `node bin/harvest-friction.mjs --list` against any project hash either lists classifications or emits the rich-schema warning
- [ ] `dedup_key` is stable across re-runs (covered by test)
- [ ] Recency decay weights fresher events higher than old (covered by test)

## Deferred (follow-up PR after this one merges)

- `commands/harvest.md` slash-command wrapper + plugin mirror
- `SKILL.md` Law-7 prose section explaining the harvest pipeline + plugin mirror
- Cron / hook / scheduled wrapper for the harvest

## Train conclusion

This is the last PR of the second-release train. Items 4 + 6 + 7 + 8 from the 28-day usage report all land between PRs #85, #86, #87, and this PR. WILD items 1 (autonomous release-train) and 2 (parallel provider-eval harness) remain on hold per the original plan.