### PR TITLE
chore(workspace): add multi-root .code-workspace for continuous-improvement + seven-laws-reserve

### DIFF
--- a/.vscode/continuous-improvement.code-workspace
+++ b/.vscode/continuous-improvement.code-workspace
@@ -1,0 +1,11 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		},
+		{
+			"path": "../../seven-laws-reserve"
+		}
+	],
+	"settings": {}
+}


### PR DESCRIPTION
## Summary
- Adds an 11-line `.vscode/continuous-improvement.code-workspace` with two folder roots: this repo (`..`) and the sibling `seven-laws-reserve` repo (`../../seven-laws-reserve`).
- Enables side-by-side editing across both repos in a single VS Code window.

## Provenance
- Cherry-picked content from the abandoned `tooling/multi-root-workspace` branch (commit `702e0d4`, cut weeks ago) which had drifted ~20+ files behind current `main`.
- Relocated from the original path `nanobanana-output/continuous-improvement.code-workspace` (now gitignored at `.gitignore:5`) to `.vscode/` so the file is tracked alongside existing IDE config (`.vscode/extensions.json`).

## Test plan
- [ ] Open the workspace file in VS Code, confirm both folder roots load.
- [ ] Verify CI passes (single-file addition to a tracked, non-ignored path).
- [ ] After merge, delete the stale `tooling/multi-root-workspace` local + remote refs.