### PR TITLE
fix(tsconfig): pin tsc newLine to lf so Windows checkouts stay clean (#59)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "ES2022",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "newLine": "lf",
     "rootDir": "src",
     "outDir": ".",
     "strict": true,


### PR DESCRIPTION
## Summary
- Closes #59 (Windows-only manifest generator drift on clean checkout).
- Root cause is **tsc emitting CRLF on Windows** when overwriting `.mjs` outputs, clashing with `.gitattributes` `eol=lf`. The 8 manifest files originally named in #59 plus 11 `.mjs` files all surface as "modified" with empty diffs after a fresh `npm run build` on a Windows checkout.
- Fix is one line: pin `compilerOptions.newLine` to `"lf"` so `tsc` emits LF on every platform.

## Why this and not the alternatives
- `core.autocrlf=true` cannot help — tsc writes CRLF directly into the working tree, so by the time git sees the file it is already CRLF.
- `.gitattributes` `* text=auto eol=lf` is already in place; it just cannot fight a writer that bypasses it.
- Wiring `verify:generated` into required CI was the other option, but it would only catch drift at PR time without removing the local-dev `git status` noise.

## Verification (Windows 11, fresh worktree off `origin/main`)
- `npm install` → clean
- `npm run build` → working tree shows only the pre-existing `package-lock.json` 3.3.0 → 3.8.0 sync, no manifest or `.mjs` drift
- `npm run verify:generated` → exit 0 (the canonical check named in #59)
- `npm test` → 511/511 pass

## Test plan
- [ ] CI green on `lint-transcript` + `test (18 / 20 / 22)`
- [ ] One Windows reviewer confirms `git status` is clean after `npm run build` on a fresh clone
- [ ] No regression on Linux/macOS — `tsc` on those platforms already emitted LF, so behavior is unchanged

## Out of scope
- `package-lock.json` 3.3.0 → 3.8.0 sync (separate concern, will land in its own PR)
- Wiring `verify:generated` into the required CI rollup (worth doing as belt-and-suspenders, separate concern)