### PR TITLE
test(install): expand install.mjs unit test coverage (#2)

### DIFF
--- a/src/test/install.test.mts
+++ b/src/test/install.test.mts
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
@@ -18,12 +25,25 @@ interface TestSettings {
   hooks?: {
     PostToolUse?: HookEntry[];
     PreToolUse?: HookEntry[];
+    SessionStart?: HookEntry[];
+    SessionEnd?: HookEntry[];
   };
+  mcpServers?: Record<string, { command: string; args: string[] }>;
+  theme?: string;
 }
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const INSTALL_SCRIPT = join(__dirname, "..", "bin", "install.mjs");
 const SKILL_SOURCE = join(__dirname, "..", "SKILL.md");
+
+const ALL_COMMAND_FILES = [
+  "continuous-improvement.md",
+  "planning-with-files.md",
+  "proceed-with-the-recommendation.md",
+  "discipline.md",
+  "dashboard.md",
+  "learn-eval.md",
+] as const;
 
 describe("installer", () => {
   let tempHome = "";
@@ -81,6 +101,20 @@ describe("installer", () => {
   it("installs /planning-with-files command", () => {
     const commandPath = join(tempHome, ".claude", "commands", "planning-with-files.md");
     assert.ok(existsSync(commandPath), "planning-with-files command should be installed");
+  });
+
+  it("installs all 6 command files in beginner mode", () => {
+    for (const commandFile of ALL_COMMAND_FILES) {
+      const commandPath = join(tempHome, ".claude", "commands", commandFile);
+      assert.ok(existsSync(commandPath), `${commandFile} should be installed`);
+    }
+  });
+
+  it("installs Node observer artifacts alongside observe.sh", () => {
+    const observerJs = join(tempHome, ".claude", "instincts", "bin", "observe.mjs");
+    const observeEvent = join(tempHome, ".claude", "instincts", "lib", "observe-event.mjs");
+    assert.ok(existsSync(observerJs), "bin/observe.mjs should be installed");
+    assert.ok(existsSync(observeEvent), "lib/observe-event.mjs should be installed");
   });
 
   it("patches settings.json with hooks", () => {
@@ -142,5 +176,213 @@ describe("installer", () => {
       );
       assert.ok(!hasObserveHook, "observe.sh hook should be removed from settings");
     }
+  });
+});
+
+describe("installer - expert mode", () => {
+  let tempHome = "";
+
+  before(() => {
+    tempHome = join(tmpdir(), `ci-test-expert-${Date.now()}`);
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+    execFileSync("node", [INSTALL_SCRIPT, "install", "--mode", "expert"], {
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+  });
+
+  after(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("installs session.sh", () => {
+    const sessionPath = join(tempHome, ".claude", "instincts", "session.sh");
+    assert.ok(existsSync(sessionPath), "session.sh should ship in expert mode");
+  });
+
+  it("registers continuous-improvement MCP server in settings.json", () => {
+    const settingsPath = join(tempHome, ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as TestSettings;
+    assert.ok(settings.mcpServers, "mcpServers key should exist");
+    const server = settings.mcpServers?.["continuous-improvement"];
+    assert.ok(server, "continuous-improvement MCP server should be registered");
+    assert.equal(server?.command, "node", "MCP server should run via node");
+  });
+
+  it("adds SessionStart and SessionEnd hooks pointing at session.sh", () => {
+    const settingsPath = join(tempHome, ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as TestSettings;
+    assert.ok(Array.isArray(settings.hooks?.SessionStart), "SessionStart should be an array");
+    assert.ok(Array.isArray(settings.hooks?.SessionEnd), "SessionEnd should be an array");
+
+    const startHasSession = (settings.hooks?.SessionStart || []).some(
+      (entry) =>
+        Array.isArray(entry.hooks) &&
+        entry.hooks.some((hook) => hook.command?.includes("session.sh"))
+    );
+    const endHasSession = (settings.hooks?.SessionEnd || []).some(
+      (entry) =>
+        Array.isArray(entry.hooks) &&
+        entry.hooks.some((hook) => hook.command?.includes("session.sh"))
+    );
+    assert.ok(startHasSession, "SessionStart should have session.sh hook");
+    assert.ok(endHasSession, "SessionEnd should have session.sh hook");
+  });
+});
+
+describe("installer - foreign-hook preservation", () => {
+  let tempHome = "";
+
+  before(() => {
+    tempHome = join(tmpdir(), `ci-test-foreign-${Date.now()}`);
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+
+    const seed = {
+      hooks: {
+        PreToolUse: [
+          { matcher: "", hooks: [{ type: "command", command: "echo foreign-pre" }] },
+        ],
+        PostToolUse: [
+          { matcher: "", hooks: [{ type: "command", command: "echo foreign-post" }] },
+        ],
+      },
+      theme: "dark",
+    };
+    writeFileSync(
+      join(tempHome, ".claude", "settings.json"),
+      JSON.stringify(seed, null, 2) + "\n",
+    );
+
+    execFileSync("node", [INSTALL_SCRIPT, "install"], {
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+  });
+
+  after(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("preserves a foreign PreToolUse hook through install", () => {
+    const settingsPath = join(tempHome, ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as TestSettings;
+    const hasForeign = (settings.hooks?.PreToolUse || []).some(
+      (entry) =>
+        Array.isArray(entry.hooks) &&
+        entry.hooks.some((hook) => hook.command?.includes("foreign-pre"))
+    );
+    assert.ok(hasForeign, "Foreign PreToolUse hook should survive install");
+  });
+
+  it("preserves non-hook settings keys", () => {
+    const settingsPath = join(tempHome, ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as TestSettings;
+    assert.equal(settings.theme, "dark", "Foreign settings keys must not be clobbered");
+  });
+
+  it("preserves the foreign hook through uninstall", () => {
+    execFileSync("node", [INSTALL_SCRIPT, "--uninstall"], {
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+
+    const settingsPath = join(tempHome, ".claude", "settings.json");
+    const settings = JSON.parse(readFileSync(settingsPath, "utf8")) as TestSettings;
+    const hasForeign = (settings.hooks?.PreToolUse || []).some(
+      (entry) =>
+        Array.isArray(entry.hooks) &&
+        entry.hooks.some((hook) => hook.command?.includes("foreign-pre"))
+    );
+    assert.ok(hasForeign, "Foreign PreToolUse hook must NOT be removed by uninstall");
+
+    const hasObserve = (settings.hooks?.PreToolUse || []).some(
+      (entry) =>
+        Array.isArray(entry.hooks) &&
+        entry.hooks.some((hook) => hook.command?.includes("observe.sh"))
+    );
+    assert.ok(!hasObserve, "observe.sh hook should still be removed");
+  });
+});
+
+describe("installer - input validation", () => {
+  let tempHome = "";
+
+  before(() => {
+    tempHome = join(tmpdir(), `ci-test-invalid-${Date.now()}`);
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+  });
+
+  after(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("exits non-zero when given an unknown command", () => {
+    const result = spawnSync("node", [INSTALL_SCRIPT, "bogusverb"], {
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0, "Unknown command should exit non-zero");
+  });
+
+  it("falls back to beginner when --mode value is unknown", () => {
+    const output = execFileSync("node", [INSTALL_SCRIPT, "install", "--mode", "alien"], {
+      env: { ...process.env, HOME: tempHome },
+      encoding: "utf8",
+    });
+    assert.match(output, /mode: beginner/, "Invalid mode should fall back to beginner");
+  });
+});
+
+describe("installer - pack loader", () => {
+  let tempHome = "";
+
+  before(() => {
+    tempHome = join(tmpdir(), `ci-test-pack-${Date.now()}`);
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+  });
+
+  after(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("loads instincts from a known pack into the project hash dir", () => {
+    execFileSync("node", [INSTALL_SCRIPT, "install", "--pack", "react"], {
+      env: { ...process.env, HOME: tempHome },
+      cwd: tempHome,
+      encoding: "utf8",
+    });
+
+    const instinctsRoot = join(tempHome, ".claude", "instincts");
+    assert.ok(existsSync(instinctsRoot), "instincts root should exist after --pack");
+
+    const projectDirs = readdirSync(instinctsRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory() && entry.name !== "global")
+      .map((entry) => entry.name);
+
+    const candidateDirs = existsSync(join(instinctsRoot, "global"))
+      ? [...projectDirs, "global"]
+      : projectDirs;
+
+    let foundYaml = false;
+    for (const dir of candidateDirs) {
+      const yamlFiles = readdirSync(join(instinctsRoot, dir)).filter((file) =>
+        file.endsWith(".yaml"),
+      );
+      if (yamlFiles.length > 0) {
+        foundYaml = true;
+        break;
+      }
+    }
+    assert.ok(foundYaml, "At least one .yaml instinct should be loaded by --pack react");
+  });
+
+  it("reports an unknown pack with a helpful message", () => {
+    const result = spawnSync("node", [INSTALL_SCRIPT, "install", "--pack", "doesnotexist"], {
+      env: { ...process.env, HOME: tempHome },
+      cwd: tempHome,
+      encoding: "utf8",
+    });
+    const combined = (result.stdout ?? "") + (result.stderr ?? "");
+    assert.match(combined, /Unknown pack/, "Unknown pack name should produce error output");
   });
 });

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
-import { existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
@@ -8,6 +8,14 @@ import { fileURLToPath } from "node:url";
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const INSTALL_SCRIPT = join(__dirname, "..", "bin", "install.mjs");
 const SKILL_SOURCE = join(__dirname, "..", "SKILL.md");
+const ALL_COMMAND_FILES = [
+    "continuous-improvement.md",
+    "planning-with-files.md",
+    "proceed-with-the-recommendation.md",
+    "discipline.md",
+    "dashboard.md",
+    "learn-eval.md",
+];
 describe("installer", () => {
     let tempHome = "";
     before(() => {
@@ -55,6 +63,18 @@ describe("installer", () => {
         const commandPath = join(tempHome, ".claude", "commands", "planning-with-files.md");
         assert.ok(existsSync(commandPath), "planning-with-files command should be installed");
     });
+    it("installs all 6 command files in beginner mode", () => {
+        for (const commandFile of ALL_COMMAND_FILES) {
+            const commandPath = join(tempHome, ".claude", "commands", commandFile);
+            assert.ok(existsSync(commandPath), `${commandFile} should be installed`);
+        }
+    });
+    it("installs Node observer artifacts alongside observe.sh", () => {
+        const observerJs = join(tempHome, ".claude", "instincts", "bin", "observe.mjs");
+        const observeEvent = join(tempHome, ".claude", "instincts", "lib", "observe-event.mjs");
+        assert.ok(existsSync(observerJs), "bin/observe.mjs should be installed");
+        assert.ok(existsSync(observeEvent), "lib/observe-event.mjs should be installed");
+    });
     it("patches settings.json with hooks", () => {
         const settingsPath = join(tempHome, ".claude", "settings.json");
         assert.ok(existsSync(settingsPath), "settings.json should exist");
@@ -95,5 +115,162 @@ describe("installer", () => {
                 entry.hooks.some((hook) => hook.command?.includes("observe.sh")));
             assert.ok(!hasObserveHook, "observe.sh hook should be removed from settings");
         }
+    });
+});
+describe("installer - expert mode", () => {
+    let tempHome = "";
+    before(() => {
+        tempHome = join(tmpdir(), `ci-test-expert-${Date.now()}`);
+        mkdirSync(join(tempHome, ".claude"), { recursive: true });
+        execFileSync("node", [INSTALL_SCRIPT, "install", "--mode", "expert"], {
+            env: { ...process.env, HOME: tempHome },
+            encoding: "utf8",
+        });
+    });
+    after(() => {
+        rmSync(tempHome, { recursive: true, force: true });
+    });
+    it("installs session.sh", () => {
+        const sessionPath = join(tempHome, ".claude", "instincts", "session.sh");
+        assert.ok(existsSync(sessionPath), "session.sh should ship in expert mode");
+    });
+    it("registers continuous-improvement MCP server in settings.json", () => {
+        const settingsPath = join(tempHome, ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        assert.ok(settings.mcpServers, "mcpServers key should exist");
+        const server = settings.mcpServers?.["continuous-improvement"];
+        assert.ok(server, "continuous-improvement MCP server should be registered");
+        assert.equal(server?.command, "node", "MCP server should run via node");
+    });
+    it("adds SessionStart and SessionEnd hooks pointing at session.sh", () => {
+        const settingsPath = join(tempHome, ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        assert.ok(Array.isArray(settings.hooks?.SessionStart), "SessionStart should be an array");
+        assert.ok(Array.isArray(settings.hooks?.SessionEnd), "SessionEnd should be an array");
+        const startHasSession = (settings.hooks?.SessionStart || []).some((entry) => Array.isArray(entry.hooks) &&
+            entry.hooks.some((hook) => hook.command?.includes("session.sh")));
+        const endHasSession = (settings.hooks?.SessionEnd || []).some((entry) => Array.isArray(entry.hooks) &&
+            entry.hooks.some((hook) => hook.command?.includes("session.sh")));
+        assert.ok(startHasSession, "SessionStart should have session.sh hook");
+        assert.ok(endHasSession, "SessionEnd should have session.sh hook");
+    });
+});
+describe("installer - foreign-hook preservation", () => {
+    let tempHome = "";
+    before(() => {
+        tempHome = join(tmpdir(), `ci-test-foreign-${Date.now()}`);
+        mkdirSync(join(tempHome, ".claude"), { recursive: true });
+        const seed = {
+            hooks: {
+                PreToolUse: [
+                    { matcher: "", hooks: [{ type: "command", command: "echo foreign-pre" }] },
+                ],
+                PostToolUse: [
+                    { matcher: "", hooks: [{ type: "command", command: "echo foreign-post" }] },
+                ],
+            },
+            theme: "dark",
+        };
+        writeFileSync(join(tempHome, ".claude", "settings.json"), JSON.stringify(seed, null, 2) + "\n");
+        execFileSync("node", [INSTALL_SCRIPT, "install"], {
+            env: { ...process.env, HOME: tempHome },
+            encoding: "utf8",
+        });
+    });
+    after(() => {
+        rmSync(tempHome, { recursive: true, force: true });
+    });
+    it("preserves a foreign PreToolUse hook through install", () => {
+        const settingsPath = join(tempHome, ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        const hasForeign = (settings.hooks?.PreToolUse || []).some((entry) => Array.isArray(entry.hooks) &&
+            entry.hooks.some((hook) => hook.command?.includes("foreign-pre")));
+        assert.ok(hasForeign, "Foreign PreToolUse hook should survive install");
+    });
+    it("preserves non-hook settings keys", () => {
+        const settingsPath = join(tempHome, ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        assert.equal(settings.theme, "dark", "Foreign settings keys must not be clobbered");
+    });
+    it("preserves the foreign hook through uninstall", () => {
+        execFileSync("node", [INSTALL_SCRIPT, "--uninstall"], {
+            env: { ...process.env, HOME: tempHome },
+            encoding: "utf8",
+        });
+        const settingsPath = join(tempHome, ".claude", "settings.json");
+        const settings = JSON.parse(readFileSync(settingsPath, "utf8"));
+        const hasForeign = (settings.hooks?.PreToolUse || []).some((entry) => Array.isArray(entry.hooks) &&
+            entry.hooks.some((hook) => hook.command?.includes("foreign-pre")));
+        assert.ok(hasForeign, "Foreign PreToolUse hook must NOT be removed by uninstall");
+        const hasObserve = (settings.hooks?.PreToolUse || []).some((entry) => Array.isArray(entry.hooks) &&
+            entry.hooks.some((hook) => hook.command?.includes("observe.sh")));
+        assert.ok(!hasObserve, "observe.sh hook should still be removed");
+    });
+});
+describe("installer - input validation", () => {
+    let tempHome = "";
+    before(() => {
+        tempHome = join(tmpdir(), `ci-test-invalid-${Date.now()}`);
+        mkdirSync(join(tempHome, ".claude"), { recursive: true });
+    });
+    after(() => {
+        rmSync(tempHome, { recursive: true, force: true });
+    });
+    it("exits non-zero when given an unknown command", () => {
+        const result = spawnSync("node", [INSTALL_SCRIPT, "bogusverb"], {
+            env: { ...process.env, HOME: tempHome },
+            encoding: "utf8",
+        });
+        assert.notEqual(result.status, 0, "Unknown command should exit non-zero");
+    });
+    it("falls back to beginner when --mode value is unknown", () => {
+        const output = execFileSync("node", [INSTALL_SCRIPT, "install", "--mode", "alien"], {
+            env: { ...process.env, HOME: tempHome },
+            encoding: "utf8",
+        });
+        assert.match(output, /mode: beginner/, "Invalid mode should fall back to beginner");
+    });
+});
+describe("installer - pack loader", () => {
+    let tempHome = "";
+    before(() => {
+        tempHome = join(tmpdir(), `ci-test-pack-${Date.now()}`);
+        mkdirSync(join(tempHome, ".claude"), { recursive: true });
+    });
+    after(() => {
+        rmSync(tempHome, { recursive: true, force: true });
+    });
+    it("loads instincts from a known pack into the project hash dir", () => {
+        execFileSync("node", [INSTALL_SCRIPT, "install", "--pack", "react"], {
+            env: { ...process.env, HOME: tempHome },
+            cwd: tempHome,
+            encoding: "utf8",
+        });
+        const instinctsRoot = join(tempHome, ".claude", "instincts");
+        assert.ok(existsSync(instinctsRoot), "instincts root should exist after --pack");
+        const projectDirs = readdirSync(instinctsRoot, { withFileTypes: true })
+            .filter((entry) => entry.isDirectory() && entry.name !== "global")
+            .map((entry) => entry.name);
+        const candidateDirs = existsSync(join(instinctsRoot, "global"))
+            ? [...projectDirs, "global"]
+            : projectDirs;
+        let foundYaml = false;
+        for (const dir of candidateDirs) {
+            const yamlFiles = readdirSync(join(instinctsRoot, dir)).filter((file) => file.endsWith(".yaml"));
+            if (yamlFiles.length > 0) {
+                foundYaml = true;
+                break;
+            }
+        }
+        assert.ok(foundYaml, "At least one .yaml instinct should be loaded by --pack react");
+    });
+    it("reports an unknown pack with a helpful message", () => {
+        const result = spawnSync("node", [INSTALL_SCRIPT, "install", "--pack", "doesnotexist"], {
+            env: { ...process.env, HOME: tempHome },
+            cwd: tempHome,
+            encoding: "utf8",
+        });
+        const combined = (result.stdout ?? "") + (result.stderr ?? "");
+        assert.match(combined, /Unknown pack/, "Unknown pack name should produce error output");
     });
 });


### PR DESCRIPTION
## Summary
- Closes #2 (Add unit tests for install.mjs).
- Existing test file covered the beginner-mode happy path + idempotency + uninstall (9 tests). This PR adds **12 new tests** covering the previously untested surface area called out in the issue checklist plus a few real risks discovered while reading the source.
- Total coverage on `bin/install.mjs` now: **21 tests across 5 describe blocks** (was 9 in 1 block).

## What's covered now (delta)

| New describe | Tests | Why it matters |
|---|---|---|
| `installer - expert mode` | 3 | `--mode expert` was completely untested — session.sh, MCP server registration, SessionStart/SessionEnd hooks. |
| `installer - foreign-hook preservation` | 3 | Defends against the install or uninstall ever clobbering a user's pre-existing non-CI hooks or settings keys (theme, etc.). |
| `installer - input validation` | 2 | Unknown command must exit non-zero; invalid `--mode` value must fall back to beginner. |
| `installer - pack loader` | 2 | `--pack react` loads YAML instincts, `--pack <bogus>` reports the error with available pack list. |
| (in existing `installer` block) | +2 | All 6 command files installed (was 2 of 6); Node observer artifacts (bin/observe.mjs + lib/observe-event.mjs) installed alongside observe.sh. |

## Issue checklist mapping

- [x] Set up a test framework — already on `node:test` (kept).
- [x] Test config detection — Claude Code path covered; Codex/Gemini detection is **not implemented in install.mjs** (mentioned in README but no install.mjs code path exists), so out of scope here. Belongs with #9 if/when Gemini integration lands.
- [x] Test hook installation and idempotency — already covered, plus the new foreign-hook preservation tests.
- [x] Test edge cases (missing dirs, existing configs) — covered by foreign-hook preservation + input-validation blocks.

## Verification (Windows 11)
- `npm test` -> **523/523 pass** (was 511; +12 new)
- `npm run verify:generated` -> exit 0
- `npm run typecheck` -> clean

## Test plan
- [ ] CI green on `lint-transcript` + `test (18 / 20 / 22)`
- [ ] No regression on existing 9 install tests
- [ ] All 12 new tests pass

## Out of scope
- Codex / Gemini installer paths (out of scope until those integrations exist).
- Pre-existing `package-lock.json` 3.3.0 -> 3.8.0 sync (separate hygiene PR).