### PR TITLE
chore(lockfile): sync package-lock to 3.9.0 (post-#99 sweep)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",


### PR DESCRIPTION
## Summary
4-line lockfile sweep. PR #99 bumped lockfile 3.3.0 → 3.8.0; PR #100 (v3.9.0 release) landed first because of GitHub auto-merge ordering. Result: main has package.json @ 3.9.0 and package-lock.json @ 3.8.0 — a 1-version drift that produces an unsolicited diff every time a contributor runs `npm install` on a clean clone.

`npm install` on current main produces a clean 3.9.0 lockfile with no transitive churn — just the two version fields. Committing it.

## Why a separate PR
- Single-concern: lockfile only.
- Fixes the residual drift left by #99 + #100 auto-merge ordering, not the original #59 class.
- Could ride on PR A of the Gemini train (#102), but bundling cosmetic lockfile hygiene into a feature train would muddy the v3.10.0 changelog.

## Verification
- `npm install` → `up to date` after first install, no further drift
- `git diff --stat` → `package-lock.json | 4 ++--`
- No code, no test, no behavior change

## Test plan
- [ ] CI green on the lockfile-only diff
- [ ] After merge, `npm install` on a fresh clone produces no `git status` output