### PR TITLE
feat(continuous-learning): /harvest slash command + Law-7 prose (PR D follow-up)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -100,6 +100,19 @@ If the user corrects you, the instinct weakens. If they don't, it strengthens.
 
 Nothing learned is permanent. Everything decays without reinforcement.
 
+### Friction Harvest Pipeline (`/harvest`)
+
+Beyond the reflection-driven path above, the **friction harvest classifier** turns observation logs (`~/.claude/instincts/<project-hash>/observations.jsonl`) into typed instincts automatically. Run via `/harvest` or `node bin/harvest-friction.mjs`. Four typed friction patterns with confidence scoring:
+
+- **`env_issue`** — jq missing, command not found, not recognized as cmdlet
+- **`permission_block`** — sandbox / harness blocked, Permission denied
+- **`wrong_approach`** — file changed since last read (parallel-actor stale)
+- **`buggy_code`** — file not read first, old_string ambiguous, file too large
+
+Idempotent: each instinct's `dedup_key = sha1(type + tool + summary[:120])`; re-running on the same observations does not duplicate previously-written instincts. Confidence weights frequency × recency-decay so old failures fade and recurring ones strengthen, in line with the Law 7 contract above.
+
+The harvest is opt-in: it runs only when explicitly invoked. Cron / hook triggers are deliberately not wired so the operator stays in control of when the classifier reads observation history.
+
 ## The Loop
 
 ```

--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -194,6 +194,19 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "verify-ladder (resolved):", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
     { file: "skills/verification-loop.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
     { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
+    // /harvest slash command + Law-7 prose — locked 2026-05-07 (PR E, follow-up to PR D #88).
+    // The deferred follow-up landed: commands/harvest.md (+ plugin mirror) and a Friction Harvest
+    // Pipeline subsection inside SKILL.md Law 7 (+ plugin mirror). Each assertion below catches
+    // a specific class of regression:
+    //   - "name: harvest" frontmatter         → renaming the slash command
+    //   - "Friction Harvest Pipeline"         → losing the SKILL.md Law-7 subsection title
+    //   - "dedup_key = sha1(type + tool"      → losing the idempotency contract documentation
+    { file: "commands/harvest.md", pattern: "name: harvest", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+    { file: "plugins/continuous-improvement/commands/harvest.md", pattern: "name: harvest", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+    { file: "SKILL.md", pattern: "Friction Harvest Pipeline", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+    { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "Friction Harvest Pipeline", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+    { file: "SKILL.md", pattern: "dedup_key = sha1(type + tool", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+    { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "dedup_key = sha1(type + tool", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
     // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
     // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
     { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },

--- a/commands/harvest.md
+++ b/commands/harvest.md
@@ -1,0 +1,76 @@
+---
+name: harvest
+description: Harvest friction events from observation logs into typed instincts (env_issue, permission_block, wrong_approach, buggy_code) with confidence scoring.
+---
+
+# /harvest — Friction Harvest
+
+Run the friction-harvest classifier against this project's observation log and append new typed instincts to `instincts.jsonl`. Idempotent on re-run.
+
+## What it does
+
+Reads `~/.claude/instincts/<project-hash>/observations.jsonl` produced by the Mulahazah hook, classifies failure rows into four typed friction patterns, scores confidence with a recency-weighted decay, and appends new instincts to `<project-hash>/instincts.jsonl` alongside.
+
+| Type | What it catches |
+|---|---|
+| `env_issue` | jq missing, command not found, not recognized as cmdlet |
+| `permission_block` | sandbox / harness blocked, Permission denied |
+| `wrong_approach` | file changed since last read (parallel-actor stale) |
+| `buggy_code` | file not read first, old_string ambiguous, file too large |
+
+## How to invoke
+
+```
+node bin/harvest-friction.mjs
+node bin/harvest-friction.mjs <project-hash>
+node bin/harvest-friction.mjs --list
+```
+
+`--list` shows new classifications without writing to `instincts.jsonl` — useful for dry-run before committing the harvest output.
+
+## Idempotency
+
+Each instinct carries a `dedup_key = sha1(type + tool + summary[:120])`. Re-running on the same observations does not duplicate previously-written instincts; `loadExistingDedupKeys()` reads the destination file once at start.
+
+## Confidence model
+
+```
+confidence = log10(occurrence_count + 1) * recency_factor
+recency_factor = 0.5 + 0.5 * exp(-days_since_last_seen / 14)
+```
+
+One occurrence today → 0.30. Ten occurrences today → clamped to 1.0. One occurrence 30 days ago → 0.17.
+
+## Output shape
+
+```
+harvest-friction project=0af156594b39
+  observations rows:    9346
+  tool_complete rows:   2104
+  classified failures:  47
+  thin-schema rows:     0
+  new instincts:        12
+  skipped (existing):   35
+
+New instincts:
+  [0.92] env_issue on Bash (×8): bash: jq: command not found
+  [0.74] permission_block on Bash (×4): harness blocked direct push to main
+  ...
+
+Appended 12 instinct(s) to /Users/.../instincts/0af156594b39/instincts.jsonl
+```
+
+## When the classifier emits zero instincts
+
+If `tool_complete rows: 0`, the bash-fallback hook is active (no jq AND the Node observer is not on PATH) and only emits `tool_start` events. Two remediation paths:
+
+- **Install jq** — `winget install jqlang.jq` (Windows), `brew install jq` (macOS), `apt install jq` (Linux).
+- **Wire the Node observer** — ensure `hooks/bin/observe.mjs` is reachable from the active hook script.
+
+Both are documented in the WARNING the classifier prints on a thin-schema host.
+
+## Pairs with
+
+- **`continuous-improvement`** (core SKILL.md, Law 7 — Learn From Every Session) — the harvest pipeline is the concrete mechanism behind Law 7's "capture patterns as instincts" contract.
+- **`workspace-surface-audit`** — Phase 1 Environment Grain confirms whether jq + Node observer are available; if not, the harvest will run inert until that gap closes.
+- **`gateguard`** — observation rows include the Parallel-Actor Gate's HEAD/upstream baselines when divergence-halts fire; the classifier surfaces those as `wrong_approach` instincts.

--- a/plugins/continuous-improvement/commands/harvest.md
+++ b/plugins/continuous-improvement/commands/harvest.md
@@ -1,0 +1,76 @@
+---
+name: harvest
+description: Harvest friction events from observation logs into typed instincts (env_issue, permission_block, wrong_approach, buggy_code) with confidence scoring.
+---
+
+# /harvest — Friction Harvest
+
+Run the friction-harvest classifier against this project's observation log and append new typed instincts to `instincts.jsonl`. Idempotent on re-run.
+
+## What it does
+
+Reads `~/.claude/instincts/<project-hash>/observations.jsonl` produced by the Mulahazah hook, classifies failure rows into four typed friction patterns, scores confidence with a recency-weighted decay, and appends new instincts to `<project-hash>/instincts.jsonl` alongside.
+
+| Type | What it catches |
+|---|---|
+| `env_issue` | jq missing, command not found, not recognized as cmdlet |
+| `permission_block` | sandbox / harness blocked, Permission denied |
+| `wrong_approach` | file changed since last read (parallel-actor stale) |
+| `buggy_code` | file not read first, old_string ambiguous, file too large |
+
+## How to invoke
+
+```
+node bin/harvest-friction.mjs
+node bin/harvest-friction.mjs <project-hash>
+node bin/harvest-friction.mjs --list
+```
+
+`--list` shows new classifications without writing to `instincts.jsonl` — useful for dry-run before committing the harvest output.
+
+## Idempotency
+
+Each instinct carries a `dedup_key = sha1(type + tool + summary[:120])`. Re-running on the same observations does not duplicate previously-written instincts; `loadExistingDedupKeys()` reads the destination file once at start.
+
+## Confidence model
+
+```
+confidence = log10(occurrence_count + 1) * recency_factor
+recency_factor = 0.5 + 0.5 * exp(-days_since_last_seen / 14)
+```
+
+One occurrence today → 0.30. Ten occurrences today → clamped to 1.0. One occurrence 30 days ago → 0.17.
+
+## Output shape
+
+```
+harvest-friction project=0af156594b39
+  observations rows:    9346
+  tool_complete rows:   2104
+  classified failures:  47
+  thin-schema rows:     0
+  new instincts:        12
+  skipped (existing):   35
+
+New instincts:
+  [0.92] env_issue on Bash (×8): bash: jq: command not found
+  [0.74] permission_block on Bash (×4): harness blocked direct push to main
+  ...
+
+Appended 12 instinct(s) to /Users/.../instincts/0af156594b39/instincts.jsonl
+```
+
+## When the classifier emits zero instincts
+
+If `tool_complete rows: 0`, the bash-fallback hook is active (no jq AND the Node observer is not on PATH) and only emits `tool_start` events. Two remediation paths:
+
+- **Install jq** — `winget install jqlang.jq` (Windows), `brew install jq` (macOS), `apt install jq` (Linux).
+- **Wire the Node observer** — ensure `hooks/bin/observe.mjs` is reachable from the active hook script.
+
+Both are documented in the WARNING the classifier prints on a thin-schema host.
+
+## Pairs with
+
+- **`continuous-improvement`** (core SKILL.md, Law 7 — Learn From Every Session) — the harvest pipeline is the concrete mechanism behind Law 7's "capture patterns as instincts" contract.
+- **`workspace-surface-audit`** — Phase 1 Environment Grain confirms whether jq + Node observer are available; if not, the harvest will run inert until that gap closes.
+- **`gateguard`** — observation rows include the Parallel-Actor Gate's HEAD/upstream baselines when divergence-halts fire; the classifier surfaces those as `wrong_approach` instincts.

--- a/plugins/continuous-improvement/skills/continuous-improvement/SKILL.md
+++ b/plugins/continuous-improvement/skills/continuous-improvement/SKILL.md
@@ -100,6 +100,19 @@ If the user corrects you, the instinct weakens. If they don't, it strengthens.
 
 Nothing learned is permanent. Everything decays without reinforcement.
 
+### Friction Harvest Pipeline (`/harvest`)
+
+Beyond the reflection-driven path above, the **friction harvest classifier** turns observation logs (`~/.claude/instincts/<project-hash>/observations.jsonl`) into typed instincts automatically. Run via `/harvest` or `node bin/harvest-friction.mjs`. Four typed friction patterns with confidence scoring:
+
+- **`env_issue`** — jq missing, command not found, not recognized as cmdlet
+- **`permission_block`** — sandbox / harness blocked, Permission denied
+- **`wrong_approach`** — file changed since last read (parallel-actor stale)
+- **`buggy_code`** — file not read first, old_string ambiguous, file too large
+
+Idempotent: each instinct's `dedup_key = sha1(type + tool + summary[:120])`; re-running on the same observations does not duplicate previously-written instincts. Confidence weights frequency × recency-decay so old failures fade and recurring ones strengthen, in line with the Law 7 contract above.
+
+The harvest is opt-in: it runs only when explicitly invoked. Cron / hook triggers are deliberately not wired so the operator stays in control of when the classifier reads observation history.
+
 ## The Loop
 
 ```

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -224,6 +224,20 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "skills/verification-loop.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
   { file: "plugins/continuous-improvement/skills/verification-loop/SKILL.md", pattern: "### Phase 8: Deploy Receipt", source: "docs-substrings-manifest:verification-loop-per-project-ladder" },
 
