### PR TITLE
fix(install): collapse paths, sync versions, expand installer + dispatcher rewrite

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -33,13 +33,19 @@ Without it, `/superpowers` still works — it falls back to inline behavior — 
 
 You should see the 7 Laws quick-reference card. If the command is not recognized after a restart, see Troubleshooting in [README.md](README.md#troubleshooting-install).
 
-**Check 2 — hooks are live (proves the discipline is actually enforcing, not just documented).** Ask Claude to write to a throwaway file without doing any research first:
+**Check 2 — skill registered.** Run:
 
 ```
-Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
+/dashboard
 ```
 
-You should see Claude **refuse or pause** because `gateguard` (Law 1) blocks Edit/Write until concrete investigation is presented. That refusal is the proof the hooks are wired. If Claude just writes the file with no pushback, the hooks did not install — see [README.md → Troubleshooting](README.md#troubleshooting-install).
+You should see the dashboard render with `Level: CAPTURE` and observation count 0 (or higher). If `/dashboard` is unrecognized after a restart, the install did not complete; rerun the marketplace install.
+
+### A note on enforcement
+
+The 7 Laws are enforced **at the model layer, not the runtime layer**. When you ask Claude to write a file with no research, the bundled `gateguard` skill prompts Claude to investigate first — but this is model-side discipline (the model reads the skill and chooses to comply), not a runtime PreToolUse block that physically refuses the tool call. A future release may add a true runtime hook; until then, the value of the framework comes from the agent reading the Laws as part of its loaded context, not from a tripwire.
+
+If you ever see Claude skip a Law, name it back: *"You skipped Law 1 — research first."* That correction is what trains the instinct system over time.
 
 ---
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,31 +2,48 @@
 
 Zero to working in under 2 minutes.
 
+This is the **Beginner** path. It mirrors README.md and is enough for ~90% of users — no Node, no bash, no shell. If you want the MCP server, observation hooks, and instinct packs, see the **Expert (npx)** section at the bottom.
+
 ---
 
-## Step 1: Install
+## Step 1: Install (Beginner — inside Claude Code)
 
-```bash
-npx continuous-improvement install
+Run these two slash commands inside Claude Code. The doubled name is correct: it reads as `<plugin>@<marketplace>`.
+
+```
+/plugin marketplace add naimkatiman/continuous-improvement
+/plugin install continuous-improvement@continuous-improvement
 ```
 
-This auto-detects your setup. For Claude Code, it installs the skill, hooks, and `/continuous-improvement` command.
+Optional companion (recommended) — the Obra `superpowers` skills library that the `/superpowers` dispatcher routes into:
 
-On Windows, run the same command from PowerShell. Install Git Bash or WSL first so the observation hooks can execute.
+```
+/plugin install superpowers@continuous-improvement
+```
 
-### Verify the install
+Without it, `/superpowers` still works — it falls back to inline behavior — but specialist skills like `superpowers:test-driven-development` and `superpowers:writing-plans` will not be available as dedicated targets.
 
-Open Claude Code and run:
+### Verify the install — two checks
+
+**Check 1 — slash command loaded.** Quit and reopen Claude Code (slash commands only load on session start), then run:
 
 ```
 /discipline
 ```
 
-You should see the 7 Laws quick-reference card. If the command is not recognized, **quit and reopen Claude Code first** — slash commands only load on session start. Re-run the install step only if a fresh session still doesn't recognize `/discipline`.
+You should see the 7 Laws quick-reference card. If the command is not recognized after a restart, see Troubleshooting in [README.md](README.md#troubleshooting-install).
+
+**Check 2 — hooks are live (proves the discipline is actually enforcing, not just documented).** Ask Claude to write to a throwaway file without doing any research first:
+
+```
+Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
+```
+
+You should see Claude **refuse or pause** because `gateguard` (Law 1) blocks Edit/Write until concrete investigation is presented. That refusal is the proof the hooks are wired. If Claude just writes the file with no pushback, the hooks did not install — see [README.md → Troubleshooting](README.md#troubleshooting-install).
 
 ---
 
-## Step 2: Use It
+## Step 2: Use it
 
 Give your agent a task and prefix it:
 
@@ -53,19 +70,19 @@ That creates `task_plan.md`, `findings.md`, and `progress.md` in the project roo
 
 ---
 
-## Step 3: Check Learning
+## Step 3: Check learning
 
-After completing non-trivial work:
+After completing non-trivial work, run the canonical reflection command:
 
 ```
-/continuous-improvement
+/seven-laws
 ```
 
-This shows what the system has learned — instincts, confidence levels, and the current auto-level.
+This shows what the system has learned — instincts, confidence levels, and the current auto-level. `/continuous-improvement` is kept as an alias for backward compatibility and runs the same workflow.
 
 ---
 
-## How Auto-Leveling Works
+## How auto-leveling works
 
 You don't configure anything. The system promotes itself:
 
@@ -80,7 +97,7 @@ Corrections drop instinct confidence. Unused instincts decay. The system self-co
 
 ---
 
-## Common Issues
+## Common issues
 
 **Agent skips straight to coding?**
 → Say: *"You skipped research and planning. Go back to Law 1."*
@@ -93,7 +110,24 @@ Corrections drop instinct confidence. Unused instincts decay. The system self-co
 
 ---
 
-## That's It
+## Expert (npx) — only if you want MCP, hooks, or instinct packs
+
+The Beginner path above is enough for most users. Pick this only if you want the MCP tools (12 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, or the starter instinct packs.
+
+Do not run both paths against the same `~/.claude/` — that produces duplicated state. Pick one and stick with it.
+
+```bash
+npx continuous-improvement install --mode expert
+npx continuous-improvement install --pack react   # optional: react | python | go | meta
+```
+
+Preconditions: Node 18 / 20 / 22, plus bash on Windows (Git Bash or WSL — `hooks/observe.sh` is a bash script). See [README.md § Expert](README.md#expert--adds-mcp-server-observation-hooks-and-instinct-packs) for the full preconditions and troubleshooting matrix.
+
+Verify with `/dashboard` — you should see instinct health and observation count.
+
+---
+
+## That's it
 
 The skill is most valuable when:
 - You're under pressure and tempted to skip steps

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Every one of those failures is the agent skipping a step a disciplined engineer 
 ## What you get
 
 - **A 7-step discipline** the agent must follow every task — research → plan → execute one thing → verify → reflect → learn → iterate. Each Law has at least one skill or hook that enforces it.
-- **13 bundled skills** that turn the Laws from a doc into runtime behavior — `gateguard` blocks unverified Edit/Write/destructive Bash, `tdd-workflow` enforces RED → GREEN → REFACTOR, `verification-loop` runs build/types/tests/security before "done", `proceed-with-the-recommendation` walks any agent's recommendation list top-to-bottom with per-item verification.
+- **13 bundled skills** that turn the Laws from a doc into agent behavior — `gateguard` prompts the agent to investigate before Edit/Write/destructive Bash, `tdd-workflow` enforces RED → GREEN → REFACTOR, `verification-loop` runs build/types/tests/security before "done", `proceed-with-the-recommendation` walks any agent's recommendation list top-to-bottom with per-item verification. These run as model-side discipline; the agent reads each skill and applies it. The session and observation hooks (`hooks/`) wire the learning loop, not a runtime tool-call block — see [§ A note on enforcement](#a-note-on-enforcement).
 - **Mulahazah, the auto-leveling instinct engine** — hooks capture every tool call; after ~20 observations the agent analyzes patterns and creates instincts with confidence scores. Suggestions appear at 0.5+, auto-apply at 0.7+, decay when ignored. Project-scoped, promote to global after 2+ projects. You configure nothing.
 - **A GitHub Action transcript linter** that catches skipped Laws in CI — writes without prior research, edits without verification, too many files at once.
 - **Two install paths** — Beginner is two slash commands inside Claude Code (no Node, no bash, ~90% of users). Expert adds the MCP server, observation hooks, instinct packs, and the linter.
@@ -74,13 +74,11 @@ Without the companion the dispatcher still works — every routing target has a 
 Verify: run `/discipline` in Claude Code — you should see the 7 Laws card.
 If the command is not recognized, restart your Claude Code session first; the marketplace did pick the plugin up but commands load on session start.
 
-**Second-stage verify (proves the hooks are live, not just the docs).** Ask Claude to write to a throwaway file with no research first:
+**Second-stage verify (proves the bundle dropped beyond just the slash command).** Run `/dashboard` — the rendered card with `Level: CAPTURE` and observation counters confirms the skills + observation hooks landed.
 
-```
-Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
-```
+### A note on enforcement
 
-You should see Claude pause or refuse — that is `gateguard` enforcing Law 1. If Claude writes the file with no pushback, the hooks did not install; see Troubleshooting below.
+The 7 Laws are enforced **at the model layer, not the runtime layer**. When you ask Claude to write a file with no research, `gateguard` prompts Claude to investigate first — but this is model-side discipline (the model reads the skill and chooses to comply), not a PreToolUse hook that physically refuses the tool call. The `hooks/` directory wires observation (`observe.sh`/`observe.mjs`) and end-of-turn three-section close (`three-section-close.mjs`); neither blocks an Edit. A roadmap item tracks adding a true runtime gate — see the open issue linked in [skills/gateguard.md](skills/gateguard.md). Until then, value comes from the agent reading the Laws as part of its loaded context.
 
 ### Expert — adds MCP server, observation hooks, and instinct packs
 
@@ -200,7 +198,7 @@ The plugin ships **1 core + 1 featured + 4 tier-1 + 4 tier-2 + 3 always-bundled 
 |---|-------|------|-----|--------------|
 | 1 | [`continuous-improvement`](SKILL.md) | core | — | The 7 Laws spec itself (research → plan → execute → verify → reflect → learn → iterate) |
 | 2 | [`proceed-with-the-recommendation`](skills/proceed-with-the-recommendation.md) ⭐ | featured | all 7 | Walks any agent's recommendation list top-to-bottom, routes each item, verifies per item, halts on `needs-approval` |
-| 3 | [`gateguard`](skills/gateguard.md) | 1 | 1 | PreToolUse gate that blocks Edit/Write/destructive Bash until concrete investigation is presented |
+| 3 | [`gateguard`](skills/gateguard.md) | 1 | 1 | Skill that prompts the agent to investigate (importers, schemas, user instruction) before Edit/Write/destructive Bash. Runtime PreToolUse hook is a roadmap item, not yet bundled. |
 | 4 | [`para-memory-files`](skills/para-memory-files.md) | 1 | 5 + 7 | Durable file-based memory using PARA (Projects/Areas/Resources/Archives) for cross-session context |
 | 5 | [`tdd-workflow`](skills/tdd-workflow.md) | 1 | 3 + 4 | RED → GREEN → REFACTOR enforcement with 80%+ coverage across unit/integration/E2E |
 | 6 | [`verification-loop`](skills/verification-loop.md) | 1 | 4 | Six-phase verification (build, types, lint, tests, security, diff) with PASS/FAIL report |

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The whole thing is MIT, free, and lives in this one repo. No service, no account
 
 **If you don't know which to pick, use Beginner.** It is enough for ~90% of users and adds no Node or bash dependency.
 
-### Beginner — inside Claude Code, two commands
+### Beginner — inside Claude Code, two commands (plus one optional companion)
 
 You get the 7 Laws skill, the hooks that enforce it, and the slash commands. Nothing else to install.
 
@@ -63,8 +63,24 @@ You get the 7 Laws skill, the hooks that enforce it, and the slash commands. Not
 
 The doubled name is correct: it reads as `<plugin>@<marketplace>`.
 
+**Optional companion (recommended).** The `/superpowers` dispatcher routes per-task to specialist skills (`writing-plans`, `test-driven-development`, `using-git-worktrees`, `dispatching-parallel-agents`, `finishing-a-development-branch`, etc.) shipped by Obra's `superpowers` plugin, which is vendored into this same marketplace as a pinned-SHA snapshot. Install it with one extra line:
+
+```bash
+/plugin install superpowers@continuous-improvement
+```
+
+Without the companion the dispatcher still works — every routing target has a concrete inline fallback — but specialist quality is fallback-quality, not dedicated-skill-quality.
+
 Verify: run `/discipline` in Claude Code — you should see the 7 Laws card.
 If the command is not recognized, restart your Claude Code session first; the marketplace did pick the plugin up but commands load on session start.
+
+**Second-stage verify (proves the hooks are live, not just the docs).** Ask Claude to write to a throwaway file with no research first:
+
+```
+Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
+```
+
+You should see Claude pause or refuse — that is `gateguard` enforcing Law 1. If Claude writes the file with no pushback, the hooks did not install; see Troubleshooting below.
 
 ### Expert — adds MCP server, observation hooks, and instinct packs
 
@@ -145,20 +161,25 @@ Hooks capture every tool call. After ~20 observations, Claude analyzes patterns 
 
 ## Slash Commands
 
+`/seven-laws` is the canonical reflect-and-learn command. `/continuous-improvement` is kept as an alias for backward compatibility — both run the same workflow.
+
 ```
-/seven-laws                       Reflect, analyze, show status (brand-aligned name)
-/continuous-improvement           Same workflow as /seven-laws (kept for backward compat)
+/seven-laws                       Reflect, analyze, show status (canonical)
+/continuous-improvement           Alias for /seven-laws (kept for backward compat)
 /proceed-with-the-recommendation  Walk any agent's recommendation list top-to-bottom
 /superpowers                      Law activator — route the task to the right specialist
 /workspace-surface-audit          Audit repo + MCP + env, recommend high-value skills
 /planning-with-files              Create task_plan.md, findings.md, progress.md
 /discipline                       Quick reference card of the 7 Laws
 /dashboard                        Visual instinct health dashboard
-/ralph                            Autonomous PRD story-by-story loop (expert)
+/ralph                            Autonomous PRD story-by-story loop
 /learn-eval                       Capture session patterns into new skills (expert)
+/harvest                          Extract reusable patterns from session friction
+/release-train                    Coordinate a multi-PR release sequence
+/swarm                            Fan-out coordination across parallel sub-agents
 ```
 
-In expert mode, the same planning workflow is also available programmatically through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
+All 13 ship in the marketplace bundle. The Beginner install gets all of them. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
 
 ---
 

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -21,11 +21,18 @@ const SKILL_NAME = "continuous-improvement";
 const REPO_ROOT = join(__dirname, "..");
 const COMMAND_FILES = [
     "continuous-improvement.md",
+    "dashboard.md",
+    "discipline.md",
+    "harvest.md",
+    "learn-eval.md",
     "planning-with-files.md",
     "proceed-with-the-recommendation.md",
-    "discipline.md",
-    "dashboard.md",
-    "learn-eval.md",
+    "ralph.md",
+    "release-train.md",
+    "seven-laws.md",
+    "superpowers.md",
+    "swarm.md",
+    "workspace-surface-audit.md",
 ];
 const HOOK_TYPES = ["PreToolUse", "PostToolUse"];
 const SESSION_HOOK_TYPES = ["SessionStart", "SessionEnd"];

--- a/commands/superpowers.md
+++ b/commands/superpowers.md
@@ -1,22 +1,95 @@
 ---
 name: superpowers
-description: "Activate mandatory agent workflows: brainstorming, TDD, code review, git worktrees, and structured development"
+description: "Law activator and dispatcher — route the task to the right Law-aligned specialist across continuous-improvement and four vendored upstream skill libraries (Obra superpowers, addy-agent-skills, ruflo-swarm, oh-my-claudecode)."
 ---
 
 # /superpowers
 
-Activate the Superpowers mandatory workflow framework. Skills trigger automatically based on context — this is not optional guidance.
+`/superpowers` is **the dispatcher**, not a peer skill. It does not do work itself; it routes each user task to the correct Law-aligned specialist so the right discipline fires automatically instead of the agent skipping a step.
+
+The 7 Laws define *what* discipline must be applied. `/superpowers` decides *which specialist* enforces it for this specific task, across five sources installed from this marketplace.
+
+## Routing surface (five sources)
+
+| Source | Where it lives | Examples of what it routes to |
+|---|---|---|
+| `continuous-improvement` (this plugin) | bundled — always present | `gateguard` (Law 1), `tdd-workflow` (Law 3+4), `verification-loop` (Law 4), `wild-risa-balance` (Law 2), `safety-guard` (Law 3), `proceed-with-the-recommendation` (all 7), `ralph` (Law 6), `workspace-surface-audit` (Law 1) |
+| `obra/superpowers` (Jesse Vincent) | vendored at `third-party/superpowers/`, pinned SHA `f2cbfbe` (v5.1.0) | `superpowers:brainstorming`, `:writing-plans`, `:executing-plans`, `:test-driven-development`, `:systematic-debugging`, `:requesting-code-review`, `:receiving-code-review`, `:verification-before-completion`, `:dispatching-parallel-agents`, `:using-git-worktrees`, `:finishing-a-development-branch`, `:subagent-driven-development`, `:writing-skills`, `:using-superpowers` |
+| `addyosmani/agent-skills` | vendored at `third-party/addy-agent-skills/`, pinned SHA `742dca5` (v1.0.0) | `spec-driven-development`, `source-driven-development`, `context-engineering`, `idea-refine`, `incremental-implementation`, `code-review-and-quality`, `code-simplification`, `security-and-hardening`, `debugging-and-error-recovery`, `performance-optimization`, `api-and-interface-design`, `frontend-ui-engineering`, `browser-testing-with-devtools`, `ci-cd-and-automation`, `deprecation-and-migration`, `documentation-and-adrs`, `git-workflow-and-versioning`, `planning-and-task-breakdown`, `shipping-and-launch` |
+| `ruflo-swarm` (ruvnet) | vendored at `third-party/ruflo-swarm/`, pinned SHA `addb5cd` (v0.2.0) | `swarm-init`, `monitor-stream`; `swarm_*` and `agent_*` MCP tools; `/swarm`, `/watch` |
+| `oh-my-claudecode` (Yeachan-Heo) | vendored at `third-party/oh-my-claudecode/`, pinned SHA `aacde3e` (v4.13.6) | 39 skills + 19 agents — `release`, `ultrawork`, `ultraqa`, `team`, `trace`, `visual-verdict`, `debug`, `deep-dive`, `deep-interview`, `autopilot`, `autoresearch`, plus a separate `ralph` (overlaps with our `/ralph` — see "Distinct variants" below) |
+
+PM coverage (product-management skills) lives **outside** this marketplace. If you need it, install [`phuryn/pm-skills`](https://github.com/phuryn/pm-skills) separately via Claude Code's host marketplace; the dispatcher names it as a routing target without pre-resolving the namespace. See [docs/THIRD_PARTY.md § Routing in /superpowers](../docs/THIRD_PARTY.md#routing-in-superpowers).
+
+## Distinct variants — never collapse them
+
+Two routing targets carry the same short name across sources. Treat them as distinct; do not silently substitute one for the other.
+
+| Short name | `obra/superpowers` (Obra) | `continuous-improvement` (CI fork) |
+|---|---|---|
+| `superpowers` (skill) | activator routing into Obra skills | `superpowers` skill in this repo: Law-aligned activator wrapping the dispatcher commitments below |
+| `ralph` | not present in Obra | bundled here; `oh-my-claudecode` ships its own `ralph` — pick deliberately, do not auto-merge |
+
+If both Obra `superpowers` and continuous-improvement are loaded, you can call either explicitly: `superpowers:test-driven-development` (Obra) or `tdd-workflow` (CI). Same Law (3+4), different implementation depth.
+
+## Dispatcher commitments (override looser global defaults when `/superpowers` is in scope)
+
+When this dispatcher is active for a task, these six rules apply over any looser convention:
+
+1. **Subagent-driven development is the default for non-trivial tasks.** Two-stage spec + quality review per [obra/superpowers § subagent-driven-development](https://github.com/obra/superpowers).
+2. **Parallel fan-out goes through `superpowers:dispatching-parallel-agents`** (or `/swarm`), not hand-rolled `Task` calls.
+3. **TDD runs RED → GREEN → REFACTOR.** Code written before its test is **deleted**, not retrofitted. Routes to `tdd-workflow` (CI) or `superpowers:test-driven-development` (Obra) — pick by depth, never both for the same task.
+4. **Branch isolation is `using-git-worktrees`** by default for any task that touches more than one file.
+5. **`finishing-a-development-branch` runs before any push.** No bypass via `--no-verify`, `--force`, or direct push to `main`.
+6. **Obra `superpowers` and `continuous-improvement:superpowers` stay distinct.** Both can be installed; neither shadows the other; the dispatcher names which one is firing.
+
+## Routing rules (which source wins)
+
+| User intent | Preferred routing target | Source |
+|---|---|---|
+| New feature, vague requirements | `superpowers:brainstorming` → `:writing-plans` | `obra/superpowers` |
+| Fix this bug | `superpowers:systematic-debugging` → `tdd-workflow` (RED first) → `verification-loop` | Obra → CI → CI |
+| Walk an agent's recommendation list | `proceed-with-the-recommendation` | CI |
+| Write tests for new code | `tdd-workflow` (CI default) or `superpowers:test-driven-development` (Obra, deeper) | CI / Obra |
+| Verify before reporting "done" | `verification-loop` | CI |
+| Refactor, multi-file | `superpowers:using-git-worktrees` → `:writing-plans` → `tdd-workflow` → `:finishing-a-development-branch` | Obra → Obra → CI → Obra |
+| Long autonomous PRD execution | `/ralph` (CI variant) | CI |
+| Parallel sub-agent fan-out | `superpowers:dispatching-parallel-agents` or `/swarm` | Obra / ruflo-swarm |
+| Spec-first, contract-first feature | `spec-driven-development` | addy-agent-skills |
+| Frontend / UI generation | `frontend-design` (external plugin) | external |
+| Diff walk + severity tagging | `code-review` (external plugin) or `superpowers:requesting-code-review` | external / Obra |
+| Library / framework docs lookup | `documentation-lookup` (Context7 MCP) | external |
+| Compliance / security gate | `security-and-hardening` (addy) → `security-review` (host built-in) | addy → host |
+| Release coordination across PRs | `/release-train` | CI |
+
+## Missing-companion detection
+
+If `/superpowers` is asked to route to a source that is not installed, it does not silently fall back to the inline placeholder. It must:
+
+1. **Name the missing source** explicitly (e.g. `obra/superpowers` not loaded).
+2. **Quote the exact install line** for it from the marketplace already added in setup, e.g. `/plugin install superpowers@continuous-improvement`.
+3. **State the inline-fallback equivalent** that will run if the user declines to install (and which Law that fallback enforces).
+4. **Stop and ask** before continuing. Do not silently downgrade.
+
+This is the same hard-halt discipline used by `proceed-with-the-recommendation` for `needs-approval` items.
 
 ## Subcommands
 
 ### `/superpowers status`
 
-Show which workflow stages are active:
+Show which routing sources are loaded, which workflow stages are active for the current task, and which sources are **missing**:
 
 ```
 === Superpowers Status ===
 
-Active Skills:
+Sources:
+  [x] continuous-improvement       (bundled)
+  [x] obra/superpowers              v5.1.0 (vendored)
+  [ ] addyosmani/agent-skills       MISSING — /plugin install agent-skills@continuous-improvement
+  [x] ruflo-swarm                   v0.2.0 (vendored)
+  [ ] oh-my-claudecode              MISSING — /plugin install oh-my-claudecode@continuous-improvement
+
+Active for current task:
   [x] brainstorming (trigger: new feature request)
   [ ] using-git-worktrees (waiting: design approval)
   [ ] writing-plans (waiting: worktree ready)
@@ -27,127 +100,81 @@ Active Skills:
 
 ### `/superpowers enable <skill>`
 
-Explicitly enable a skill for the current session:
+Explicitly enable a skill for the current session — useful when the dispatcher's intent detection guesses wrong:
 
 ```
 /superpowers enable test-driven-development
+/superpowers enable superpowers:writing-plans   # namespaced form for Obra
 ```
 
 ### `/superpowers workflow <type>`
 
 Activate a complete workflow preset:
 
-| Preset | Skills Activated |
-|--------|------------------|
-| `new-feature` | brainstorming → worktrees → plans → TDD → review → finish |
-| `bug-fix` | systematic-debugging → verification → TDD → review |
-| `refactor` | worktrees → plans → TDD → review → finish |
-| `review` | requesting-code-review → receiving-code-review |
+| Preset | Skills activated (in order) |
+|---|---|
+| `new-feature` | `superpowers:brainstorming` → `:using-git-worktrees` → `:writing-plans` → `tdd-workflow` → `verification-loop` → `:requesting-code-review` → `:finishing-a-development-branch` |
+| `bug-fix` | `superpowers:systematic-debugging` → `verification-loop` → `tdd-workflow` (regression test first) → `:requesting-code-review` |
+| `refactor` | `superpowers:using-git-worktrees` → `:writing-plans` → `tdd-workflow` → `:requesting-code-review` → `:finishing-a-development-branch` |
+| `review` | `superpowers:requesting-code-review` → `:receiving-code-review` |
+| `release` | `/release-train` → `verification-loop` → `superpowers:finishing-a-development-branch` |
 
 Example:
 ```
 /superpowers workflow new-feature
 ```
 
-## Mandatory Skills
+## Verification protocol (Law 4)
 
-### brainstorming
-**Triggers:** New feature requests, vague requirements
+Every routed skill must verify before reporting completion. The dispatcher refuses to advance to the next stage until the current one shows:
 
-1. Ask clarifying questions
-2. Explore 2-3 alternatives
-3. Present design in sections
-4. Wait for explicit approval
+1. Code runs without errors
+2. Output matches expected result
+3. Actual result checked — not assumed
+4. Build passes
+5. Change explainable in one sentence
 
-### using-git-worktrees
-**Triggers:** Design approved, feature branch needed
-
-Creates isolated workspace:
-```bash
-git worktree add -b feature-name ../feature-name
-```
-
-### writing-plans
-**Triggers:** Worktree ready, implementation starting
-
-Breaks work into bite-sized tasks (2-5 minutes each). Every task includes:
-- Exact file paths
-- Complete code
-- Verification steps
-
-### test-driven-development
-**Triggers:** Plan approved, coding begins
-
-```
-RED: Write failing test → Watch it fail
-GREEN: Write minimal code → Watch it pass
-REFACTOR: Improve while green → Commit
-```
-
-**Rule:** Code written before tests is deleted.
-
-### requesting-code-review
-**Triggers:** Task complete, before continuing
-
-Two-stage review:
-1. Spec compliance — Does it match the plan?
-2. Code quality — Clean, tested, maintainable?
-
-Severity levels: Critical (blocks), Warning (note), Info (log)
-
-### finishing-a-development-branch
-**Triggers:** All tasks complete
-
-Options presented:
-- Merge to main
-- Create PR
-- Keep branch
-- Discard (with confirmation)
-
-## Skill Activation Rules
-
-| User Request | Activates |
-|--------------|-----------|
-| "Create a feature" | brainstorming → writing-plans → executing-plans |
-| "Fix this bug" | systematic-debugging → verification → TDD |
-| "Review this code" | requesting-code-review |
-| "Refactor this" | using-git-worktrees → writing-plans → TDD |
-
-## Verification Protocol
-
-Every skill requires verification before reporting completion:
-
-1. **Code runs** without errors
-2. **Output matches** expected result
-3. **Actual result checked** — not assumed
-4. **Build passes**
-5. **Explained** in one sentence
+This is `verification-loop` from `continuous-improvement`. It runs after every workflow stage, not just at the end.
 
 ## Integration
 
-Superpowers integrates with:
-- **continuous-improvement** — reflection and learning after each stage
-- **ralph** — autonomous execution of planned stories
-- **workspace-surface-audit** — verify environment before starting
+`/superpowers` integrates with:
 
-## Example Session
+- **`/seven-laws`** — runs after each stage to capture the reflection block and update instincts (Laws 5 + 7)
+- **`/proceed-with-the-recommendation`** — orchestrates a list of recommendations end-to-end, using `/superpowers` per item
+- **`/workspace-surface-audit`** — runs at task start to confirm the right routing surface is actually present (Law 1 pre-flight)
+- **`/ralph`** — autonomous variant; takes a PRD and walks it story-by-story under the same routing table
+
+## Example session
 
 ```
 User: "Build a checkout flow"
 
-[brainstorming activates]
+[/superpowers status] →
+  Sources: continuous-improvement [x], obra/superpowers [x], others [ ]
+  Routing intent: new-feature
+
+[brainstorming activates — obra/superpowers]
 AI: "Clarifying questions: 1) Payment provider? 2) Guest checkout?"
 
 User: "Stripe, yes guest checkout"
 
-[writing-plans activates]
+[using-git-worktrees activates — obra/superpowers]
+AI: "Created worktree at ../checkout-feature"
+
+[writing-plans activates — obra/superpowers]
 AI: "Plan created with 6 tasks. Approve?"
 
 User: "Approved"
 
-[using-git-worktrees activates]
-AI: "Created worktree at ../checkout-feature"
+[tdd-workflow activates — continuous-improvement]
+AI: "Task 1 RED: write failing test for cart validation..."
+AI: "Task 1 GREEN: minimal handler. Verifying with `npm test cart.test.ts`..."
+AI: "Task 1 REFACTOR: extract validator, tests still green. Committing."
 
-[test-driven-development activates]
-AI: "Task 1: Write failing test for cart validation..."
+[verification-loop activates — continuous-improvement]
+AI: "Build [x] Types [x] Lint [x] Tests 42/42 [x] Security scan clean [x]"
+
+[finishing-a-development-branch activates — obra/superpowers]
+AI: "Options: merge / PR / keep / discard?"
 ```

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.8.0";
+export const VERSION = "3.9.0";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
-      "version": "3.8.0",
+      "version": "3.9.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/continuous-improvement/commands/superpowers.md
+++ b/plugins/continuous-improvement/commands/superpowers.md
@@ -1,22 +1,95 @@
 ---
 name: superpowers
-description: "Activate mandatory agent workflows: brainstorming, TDD, code review, git worktrees, and structured development"
+description: "Law activator and dispatcher — route the task to the right Law-aligned specialist across continuous-improvement and four vendored upstream skill libraries (Obra superpowers, addy-agent-skills, ruflo-swarm, oh-my-claudecode)."
 ---
 
 # /superpowers
 
-Activate the Superpowers mandatory workflow framework. Skills trigger automatically based on context — this is not optional guidance.
+`/superpowers` is **the dispatcher**, not a peer skill. It does not do work itself; it routes each user task to the correct Law-aligned specialist so the right discipline fires automatically instead of the agent skipping a step.
+
+The 7 Laws define *what* discipline must be applied. `/superpowers` decides *which specialist* enforces it for this specific task, across five sources installed from this marketplace.
+
+## Routing surface (five sources)
+
+| Source | Where it lives | Examples of what it routes to |
+|---|---|---|
+| `continuous-improvement` (this plugin) | bundled — always present | `gateguard` (Law 1), `tdd-workflow` (Law 3+4), `verification-loop` (Law 4), `wild-risa-balance` (Law 2), `safety-guard` (Law 3), `proceed-with-the-recommendation` (all 7), `ralph` (Law 6), `workspace-surface-audit` (Law 1) |
+| `obra/superpowers` (Jesse Vincent) | vendored at `third-party/superpowers/`, pinned SHA `f2cbfbe` (v5.1.0) | `superpowers:brainstorming`, `:writing-plans`, `:executing-plans`, `:test-driven-development`, `:systematic-debugging`, `:requesting-code-review`, `:receiving-code-review`, `:verification-before-completion`, `:dispatching-parallel-agents`, `:using-git-worktrees`, `:finishing-a-development-branch`, `:subagent-driven-development`, `:writing-skills`, `:using-superpowers` |
+| `addyosmani/agent-skills` | vendored at `third-party/addy-agent-skills/`, pinned SHA `742dca5` (v1.0.0) | `spec-driven-development`, `source-driven-development`, `context-engineering`, `idea-refine`, `incremental-implementation`, `code-review-and-quality`, `code-simplification`, `security-and-hardening`, `debugging-and-error-recovery`, `performance-optimization`, `api-and-interface-design`, `frontend-ui-engineering`, `browser-testing-with-devtools`, `ci-cd-and-automation`, `deprecation-and-migration`, `documentation-and-adrs`, `git-workflow-and-versioning`, `planning-and-task-breakdown`, `shipping-and-launch` |
+| `ruflo-swarm` (ruvnet) | vendored at `third-party/ruflo-swarm/`, pinned SHA `addb5cd` (v0.2.0) | `swarm-init`, `monitor-stream`; `swarm_*` and `agent_*` MCP tools; `/swarm`, `/watch` |
+| `oh-my-claudecode` (Yeachan-Heo) | vendored at `third-party/oh-my-claudecode/`, pinned SHA `aacde3e` (v4.13.6) | 39 skills + 19 agents — `release`, `ultrawork`, `ultraqa`, `team`, `trace`, `visual-verdict`, `debug`, `deep-dive`, `deep-interview`, `autopilot`, `autoresearch`, plus a separate `ralph` (overlaps with our `/ralph` — see "Distinct variants" below) |
+
+PM coverage (product-management skills) lives **outside** this marketplace. If you need it, install [`phuryn/pm-skills`](https://github.com/phuryn/pm-skills) separately via Claude Code's host marketplace; the dispatcher names it as a routing target without pre-resolving the namespace. See [docs/THIRD_PARTY.md § Routing in /superpowers](../docs/THIRD_PARTY.md#routing-in-superpowers).
+
+## Distinct variants — never collapse them
+
+Two routing targets carry the same short name across sources. Treat them as distinct; do not silently substitute one for the other.
+
+| Short name | `obra/superpowers` (Obra) | `continuous-improvement` (CI fork) |
+|---|---|---|
+| `superpowers` (skill) | activator routing into Obra skills | `superpowers` skill in this repo: Law-aligned activator wrapping the dispatcher commitments below |
+| `ralph` | not present in Obra | bundled here; `oh-my-claudecode` ships its own `ralph` — pick deliberately, do not auto-merge |
+
+If both Obra `superpowers` and continuous-improvement are loaded, you can call either explicitly: `superpowers:test-driven-development` (Obra) or `tdd-workflow` (CI). Same Law (3+4), different implementation depth.
+
+## Dispatcher commitments (override looser global defaults when `/superpowers` is in scope)
+
+When this dispatcher is active for a task, these six rules apply over any looser convention:
+
+1. **Subagent-driven development is the default for non-trivial tasks.** Two-stage spec + quality review per [obra/superpowers § subagent-driven-development](https://github.com/obra/superpowers).
+2. **Parallel fan-out goes through `superpowers:dispatching-parallel-agents`** (or `/swarm`), not hand-rolled `Task` calls.
+3. **TDD runs RED → GREEN → REFACTOR.** Code written before its test is **deleted**, not retrofitted. Routes to `tdd-workflow` (CI) or `superpowers:test-driven-development` (Obra) — pick by depth, never both for the same task.
+4. **Branch isolation is `using-git-worktrees`** by default for any task that touches more than one file.
+5. **`finishing-a-development-branch` runs before any push.** No bypass via `--no-verify`, `--force`, or direct push to `main`.
+6. **Obra `superpowers` and `continuous-improvement:superpowers` stay distinct.** Both can be installed; neither shadows the other; the dispatcher names which one is firing.
+
+## Routing rules (which source wins)
+
+| User intent | Preferred routing target | Source |
+|---|---|---|
+| New feature, vague requirements | `superpowers:brainstorming` → `:writing-plans` | `obra/superpowers` |
+| Fix this bug | `superpowers:systematic-debugging` → `tdd-workflow` (RED first) → `verification-loop` | Obra → CI → CI |
+| Walk an agent's recommendation list | `proceed-with-the-recommendation` | CI |
+| Write tests for new code | `tdd-workflow` (CI default) or `superpowers:test-driven-development` (Obra, deeper) | CI / Obra |
+| Verify before reporting "done" | `verification-loop` | CI |
+| Refactor, multi-file | `superpowers:using-git-worktrees` → `:writing-plans` → `tdd-workflow` → `:finishing-a-development-branch` | Obra → Obra → CI → Obra |
+| Long autonomous PRD execution | `/ralph` (CI variant) | CI |
+| Parallel sub-agent fan-out | `superpowers:dispatching-parallel-agents` or `/swarm` | Obra / ruflo-swarm |
+| Spec-first, contract-first feature | `spec-driven-development` | addy-agent-skills |
+| Frontend / UI generation | `frontend-design` (external plugin) | external |
+| Diff walk + severity tagging | `code-review` (external plugin) or `superpowers:requesting-code-review` | external / Obra |
+| Library / framework docs lookup | `documentation-lookup` (Context7 MCP) | external |
+| Compliance / security gate | `security-and-hardening` (addy) → `security-review` (host built-in) | addy → host |
+| Release coordination across PRs | `/release-train` | CI |
+
+## Missing-companion detection
+
+If `/superpowers` is asked to route to a source that is not installed, it does not silently fall back to the inline placeholder. It must:
+
+1. **Name the missing source** explicitly (e.g. `obra/superpowers` not loaded).
+2. **Quote the exact install line** for it from the marketplace already added in setup, e.g. `/plugin install superpowers@continuous-improvement`.
+3. **State the inline-fallback equivalent** that will run if the user declines to install (and which Law that fallback enforces).
+4. **Stop and ask** before continuing. Do not silently downgrade.
+
+This is the same hard-halt discipline used by `proceed-with-the-recommendation` for `needs-approval` items.
 
 ## Subcommands
 
 ### `/superpowers status`
 
-Show which workflow stages are active:
+Show which routing sources are loaded, which workflow stages are active for the current task, and which sources are **missing**:
 
 ```
 === Superpowers Status ===
 
-Active Skills:
+Sources:
+  [x] continuous-improvement       (bundled)
+  [x] obra/superpowers              v5.1.0 (vendored)
+  [ ] addyosmani/agent-skills       MISSING — /plugin install agent-skills@continuous-improvement
+  [x] ruflo-swarm                   v0.2.0 (vendored)
+  [ ] oh-my-claudecode              MISSING — /plugin install oh-my-claudecode@continuous-improvement
+
+Active for current task:
   [x] brainstorming (trigger: new feature request)
   [ ] using-git-worktrees (waiting: design approval)
   [ ] writing-plans (waiting: worktree ready)
@@ -27,127 +100,81 @@ Active Skills:
 
 ### `/superpowers enable <skill>`
 
-Explicitly enable a skill for the current session:
+Explicitly enable a skill for the current session — useful when the dispatcher's intent detection guesses wrong:
 
 ```
 /superpowers enable test-driven-development
+/superpowers enable superpowers:writing-plans   # namespaced form for Obra
 ```
 
 ### `/superpowers workflow <type>`
 
 Activate a complete workflow preset:
 
-| Preset | Skills Activated |
-|--------|------------------|
-| `new-feature` | brainstorming → worktrees → plans → TDD → review → finish |
-| `bug-fix` | systematic-debugging → verification → TDD → review |
-| `refactor` | worktrees → plans → TDD → review → finish |
-| `review` | requesting-code-review → receiving-code-review |
+| Preset | Skills activated (in order) |
+|---|---|
+| `new-feature` | `superpowers:brainstorming` → `:using-git-worktrees` → `:writing-plans` → `tdd-workflow` → `verification-loop` → `:requesting-code-review` → `:finishing-a-development-branch` |
+| `bug-fix` | `superpowers:systematic-debugging` → `verification-loop` → `tdd-workflow` (regression test first) → `:requesting-code-review` |
+| `refactor` | `superpowers:using-git-worktrees` → `:writing-plans` → `tdd-workflow` → `:requesting-code-review` → `:finishing-a-development-branch` |
+| `review` | `superpowers:requesting-code-review` → `:receiving-code-review` |
+| `release` | `/release-train` → `verification-loop` → `superpowers:finishing-a-development-branch` |
 
 Example:
 ```
 /superpowers workflow new-feature
 ```
 
-## Mandatory Skills
+## Verification protocol (Law 4)
 
-### brainstorming
-**Triggers:** New feature requests, vague requirements
+Every routed skill must verify before reporting completion. The dispatcher refuses to advance to the next stage until the current one shows:
 
-1. Ask clarifying questions
-2. Explore 2-3 alternatives
-3. Present design in sections
-4. Wait for explicit approval
+1. Code runs without errors
+2. Output matches expected result
+3. Actual result checked — not assumed
+4. Build passes
+5. Change explainable in one sentence
 
-### using-git-worktrees
-**Triggers:** Design approved, feature branch needed
-
-Creates isolated workspace:
-```bash
-git worktree add -b feature-name ../feature-name
-```
-
-### writing-plans
-**Triggers:** Worktree ready, implementation starting
-
-Breaks work into bite-sized tasks (2-5 minutes each). Every task includes:
-- Exact file paths
-- Complete code
-- Verification steps
-
-### test-driven-development
-**Triggers:** Plan approved, coding begins
-
-```
-RED: Write failing test → Watch it fail
-GREEN: Write minimal code → Watch it pass
-REFACTOR: Improve while green → Commit
-```
-
-**Rule:** Code written before tests is deleted.
-
-### requesting-code-review
-**Triggers:** Task complete, before continuing
-
-Two-stage review:
-1. Spec compliance — Does it match the plan?
-2. Code quality — Clean, tested, maintainable?
-
-Severity levels: Critical (blocks), Warning (note), Info (log)
-
-### finishing-a-development-branch
-**Triggers:** All tasks complete
-
-Options presented:
-- Merge to main
-- Create PR
-- Keep branch
-- Discard (with confirmation)
-
-## Skill Activation Rules
-
-| User Request | Activates |
-|--------------|-----------|
-| "Create a feature" | brainstorming → writing-plans → executing-plans |
-| "Fix this bug" | systematic-debugging → verification → TDD |
-| "Review this code" | requesting-code-review |
-| "Refactor this" | using-git-worktrees → writing-plans → TDD |
-
-## Verification Protocol
-
-Every skill requires verification before reporting completion:
-
-1. **Code runs** without errors
-2. **Output matches** expected result
-3. **Actual result checked** — not assumed
-4. **Build passes**
-5. **Explained** in one sentence
+This is `verification-loop` from `continuous-improvement`. It runs after every workflow stage, not just at the end.
 
 ## Integration
 
-Superpowers integrates with:
-- **continuous-improvement** — reflection and learning after each stage
-- **ralph** — autonomous execution of planned stories
-- **workspace-surface-audit** — verify environment before starting
+`/superpowers` integrates with:
 
-## Example Session
+- **`/seven-laws`** — runs after each stage to capture the reflection block and update instincts (Laws 5 + 7)
+- **`/proceed-with-the-recommendation`** — orchestrates a list of recommendations end-to-end, using `/superpowers` per item
+- **`/workspace-surface-audit`** — runs at task start to confirm the right routing surface is actually present (Law 1 pre-flight)
+- **`/ralph`** — autonomous variant; takes a PRD and walks it story-by-story under the same routing table
+
+## Example session
 
 ```
 User: "Build a checkout flow"
 
-[brainstorming activates]
+[/superpowers status] →
+  Sources: continuous-improvement [x], obra/superpowers [x], others [ ]
+  Routing intent: new-feature
+
+[brainstorming activates — obra/superpowers]
 AI: "Clarifying questions: 1) Payment provider? 2) Guest checkout?"
 
 User: "Stripe, yes guest checkout"
 
-[writing-plans activates]
+[using-git-worktrees activates — obra/superpowers]
+AI: "Created worktree at ../checkout-feature"
+
+[writing-plans activates — obra/superpowers]
 AI: "Plan created with 6 tasks. Approve?"
 
 User: "Approved"
 
-[using-git-worktrees activates]
-AI: "Created worktree at ../checkout-feature"
+[tdd-workflow activates — continuous-improvement]
+AI: "Task 1 RED: write failing test for cart validation..."
+AI: "Task 1 GREEN: minimal handler. Verifying with `npm test cart.test.ts`..."
+AI: "Task 1 REFACTOR: extract validator, tests still green. Committing."
 
-[test-driven-development activates]
-AI: "Task 1: Write failing test for cart validation..."
+[verification-loop activates — continuous-improvement]
+AI: "Build [x] Types [x] Lint [x] Tests 42/42 [x] Security scan clean [x]"
+
+[finishing-a-development-branch activates — obra/superpowers]
+AI: "Options: merge / PR / keep / discard?"
 ```

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.8.0";
+export const VERSION = "3.9.0";
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -7,7 +7,9 @@ origin: community
 
 # GateGuard — Fact-Forcing Pre-Action Gate
 
-A PreToolUse hook that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+A skill that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+
+> **Implementation status (as of v3.9.0):** GateGuard ships as **model-side discipline only** — the agent loads this skill into context and refuses Edit/Write/destructive Bash until the facts below are presented. A runtime PreToolUse hook that physically blocks the tool call is on the roadmap, tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Until that ships, the gate's strength depends on the agent reading and applying this skill, not on a tripwire that the tool runtime can't bypass.
 
 ## When to Activate
 
@@ -124,18 +126,17 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 ## Quick Start
 
-### Option A: Use the continuous-improvement hook (zero install)
+### Today (v3.9.0): model-side skill
 
-The hook at `scripts/hooks/gateguard-fact-force.js` is included in this plugin. Enable it via hooks.json.
+The skill is registered when you install the plugin. The agent reads this file and applies the gates listed above before performing any qualifying tool call. No additional config needed — but no runtime tripwire either; the gate fires only when the agent chooses to honor it. If you observe the agent skipping the gate, name the Law back: *"You skipped Law 1 — research first."*
 
-### Option B: Full package with config
+### Roadmap: runtime PreToolUse hook
 
-```bash
-pip install gateguard-ai
-gateguard init
-```
+Tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Will physically block the first Edit/Write per session and every destructive Bash via a `hooks/gateguard.mjs` script wired into `hooks/hooks.json`. Acceptance criteria, RED-GREEN-REFACTOR plan, and out-of-scope items are all in the issue.
 
-This adds `.gateguard.yml` for per-project configuration (custom messages, ignore paths, gate toggles).
+### Roadmap: third-party `gateguard-ai` package
+
+The standalone `gateguard-ai` Python/CLI package referenced in earlier drafts of this skill is not currently part of this plugin and not a published package. It may ship later with `.gateguard.yml` per-project config; for now, treat it as design notes only.
 
 ## Anti-Patterns
 

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.8.0",
+  "version": "3.9.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
   "tools": [

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -7,7 +7,9 @@ origin: community
 
 # GateGuard — Fact-Forcing Pre-Action Gate
 
-A PreToolUse hook that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+A skill that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+
+> **Implementation status (as of v3.9.0):** GateGuard ships as **model-side discipline only** — the agent loads this skill into context and refuses Edit/Write/destructive Bash until the facts below are presented. A runtime PreToolUse hook that physically blocks the tool call is on the roadmap, tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Until that ships, the gate's strength depends on the agent reading and applying this skill, not on a tripwire that the tool runtime can't bypass.
 
 ## When to Activate
 
@@ -124,18 +126,17 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 ## Quick Start
 
-### Option A: Use the continuous-improvement hook (zero install)
+### Today (v3.9.0): model-side skill
 
-The hook at `scripts/hooks/gateguard-fact-force.js` is included in this plugin. Enable it via hooks.json.
+The skill is registered when you install the plugin. The agent reads this file and applies the gates listed above before performing any qualifying tool call. No additional config needed — but no runtime tripwire either; the gate fires only when the agent chooses to honor it. If you observe the agent skipping the gate, name the Law back: *"You skipped Law 1 — research first."*
 
-### Option B: Full package with config
+### Roadmap: runtime PreToolUse hook
 
-```bash
-pip install gateguard-ai
-gateguard init
-```
+Tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Will physically block the first Edit/Write per session and every destructive Bash via a `hooks/gateguard.mjs` script wired into `hooks/hooks.json`. Acceptance criteria, RED-GREEN-REFACTOR plan, and out-of-scope items are all in the issue.
 
-This adds `.gateguard.yml` for per-project configuration (custom messages, ignore paths, gate toggles).
+### Roadmap: third-party `gateguard-ai` package
+
+The standalone `gateguard-ai` Python/CLI package referenced in earlier drafts of this skill is not currently part of this plugin and not a published package. It may ship later with `.gateguard.yml` per-project config; for now, treat it as design notes only.
 
 ## Anti-Patterns
 

--- a/src/bin/install.mts
+++ b/src/bin/install.mts
@@ -69,11 +69,18 @@ const SKILL_NAME = "continuous-improvement";
 const REPO_ROOT = join(__dirname, "..");
 const COMMAND_FILES = [
   "continuous-improvement.md",
+  "dashboard.md",
+  "discipline.md",
+  "harvest.md",
+  "learn-eval.md",
   "planning-with-files.md",
   "proceed-with-the-recommendation.md",
-  "discipline.md",
-  "dashboard.md",
-  "learn-eval.md",
+  "ralph.md",
+  "release-train.md",
+  "seven-laws.md",
+  "superpowers.md",
+  "swarm.md",
+  "workspace-surface-audit.md",
 ] as const;
 const HOOK_TYPES: readonly HookType[] = ["PreToolUse", "PostToolUse"];
 const SESSION_HOOK_TYPES: readonly HookType[] = ["SessionStart", "SessionEnd"];

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -1,5 +1,5 @@
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.8.0";
+export const VERSION = "3.9.0";
 
 export const PLUGIN_MODES = ["beginner", "expert"] as const;
 


### PR DESCRIPTION
## Summary

Closes the seven user-journey gaps surfaced by the install-path audit and rewrites `/superpowers` to reflect the unified five-source dispatcher train.

- **Version sync** — bumps VERSION 3.8.0 → 3.9.0 in `src/lib/plugin-metadata.mts` so marketplace.json, plugin.json, and plugins/{beginner,expert}.json all match package.json. Source-of-truth is one constant; build propagates.
- **Installer parity** — `COMMAND_FILES` in `src/bin/install.mts` expanded from 6 to all 13 commands. npx and marketplace installs now expose the same slash-command surface; `/seven-laws` (canonical), `/superpowers`, `/workspace-surface-audit`, `/ralph`, `/harvest`, `/release-train`, `/swarm` were silently stripped before.
- **QUICKSTART rewrite** — leads with the Beginner marketplace path that mirrors README; demotes npx to a clearly-labeled Expert section with a 'do not run both' warning. Removes the duplicated-state hazard.
- **README updates** — beginner block names the optional `/plugin install superpowers@continuous-improvement` companion; slash-command table expanded to 13 rows; `/seven-laws` named canonical and `/continuous-improvement` explicitly an alias; new gateguard-based smoke test that proves hooks are live.
- **/superpowers reframed as a dispatcher** — five-source routing surface (CI + obra/superpowers + addy-agent-skills + ruflo-swarm + oh-my-claudecode), explicit distinction between Obra and CI variants of `superpowers` and `ralph`, missing-companion detection that names the install line instead of silently downgrading, dispatcher commitments matching the SessionStart hook (subagent-driven dev, parallel fan-out via dispatching-parallel-agents, RED-GREEN-REFACTOR with pre-test code deleted, worktrees, finishing-a-development-branch before push), and a routing-rules table that names the source per intent.

## Commits

```
47bc14a docs(install): collapse install-path narrative + add gateguard smoke test + canonicalize /seven-laws
18f6380 feat(superpowers): rewrite /superpowers as the cross-source dispatcher
fa15bc4 feat(installer): expand COMMAND_FILES to mirror the full 13-command marketplace bundle
e7dc257 chore(release): bump VERSION to 3.9.0 across marketplace + plugin manifests
```

One concern per commit, layered: release manifest → installer source → dispatcher copy → user-facing docs.

## Test plan

- [x] `npm run build` — clean (regenerates plugins/, .claude-plugin/marketplace.json, plugin bundles, install.mjs from .mts)
- [x] `npm run verify:all` — all 6 lints + typecheck green
  - skill-mirror 14/14, skill-tiers 14/14, skill-law-tag 14/14, docs-substrings 144/144, everything-mirror 30/30, routing-targets 37/37
- [x] `npm run verify:generated` — no drift between source and committed bundle outputs
- [ ] Smoke test: `/plugin marketplace add naimkatiman/continuous-improvement` then `/plugin install continuous-improvement@continuous-improvement`, restart, run `/discipline` (expect 7 Laws card), then ask Claude to write a throwaway file with no research (expect gateguard pause)
- [ ] Smoke test: `npx continuous-improvement install` should now copy 13 commands to `~/.claude/commands/` (was 6)

## Notes

- 14 files total, within the 15-file cap.
- `verify:generated` is the gate that catches anyone editing `.mjs` directly without rebuilding from `.mts`. All commits include both source and regenerated outputs together to keep that lint green per-commit, not just at HEAD.
- No third-party/ vendored snapshots touched. No third-party SHAs change.