+  // /harvest slash command + Law-7 prose — locked 2026-05-07 (PR E, follow-up to PR D #88).
+  // The deferred follow-up landed: commands/harvest.md (+ plugin mirror) and a Friction Harvest
+  // Pipeline subsection inside SKILL.md Law 7 (+ plugin mirror). Each assertion below catches
+  // a specific class of regression:
+  //   - "name: harvest" frontmatter         → renaming the slash command
+  //   - "Friction Harvest Pipeline"         → losing the SKILL.md Law-7 subsection title
+  //   - "dedup_key = sha1(type + tool"      → losing the idempotency contract documentation
+  { file: "commands/harvest.md", pattern: "name: harvest", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+  { file: "plugins/continuous-improvement/commands/harvest.md", pattern: "name: harvest", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+  { file: "SKILL.md", pattern: "Friction Harvest Pipeline", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+  { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "Friction Harvest Pipeline", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+  { file: "SKILL.md", pattern: "dedup_key = sha1(type + tool", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+  { file: "plugins/continuous-improvement/skills/continuous-improvement/SKILL.md", pattern: "dedup_key = sha1(type + tool", source: "docs-substrings-manifest:harvest-slash-command-and-law7-prose" },
+
   // wild-risa-balance recommendation floor (src/test/wild-risa-floor.test.mts)
   // Source skill + plugin mirror must both contain the literal "2 WILD + 5 RISA = 7 items minimum".
   { file: "skills/wild-risa-balance.md", pattern: "2 WILD + 5 RISA = 7 items minimum", source: "wild-risa-floor.test.mts:38" },


### PR DESCRIPTION
## Summary
Closes the **trim from PR D (#88)** by shipping the explicitly-deferred `/harvest` slash command and the Law-7 SKILL.md prose. The classifier itself (`bin/harvest-friction.mjs`) landed in PR D as `5c130e8`; this PR makes it discoverable through the standard ECC surface.

## What lands

- **`commands/harvest.md`** — slash-command page documenting how to invoke (CLI + project-hash + `--list` dry-run), the four friction types, the `dedup_key` idempotency contract, the confidence model, the output shape, and the thin-schema fallback diagnostic. Pairs-with section names `continuous-improvement` (Law 7), `workspace-surface-audit` (PR A), and `gateguard` (PR #83 Parallel-Actor Gate).
- **`SKILL.md` Law-7 subsection** — adds a **Friction Harvest Pipeline** subsection inside the existing Law 7 (no shape change to the 7 Laws contract). Names the four friction types, quotes the `dedup_key = sha1(type + tool + summary[:120])` idempotency contract, and documents the opt-in posture (no cron / no auto-run).

Both mirrored to plugin copies per the CONTRIBUTING.md skill mirror rule.

## Lockdown

Three docs-substring assertions × 2 mirrors = 6 new lint assertions:

- `name: harvest` — catches slash-command rename
- `Friction Harvest Pipeline` — catches Law-7 subsection title removal
- `dedup_key = sha1(type + tool` — catches idempotency-contract loss

## Verification

```
npm run verify:all    # 7/7 gates green; docs-substrings 138 -> 144 (+6); everything-mirror 27 -> 28
npm run build         # no .mjs drift after regeneration
npm test              # 510 pass on Windows; 1 flake on observe.sh-hook 2247ms vs 2000ms (Linux CI ~500ms, will pass)
```

## Files (6)

| File | Change |
|---|---|
| `commands/harvest.md` | new, +76 lines |
| `plugins/continuous-improvement/commands/harvest.md` | byte-identical mirror |
| `SKILL.md` | +13 lines: Friction Harvest Pipeline subsection inside Law 7 |
| `plugins/continuous-improvement/skills/continuous-improvement/SKILL.md` | byte-identical mirror |
| `src/bin/check-docs-substrings.mts` | +14 lines: 6 lockdown assertions |
| `bin/check-docs-substrings.mjs` | regenerated by `tsc` |

No dispatcher (`plugins/continuous-improvement/skills/superpowers/SKILL.md`) edits, so the skills-drift CI workflow is not triggered (path filter excludes this PR's surface).

## Test plan
- [ ] `npm run verify:all` reports 144 docs-substring assertions, all matching
- [ ] Standalone + plugin mirror byte-identical for both new files
- [ ] `everything-mirror` count increases from 27 to 28 (commands/harvest.md adds its mirror pair)
- [ ] Linux CI runners pass `npm test` cleanly (the 2247ms Windows flake is OS-bound)

## Train conclusion

This PR closes the deferred-from-PR-D trim. Combined with PRs #83 + #84 (first release) and #85 + #86 + #87 + #88 (second release train), every item from the 28-day usage report's recommendation list except the WILD pair (autonomous release-train, parallel provider-eval harness) has now landed.