### PR TITLE
feat(insights-residue): hotfix-pr mode + synthetic-checks rung + claude-md template

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ Authored end-to-end with `/superpowers` and `/proceed-with-the-recommendation`: 
 - [QUICKSTART.md](QUICKSTART.md) — 2-minute setup
 - [SKILL.md](SKILL.md) — full 7 Laws spec
 - [examples/](examples/) — bug fix, feature build, refactor walkthroughs
+- [templates/insights-claude-md.md](templates/insights-claude-md.md) — paste-in CLAUDE.md blocks for verification discipline, environment notes, think-before-acting, and git/deploy workflow (sourced from the 28-day usage report)
 - [CONTRIBUTING.md](CONTRIBUTING.md) — architecture, repo internals
 - [SECURITY.md](SECURITY.md)
 

--- a/docs/plans/2026-05-09-insights-report-residue.md
+++ b/docs/plans/2026-05-09-insights-report-residue.md
@@ -1,0 +1,100 @@
+# 2026-05-09 — Insights-report residue (3 horizon gaps)
+
+Plan for the small follow-up stack that closes the three horizon items from the 28-day usage report (`C:\Users\thinkpad\.claude\usage-data\report.html`) which the v3.7 → v3.9 release train did NOT cover. The first release (PRs #83 + #84) landed `deploy-receipt` and the P-MAG third surface; the second release (PRs #85 + #86 + #87 + #88 + #89) landed the environment grain, stacked-PR plan precondition, per-project verify ladder, and friction harvester; the unified-dispatcher train (PRs #91 → #95 + #101) wrapped report-derived autonomous workflows as `/release-train` and `/swarm`.
+
+This plan completes the residue: the auto-rollback / hotfix-PR generation layer the report asked for, the synthetic-checks rung that turns receipts into baseline diffs, and the paste-in CLAUDE.md template the report literally provided four blocks for.
+
+Per global CLAUDE.md: feature spans 3 commits + plan doc; mandatory before any implementation edit; cited in every commit it produces.
+
+## Goal
+
+Close the three remaining horizon items from the report as a single small stack on `feat/insights-report-residue`:
+
+1. **Self-Healing Production Verification Loop (auto-rollback / hotfix-PR portion).** `deploy-receipt` today verifies the deploy seam and surfaces `INCOMPLETE` to the operator. The report asked for the next step: when INCOMPLETE persists past a known recovery window, open a `hotfix/<sha>-<symptom>` branch with a failing repro test and a documented rollback recommendation. The skill describes when to do this and what shape; it does NOT execute rollbacks itself (operator-gated).
+
+2. **Synthetic-checks against staging baseline diff.** The report asked for synthetic checks that run against production after deploy and diff against a staging baseline. Today there is no convention for where these live or how they plug into the verify ladder. PR adds `synthetic-checks/` directory convention, a sample, and a new `synthetic_checks` rung in `verify-ladder.example.json` + `verification-loop` skill text.
+
+3. **Four CLAUDE.md paste-in blocks.** The report listed four CLAUDE.md additions ("Verification Discipline", "Environment Notes", "Think Before Acting", "Git & Deploy Workflow") with copy-buttons. The discipline behavior was encoded as skills (gateguard, workspace-surface-audit, verification-loop, deploy-receipt) — but project-local CLAUDE.md text is still missing. Add `templates/insights-claude-md.md` so any project can paste them in without re-reading the report.
+
+Each commit is single-concern, mirrored to its plugin copy in the same commit (skill-mirror invariant from PR #83), and stays under the file budget.
+
+## Out of scope (logged here so we don't drift)
+
+- **Webhook-driven long-lived verification agent.** Receipt + ladder run in-session at merge time. A separate orchestrator listening for Railway/Cloudflare webhooks is a different surface and a different deployment shape (Cloudflare Worker, GitHub Actions cron, etc.) — separate plan.
+- **Auto-rollback execution.** The skill describes when an operator should rollback and pins the documented commands; it never runs `railway rollback` or `wrangler rollback` on its own. That is operator-gated and the boundary is intentional.
+- **Hook-form deploy preflight in `.claude/settings.json`.** The report originally asked for a hook; we already shipped this as a skill (`deploy-receipt`) for parity. Hook form would duplicate the surface.
+- **Removing the existing skill-form deploy-receipt.** The new mode is additive. Default behavior (`--on-incomplete=report-only`) is preserved; `--on-incomplete=open-hotfix-pr` is opt-in.
+
+## Per-PR scope
+
+### Commit 1 — `feat(deploy-receipt): --on-incomplete=open-hotfix-pr mode`
+
+**Files touched (2):**
+- `skills/deploy-receipt.md` — new "On-Incomplete Modes" section after "Output Shape", documenting two modes:
+  - `report-only` (default, current behavior — surface INCOMPLETE as operator-action item)
+  - `open-hotfix-pr` (new — when INCOMPLETE persists past recovery window, write failing repro test + open `hotfix/<sha>-<symptom>` branch + post the documented rollback command as a PR comment, but never execute rollback or merge)
+  Plus three new anti-patterns specific to the new mode (no auto-merge of hotfix PR; no force-push; no skipping branch protection).
+- `plugins/continuous-improvement/skills/deploy-receipt/SKILL.md` — byte-identical mirror.
+
+**WILL build:** the contract for the new mode — when it activates, what the hotfix branch contains, what the PR description must cite, and the explicit refusals.
+
+**Will NOT build:** automation that opens the PR. The skill authors the contract; the agent (or future companion script) executes it. No new `bin/` script in this PR.
+
+**Verification:** `npm run verify:all` (skill-mirror confirms byte-identical, docs-substrings unchanged unless lockdown is added later, typecheck clean).
+
+**Lines estimate:** ~50 added to standalone + same to plugin = ~100 LOC across 2 files.
+
+### Commit 2 — `feat(verification-loop): synthetic-checks/ rung + staging-baseline convention`
+
+**Files touched (5):**
+- `synthetic-checks/README.md` — new directory convention. Documents:
+  - one file per check (`<name>.synthetic.{ts,mjs,sh}`)
+  - input contract (env vars: `BASE_URL`, `BASELINE_URL`, `EXPECTED_SHA`)
+  - output contract (exit code 0 = match baseline, non-zero = drift; stdout is human-readable diff)
+  - the new ladder rung calls each file with the production base URL and diffs against the staging baseline URL
+- `synthetic-checks/example-version-endpoint.synthetic.sh` — minimal sample showing the contract (curl `/version` against `$BASE_URL` and `$BASELINE_URL`, diff the two payloads, exit 1 on diff).
+- `templates/verify-ladder.example.json` — add `synthetic_checks` field to each starter shape; add a new `_synthetic_checks_doc` block explaining how the rung resolves files in `synthetic-checks/`.
+- `skills/verification-loop.md` — extend Phase 8 to include the synthetic-checks rung that runs after deploy-receipt is COMPLETE; document inputs, outputs, and the "drift surfaces as INCOMPLETE" rule.
+- `plugins/continuous-improvement/skills/verification-loop/SKILL.md` — byte-identical mirror.
+
+**WILL build:** the directory convention, one runnable sample, the ladder field, and the skill text describing when the rung runs and how a drift result is surfaced.
+
+**Will NOT build:** a runner script that orchestrates the synthetic checks. The skill authors the contract; the agent invokes the files via the resolved ladder. No new `bin/` script in this PR.
+
+**Verification:** `npm run verify:all` (skill-mirror, docs-substrings, typecheck — all unchanged), plus a manual `bash synthetic-checks/example-version-endpoint.synthetic.sh` smoke run with two URLs that match (exit 0) and two URLs that disagree (exit 1).
+
+**Lines estimate:** ~40 (README) + ~20 (sample) + ~10 (ladder) + ~25 (skill) × 2 mirrors = ~120 LOC across 5 files.
+
+### Commit 3 — `docs(templates): insights-claude-md paste-in blocks`
+
+**Files touched (2):**
+- `templates/insights-claude-md.md` — new file. Contains the four blocks from the report verbatim, each in its own `## Section` with a short header explaining when to paste it. Headers paraphrase the report; block content stays as written so anyone re-reading the report can match them line-for-line.
+- `README.md` — one-line pointer in the existing templates/conventions section so the file is discoverable.
+
+**WILL build:** the four blocks (Verification Discipline, Environment Notes, Think Before Acting, Git & Deploy Workflow) with one-line preamble per block, plus the README pointer.
+
+**Will NOT build:** automation that pastes them into a project's CLAUDE.md. This is opt-in copy.
+
+**Verification:** `npm run verify:all` (docs-substrings: README pointer phrasing not locked, but the four heading literals from this template will be added as deferred lockdowns in a follow-up PR if drift becomes a risk).
+
+**Lines estimate:** ~80 LOC for the template + 1 line in README = ~81 LOC across 2 files.
+
+## Total scope
+
+- 3 commits, 9 files of substance (2 + 5 + 2)
+- Estimated ~300 LOC added, 0 removed
+- All within Surgical Changes guardrails (≤15 files per commit, single concern each)
+- Plan doc cited in every commit message
+
+## Verification at branch close
+
+Before opening the PR:
+1. `npm run build` — clean tsc + manifest regen
+2. `npm run verify:all` — skill-mirror, docs-substrings, everything-mirror, routing-targets, typecheck
+3. `npm test` — full suite (build + node --test test/*.test.mjs)
+4. `git diff --stat origin/main...HEAD` — confirm file count is bounded (target: ≤9 files)
+5. Manual: re-read each new SKILL.md edit for Law-4 framing parity with the existing deploy-receipt and verification-loop text
+
+## PR shape
+
+Single PR off `feat/insights-report-residue` → `main`. Title: `feat(insights-residue): hotfix-pr mode + synthetic-checks rung + claude-md template`. Body cites this plan doc, names the three horizon items closed, and re-states the four out-of-scope items so a reviewer can hold the line.

--- a/plugins/continuous-improvement/skills/deploy-receipt/SKILL.md
+++ b/plugins/continuous-improvement/skills/deploy-receipt/SKILL.md
@@ -101,6 +101,50 @@ After running verification:
 
 A `COMPLETE` receipt is the only state that lets the merge be reported as `done`. `INCOMPLETE` receipts surface a single named operator-action item (e.g. "Railway last deploy is older than the merge — re-trigger from dashboard or `railway up`").
 
+## On-Incomplete Modes
+
+The default behavior on `INCOMPLETE` is **report-only** — the receipt block names the gap, the operator decides recovery. A second mode is available for projects that want the skill to also stage a recovery branch and a failing repro test, without ever executing rollback or merge.
+
+### Mode A — `report-only` (default)
+
+The current behavior. Print the receipt block, surface the named operator-action item, hand off. No branch creation, no PR opened. Use this mode when the operator is at the keyboard and will react to the receipt directly. No flag required.
+
+### Mode B — `open-hotfix-pr` (opt-in)
+
+Use this mode when the receipt is `INCOMPLETE` AND a documented recovery window has elapsed without the deploy self-correcting (default 10 minutes from merge; tunable per project via `verify-ladder.json` `deploy_receipt_recovery_window_seconds`). The skill then stages a recovery branch *for the operator to review*, but never merges or rolls back on its own.
+
+Activate with the explicit invocation:
+
+```
+deploy-receipt --on-incomplete=open-hotfix-pr
+```
+
+When triggered, this mode performs four steps in order, halting on the first failure:
+
+1. **Branch.** `git checkout -b hotfix/<merge-sha-short>-<symptom-slug> origin/<deploy-branch>`. The symptom slug is derived from the named gap on the receipt — `sha-mismatch`, `health-non-200`, `version-endpoint-stale`, or `no-provider-source`. If the slug cannot be derived, halt and revert to report-only.
+2. **Failing repro test.** Write a single test file at `tests/regressions/deploy-<merge-sha-short>.test.<ext>` that asserts the gap (e.g. `expect(deployedSha).toEqual(mergeSha)` or `expect(healthResponse.status).toBe(200)`). The test MUST currently fail when run against production. The skill writes the assertion against the receipt's recorded values, not against speculation. If the test cannot be made to fail deterministically, halt and revert to report-only.
+3. **Open PR.** `gh pr create --base <deploy-branch> --head hotfix/... --draft` with body that cites the receipt block verbatim, the merge SHA, the deployed SHA, the named gap, and the documented rollback command for the detected provider (a one-line shell snippet from the table below). Draft state is mandatory — never open as ready-for-review without operator approval.
+4. **Hand off.** Print a single-line operator-action item naming the new branch, the PR URL, and the documented rollback command. Stop. Do not modify production. Do not merge the PR. Do not run the rollback.
+
+### Documented rollback commands (cited in the PR body, never executed)
+
+| Provider | Documented rollback command |
+|---|---|
+| Railway | `railway redeploy --service <service-id> --commit <previous-good-sha>` |
+| Cloudflare Workers | `wrangler rollback --message "deploy-receipt: <merge-sha-short> failed health/SHA gate"` |
+| Vercel | `vercel rollback <previous-good-deployment-url>` |
+| Netlify | `netlify rollback` (interactive — operator picks the prior deploy) |
+| Fly.io | `fly releases rollback <previous-good-version>` |
+
+The rollback command is **printed**, not run. The skill's job is to give the operator a complete recovery packet (branch + failing test + cited command) without taking the irreversible step itself.
+
+### When NOT to use Mode B
+
+- The deploy is mid-rolling-restart or mid-canary — the receipt is INCOMPLETE because the deploy is still in progress, not because it failed. Wait for the recovery window first.
+- Branch protection on the deploy branch denies hotfix branches by name pattern — the PR will fail to open and the skill should fall back to report-only with a named operator action ("hotfix branch denied by protection — recovery requires direct console access").
+- The previous-good SHA cannot be determined from `git log origin/<deploy-branch>` alone — the rollback command in the PR body would be a guess. Fall back to report-only and name the gap as "previous-good SHA unverifiable — operator must select".
+- The operator has already started a manual recovery (a fresh deploy is running, the dashboard shows a rollback in progress). Detect via Route A or Route B and skip Mode B for this receipt cycle.
+
 ## Anti-Patterns
 
 - **"Eventually consistent" excuse.** Reporting done with `Deployed SHA: not retrieved` and a comment like "deploy will pick up shortly" is exactly the failure mode this skill prevents. There is no eventually — there is COMPLETE or INCOMPLETE.
@@ -108,6 +152,9 @@ A `COMPLETE` receipt is the only state that lets the merge be reported as `done`
 - **Skipping for "small changes."** A docs-only commit still needs a receipt if the deploy branch auto-deploys — small changes have caused stale-build incidents on every provider in the table above.
 - **Recommending the CLI install mid-receipt.** If Route A is unavailable, fall through to B then C. Adding tooling is a separate decision the operator makes outside the receipt loop.
 - **Treating absence of evidence as evidence of success.** If none of the three routes produce a SHA, the receipt is `INCOMPLETE — no provider source available`, not `COMPLETE (assumed)`.
+- **Auto-merging the hotfix PR.** Mode B opens the PR as draft and stops. Auto-merge, `--admin` overrides, and `gh pr merge` calls are refused inside this skill. The hotfix is the operator's decision; the skill stages it but never lands it.
+- **Force-pushing or rewriting the hotfix branch.** Mode B branches off `origin/<deploy-branch>` once and pushes once. If the failing test needs changes, the skill writes a new commit on the branch — never `--force` and never `git rebase --interactive`.
+- **Executing the rollback command.** The rollback command is cited in the PR body for operator review. Mode B never runs `railway redeploy`, `wrangler rollback`, `vercel rollback`, etc. on its own. If the operator wants execution, they run it themselves or they wire a separate runner; that is a different skill.
 
 ## Pairs With
 

--- a/plugins/continuous-improvement/skills/verification-loop/SKILL.md
+++ b/plugins/continuous-improvement/skills/verification-loop/SKILL.md
@@ -147,6 +147,36 @@ For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or wh
 
 INCOMPLETE receipts move to "Immediate operator action" in the close, never to "ready". Library-only / package-published repos skip this phase entirely (no deploy seam exists).
 
+### Phase 9: Synthetic Checks (production-vs-baseline diff)
+
+Phase 8 confirms the deploy seam. Phase 9 confirms the deployed surface matches the staging baseline on the dimensions that matter — endpoint payload shape, header presence, data freshness, routing correctness. A deploy can land with a matching SHA and a 200 healthcheck and still serve broken responses (stale data sources, dropped headers, regressed payloads). Phase 9 is the gate that catches that.
+
+**When this rung runs:**
+
+- ONLY after Phase 8 reports `Receipt status: COMPLETE`. An INCOMPLETE receipt blocks Phase 9 — fix the receipt gap first, then re-run.
+- ONLY when the resolved ladder declares `synthetic_checks` as a non-null directory path (default: `synthetic-checks/`). A `null` field skips the rung silently. A missing field falls through to the directory sniff: if `synthetic-checks/` exists at the repo root with at least one `*.synthetic.*` file, the rung activates; otherwise it is recorded as "skipped — no synthetic-checks directory found".
+
+**What the runner does:**
+
+1. List every `*.synthetic.{sh,mjs,ts,py}` file in the resolved directory in lexical order.
+2. For each file, set the input env vars: `BASE_URL` (production base from project config), `BASELINE_URL` (staging baseline from project config), `EXPECTED_SHA` (the merge SHA Phase 8 reported COMPLETE), `DEPLOY_BRANCH` (the deploy branch name), `RECEIPT_TIMESTAMP` (ISO-8601 of the receipt).
+3. Invoke the file via the right interpreter (`bash` for `.sh`, `node` for `.mjs`, `tsx` for `.ts`, `python` for `.py`). Files with unrecognized extensions are skipped with a warning.
+4. Capture stdout + stderr + exit code per file. On exit 0, the check passed. On any non-zero exit, the check failed and stdout is the operator-facing diff.
+5. Aggregate: if every file exited 0, Phase 9 is `PASS`. If any file exited non-zero, Phase 9 is `FAIL — synthetic drift on <filenames>` and the captured diffs go into the verification report verbatim (no agent re-summarization).
+
+**Surfacing rule:**
+
+A failed synthetic check surfaces as `INCOMPLETE — synthetic drift` at the same severity as a failed deploy receipt. The merge moves to "Immediate operator action" with the named drift and the diff payload. Do NOT downgrade synthetic drift to "warning" — the rung exists because the report flagged exactly this gap (deploys that look healthy but serve broken responses).
+
+**Anti-patterns specific to this rung:**
+
+- **Smoke checks masquerading as synthetic checks.** A check that only verifies "endpoint returns 200" passes against a stale deploy. Synthetic checks MUST diff production against a baseline.
+- **Hardcoded baseline URLs in the check.** Baseline lives in env (`BASELINE_URL`), not in the file. Hardcoding it breaks the convention and makes per-environment use impossible.
+- **Re-summarizing the diff.** The captured stdout from a failed check is the operator-facing artifact. The agent does not re-write or shorten it.
+- **Treating an absent directory as PASS.** No synthetic-checks directory means the rung is `skipped`, not `PASS`. The operator sees the absence in the resolved ladder.
+
+See `synthetic-checks/README.md` for the file convention, the input/output contract, and a runnable sample (`example-version-endpoint.synthetic.sh`).
+
 ## Output Format
 
 After running all phases, produce a verification report:
@@ -163,6 +193,8 @@ Security:     [PASS/FAIL] (X issues)
 Diff:         [X files changed]
 Goal landed:  [YES/NO] — <one-line evidence or gap>
 All promised: [YES/NO] — <X of Y steps Done; list any Skipped>
+Deploy:       [COMPLETE/INCOMPLETE/skipped] — <SHA + health summary>
+Synthetic:    [PASS/FAIL/skipped] — <X of Y checks; failed: <filenames>>
 
 Overall:   [READY/NOT READY] for PR
 

--- a/skills/deploy-receipt.md
+++ b/skills/deploy-receipt.md
@@ -101,6 +101,50 @@ After running verification:
 
 A `COMPLETE` receipt is the only state that lets the merge be reported as `done`. `INCOMPLETE` receipts surface a single named operator-action item (e.g. "Railway last deploy is older than the merge — re-trigger from dashboard or `railway up`").
 
+## On-Incomplete Modes
+
+The default behavior on `INCOMPLETE` is **report-only** — the receipt block names the gap, the operator decides recovery. A second mode is available for projects that want the skill to also stage a recovery branch and a failing repro test, without ever executing rollback or merge.
+
+### Mode A — `report-only` (default)
+
+The current behavior. Print the receipt block, surface the named operator-action item, hand off. No branch creation, no PR opened. Use this mode when the operator is at the keyboard and will react to the receipt directly. No flag required.
+
+### Mode B — `open-hotfix-pr` (opt-in)
+
+Use this mode when the receipt is `INCOMPLETE` AND a documented recovery window has elapsed without the deploy self-correcting (default 10 minutes from merge; tunable per project via `verify-ladder.json` `deploy_receipt_recovery_window_seconds`). The skill then stages a recovery branch *for the operator to review*, but never merges or rolls back on its own.
+
+Activate with the explicit invocation:
+
+```
+deploy-receipt --on-incomplete=open-hotfix-pr
+```
+
+When triggered, this mode performs four steps in order, halting on the first failure:
+
+1. **Branch.** `git checkout -b hotfix/<merge-sha-short>-<symptom-slug> origin/<deploy-branch>`. The symptom slug is derived from the named gap on the receipt — `sha-mismatch`, `health-non-200`, `version-endpoint-stale`, or `no-provider-source`. If the slug cannot be derived, halt and revert to report-only.
+2. **Failing repro test.** Write a single test file at `tests/regressions/deploy-<merge-sha-short>.test.<ext>` that asserts the gap (e.g. `expect(deployedSha).toEqual(mergeSha)` or `expect(healthResponse.status).toBe(200)`). The test MUST currently fail when run against production. The skill writes the assertion against the receipt's recorded values, not against speculation. If the test cannot be made to fail deterministically, halt and revert to report-only.
+3. **Open PR.** `gh pr create --base <deploy-branch> --head hotfix/... --draft` with body that cites the receipt block verbatim, the merge SHA, the deployed SHA, the named gap, and the documented rollback command for the detected provider (a one-line shell snippet from the table below). Draft state is mandatory — never open as ready-for-review without operator approval.
+4. **Hand off.** Print a single-line operator-action item naming the new branch, the PR URL, and the documented rollback command. Stop. Do not modify production. Do not merge the PR. Do not run the rollback.
+
+### Documented rollback commands (cited in the PR body, never executed)
+
+| Provider | Documented rollback command |
+|---|---|
+| Railway | `railway redeploy --service <service-id> --commit <previous-good-sha>` |
+| Cloudflare Workers | `wrangler rollback --message "deploy-receipt: <merge-sha-short> failed health/SHA gate"` |
+| Vercel | `vercel rollback <previous-good-deployment-url>` |
+| Netlify | `netlify rollback` (interactive — operator picks the prior deploy) |
+| Fly.io | `fly releases rollback <previous-good-version>` |
+
+The rollback command is **printed**, not run. The skill's job is to give the operator a complete recovery packet (branch + failing test + cited command) without taking the irreversible step itself.
+
+### When NOT to use Mode B
+
+- The deploy is mid-rolling-restart or mid-canary — the receipt is INCOMPLETE because the deploy is still in progress, not because it failed. Wait for the recovery window first.
+- Branch protection on the deploy branch denies hotfix branches by name pattern — the PR will fail to open and the skill should fall back to report-only with a named operator action ("hotfix branch denied by protection — recovery requires direct console access").
+- The previous-good SHA cannot be determined from `git log origin/<deploy-branch>` alone — the rollback command in the PR body would be a guess. Fall back to report-only and name the gap as "previous-good SHA unverifiable — operator must select".
+- The operator has already started a manual recovery (a fresh deploy is running, the dashboard shows a rollback in progress). Detect via Route A or Route B and skip Mode B for this receipt cycle.
+
 ## Anti-Patterns
 
 - **"Eventually consistent" excuse.** Reporting done with `Deployed SHA: not retrieved` and a comment like "deploy will pick up shortly" is exactly the failure mode this skill prevents. There is no eventually — there is COMPLETE or INCOMPLETE.
@@ -108,6 +152,9 @@ A `COMPLETE` receipt is the only state that lets the merge be reported as `done`
 - **Skipping for "small changes."** A docs-only commit still needs a receipt if the deploy branch auto-deploys — small changes have caused stale-build incidents on every provider in the table above.
 - **Recommending the CLI install mid-receipt.** If Route A is unavailable, fall through to B then C. Adding tooling is a separate decision the operator makes outside the receipt loop.
 - **Treating absence of evidence as evidence of success.** If none of the three routes produce a SHA, the receipt is `INCOMPLETE — no provider source available`, not `COMPLETE (assumed)`.
+- **Auto-merging the hotfix PR.** Mode B opens the PR as draft and stops. Auto-merge, `--admin` overrides, and `gh pr merge` calls are refused inside this skill. The hotfix is the operator's decision; the skill stages it but never lands it.
+- **Force-pushing or rewriting the hotfix branch.** Mode B branches off `origin/<deploy-branch>` once and pushes once. If the failing test needs changes, the skill writes a new commit on the branch — never `--force` and never `git rebase --interactive`.
+- **Executing the rollback command.** The rollback command is cited in the PR body for operator review. Mode B never runs `railway redeploy`, `wrangler rollback`, `vercel rollback`, etc. on its own. If the operator wants execution, they run it themselves or they wire a separate runner; that is a different skill.
 
 ## Pairs With
 

--- a/skills/verification-loop.md
+++ b/skills/verification-loop.md
@@ -147,6 +147,36 @@ For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or wh
 
 INCOMPLETE receipts move to "Immediate operator action" in the close, never to "ready". Library-only / package-published repos skip this phase entirely (no deploy seam exists).
 
+### Phase 9: Synthetic Checks (production-vs-baseline diff)
+
+Phase 8 confirms the deploy seam. Phase 9 confirms the deployed surface matches the staging baseline on the dimensions that matter — endpoint payload shape, header presence, data freshness, routing correctness. A deploy can land with a matching SHA and a 200 healthcheck and still serve broken responses (stale data sources, dropped headers, regressed payloads). Phase 9 is the gate that catches that.
+
+**When this rung runs:**
+
+- ONLY after Phase 8 reports `Receipt status: COMPLETE`. An INCOMPLETE receipt blocks Phase 9 — fix the receipt gap first, then re-run.
+- ONLY when the resolved ladder declares `synthetic_checks` as a non-null directory path (default: `synthetic-checks/`). A `null` field skips the rung silently. A missing field falls through to the directory sniff: if `synthetic-checks/` exists at the repo root with at least one `*.synthetic.*` file, the rung activates; otherwise it is recorded as "skipped — no synthetic-checks directory found".
+
+**What the runner does:**
+
+1. List every `*.synthetic.{sh,mjs,ts,py}` file in the resolved directory in lexical order.
+2. For each file, set the input env vars: `BASE_URL` (production base from project config), `BASELINE_URL` (staging baseline from project config), `EXPECTED_SHA` (the merge SHA Phase 8 reported COMPLETE), `DEPLOY_BRANCH` (the deploy branch name), `RECEIPT_TIMESTAMP` (ISO-8601 of the receipt).
+3. Invoke the file via the right interpreter (`bash` for `.sh`, `node` for `.mjs`, `tsx` for `.ts`, `python` for `.py`). Files with unrecognized extensions are skipped with a warning.
+4. Capture stdout + stderr + exit code per file. On exit 0, the check passed. On any non-zero exit, the check failed and stdout is the operator-facing diff.
+5. Aggregate: if every file exited 0, Phase 9 is `PASS`. If any file exited non-zero, Phase 9 is `FAIL — synthetic drift on <filenames>` and the captured diffs go into the verification report verbatim (no agent re-summarization).
+
+**Surfacing rule:**
+
+A failed synthetic check surfaces as `INCOMPLETE — synthetic drift` at the same severity as a failed deploy receipt. The merge moves to "Immediate operator action" with the named drift and the diff payload. Do NOT downgrade synthetic drift to "warning" — the rung exists because the report flagged exactly this gap (deploys that look healthy but serve broken responses).
+
+**Anti-patterns specific to this rung:**
+
+- **Smoke checks masquerading as synthetic checks.** A check that only verifies "endpoint returns 200" passes against a stale deploy. Synthetic checks MUST diff production against a baseline.
+- **Hardcoded baseline URLs in the check.** Baseline lives in env (`BASELINE_URL`), not in the file. Hardcoding it breaks the convention and makes per-environment use impossible.
+- **Re-summarizing the diff.** The captured stdout from a failed check is the operator-facing artifact. The agent does not re-write or shorten it.
+- **Treating an absent directory as PASS.** No synthetic-checks directory means the rung is `skipped`, not `PASS`. The operator sees the absence in the resolved ladder.
+
+See `synthetic-checks/README.md` for the file convention, the input/output contract, and a runnable sample (`example-version-endpoint.synthetic.sh`).
+
 ## Output Format
 
 After running all phases, produce a verification report:
@@ -163,6 +193,8 @@ Security:     [PASS/FAIL] (X issues)
 Diff:         [X files changed]
 Goal landed:  [YES/NO] — <one-line evidence or gap>
 All promised: [YES/NO] — <X of Y steps Done; list any Skipped>
+Deploy:       [COMPLETE/INCOMPLETE/skipped] — <SHA + health summary>
+Synthetic:    [PASS/FAIL/skipped] — <X of Y checks; failed: <filenames>>
 
 Overall:   [READY/NOT READY] for PR
 

--- a/synthetic-checks/README.md
+++ b/synthetic-checks/README.md
@@ -1,0 +1,68 @@
+# synthetic-checks/
+
+Per-project synthetic checks that run after `deploy-receipt` reports `COMPLETE` and diff production against a staging baseline. Wired into the `verification-loop` skill via the `synthetic_checks` rung in `.claude/verify-ladder.json`.
+
+## Why this directory exists
+
+The 28-day usage report flagged a gap that `deploy-receipt` alone does not close: a deploy can land with a matching SHA and a 200 healthcheck, and still serve broken responses on real endpoints (stale data sources, mis-routed APIs, dropped headers, regressed payload shapes). The receipt confirms the deploy seam; synthetic checks confirm the application surface.
+
+A synthetic check is a single executable file that:
+
+1. Hits a documented endpoint on the **production** base URL.
+2. Hits the same endpoint on the **staging baseline** URL.
+3. Diffs the two responses on the dimensions that matter for that endpoint.
+4. Exits `0` if they agree, non-zero if they drift.
+
+The drift surfaces as `INCOMPLETE` on the verification-loop ladder, NOT as `COMPLETE`. A synthetic check is a gate, not a report.
+
+## File convention
+
+One check per file. Filename: `<name>.synthetic.<ext>`, where `<ext>` is one of `sh`, `mjs`, `ts`, `py`. Examples:
+
+- `version-endpoint.synthetic.sh`
+- `top-gainers-payload-shape.synthetic.mjs`
+- `feed-freshness.synthetic.ts`
+- `bot-trigger-routing.synthetic.py`
+
+The extension determines how the verification-loop runner invokes the file (`bash`, `node`, `tsx`, `python`). Files without a recognized extension are skipped with a warning.
+
+## Input contract
+
+Every synthetic check receives the following environment variables. The runner sets them; the check reads them.
+
+| Variable | Required | Meaning |
+|---|---|---|
+| `BASE_URL` | yes | Production base URL (e.g. `https://api.example.com`) |
+| `BASELINE_URL` | yes | Staging baseline URL (e.g. `https://staging.example.com`) |
+| `EXPECTED_SHA` | no | The merge SHA the receipt reported as COMPLETE; checks may use this to verify a `/version` payload includes the right commit |
+| `DEPLOY_BRANCH` | no | The deploy branch name (typically `main`); useful for branch-aware checks |
+| `RECEIPT_TIMESTAMP` | no | ISO-8601 timestamp of the receipt; useful for freshness checks |
+
+A check that needs additional configuration reads it from the project's existing config surface (env file, `.claude/verify-ladder.json`, etc.) — the runner does NOT inject project secrets.
+
+## Output contract
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Production matches the baseline on the dimensions this check measures |
+| Non-zero | Drift detected; stdout MUST contain a human-readable diff |
+
+The runner captures stdout and stderr verbatim. On non-zero exit, the diff lands in the verification-loop output unmodified — agents do not re-summarize it. Operators see the actual mismatch.
+
+## What a synthetic check is NOT
+
+- **Not a unit test.** Unit tests run against in-process code; synthetic checks run against deployed services.
+- **Not an integration test.** Integration tests use ephemeral fixtures; synthetic checks compare two real environments.
+- **Not a load test.** Synthetic checks measure correctness, not capacity. Latency assertions belong in a separate harness.
+- **Not a smoke test.** Smoke tests verify "the service is up". Synthetic checks verify "the service serves the same thing staging serves". A smoke test passes against a stale deploy; a synthetic check fails.
+- **Not a replacement for `deploy-receipt`.** The receipt confirms the SHA at the deploy seam. Synthetic checks confirm the surface. Both rungs run; either INCOMPLETE blocks the merge from being reported as done.
+
+## Sample
+
+`example-version-endpoint.synthetic.sh` is a minimal example showing the contract — curl `/version` against both URLs, diff the JSON, exit non-zero on mismatch. Copy it as a starting point and adjust the endpoint, the diff dimensions, and the failure message for your project.
+
+## How the rung resolves these files
+
+Phase 8 of the verification-loop skill, when the ladder declares `synthetic_checks: "synthetic-checks/"` (the directory name), runs every `*.synthetic.*` file in that directory in lexical order. Any non-zero exit surfaces as `INCOMPLETE — synthetic drift on <filename>` and includes the captured diff in the verification report. The rung runs only after `deploy-receipt` reports `COMPLETE`; it does not run if the receipt is INCOMPLETE (that is a different gap, addressed at the receipt rung).
+
+A project that wants to skip the rung sets `synthetic_checks: null` in its ladder. A project that wants to point at a different directory sets `synthetic_checks: "infra/synthetic/"`. A project with no `synthetic-checks/` directory and no ladder field gets the rung silently skipped — the ladder Phase 0 resolution names it as "skipped — no synthetic-checks directory found" so the operator can spot the absence.

--- a/synthetic-checks/example-version-endpoint.synthetic.sh
+++ b/synthetic-checks/example-version-endpoint.synthetic.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# example-version-endpoint.synthetic.sh
+#
+# Reference synthetic check for the synthetic-checks/ directory convention.
+# Hits /version on $BASE_URL and $BASELINE_URL and diffs the JSON payloads.
+# Exit 0 if they agree on every key. Exit 1 if they drift, with the diff
+# printed to stdout so the verification-loop runner can include it
+# verbatim in the report.
+#
+# Copy this file, rename it (e.g. cp example-version-endpoint.synthetic.sh
+# version.synthetic.sh), point it at your project's actual version endpoint,
+# and adjust the diff dimensions for your payload shape.
+#
+# Inputs (set by the verification-loop runner):
+#   BASE_URL       Production base URL (required)
+#   BASELINE_URL   Staging baseline URL (required)
+#   EXPECTED_SHA   Merge SHA the deploy receipt reported COMPLETE (optional)
+#
+# Exit codes:
+#   0   Production matches baseline on /version
+#   1   Drift detected; stdout has the diff
+#   2   Configuration error (missing input, endpoint unreachable)
+
+set -u
+
+if [[ -z "${BASE_URL:-}" || -z "${BASELINE_URL:-}" ]]; then
+  echo "configuration error: BASE_URL and BASELINE_URL must both be set" >&2
+  exit 2
+fi
+
+prod_payload=$(curl -fsS --max-time 10 "${BASE_URL%/}/version" 2>&1) || {
+  echo "configuration error: could not reach ${BASE_URL%/}/version: ${prod_payload}" >&2
+  exit 2
+}
+
+baseline_payload=$(curl -fsS --max-time 10 "${BASELINE_URL%/}/version" 2>&1) || {
+  echo "configuration error: could not reach ${BASELINE_URL%/}/version: ${baseline_payload}" >&2
+  exit 2
+}
+
+if [[ "${prod_payload}" == "${baseline_payload}" ]]; then
+  exit 0
+fi
+
+echo "drift on /version between ${BASE_URL} and ${BASELINE_URL}"
+echo "----- production -----"
+echo "${prod_payload}"
+echo "----- baseline -----"
+echo "${baseline_payload}"
+
+if [[ -n "${EXPECTED_SHA:-}" ]]; then
+  if echo "${prod_payload}" | grep -q "${EXPECTED_SHA}"; then
+    echo "note: production /version contains expected SHA ${EXPECTED_SHA}"
+  else
+    echo "warning: production /version does NOT contain expected SHA ${EXPECTED_SHA}"
+  fi
+fi
+
+exit 1

--- a/templates/insights-claude-md.md
+++ b/templates/insights-claude-md.md
@@ -1,0 +1,91 @@
+# insights-claude-md.md — paste-in CLAUDE.md blocks
+
+The four blocks below originate from the 28-day Claude Code usage report (`usage-data/report.html`, "Suggested CLAUDE.md Additions" section). Each block targets a recurring friction class the report flagged:
+
+- **Verification Discipline** — sessions where typecheck/test was skipped or run from the wrong CWD
+- **Environment Notes** — Windows + Git Bash + PowerShell mismatches that cost retries
+- **Think Before Acting** — sessions where edits started before grounding was complete
+- **Git & Deploy Workflow** — merge declared "done" while the deploy provider was still on a stale commit
+
+The discipline behavior is already encoded as continuous-improvement skills (`gateguard`, `workspace-surface-audit`, `verification-loop`, `deploy-receipt`). These blocks are the *project-local* CLAUDE.md text — the per-repo reminder that lives where developers actually look when they read `CLAUDE.md`. Skills enforce; CLAUDE.md communicates.
+
+## How to use this file
+
+1. Open the target project's `CLAUDE.md`.
+2. Pick the blocks that apply to that project (TypeScript projects probably want all four; library-only projects can skip the deploy block).
+3. Paste them under existing sections or as new top-level sections.
+4. Adjust placeholders — the report's wording is opinionated. `pnpm` is just an example; if the project uses `npm` or `yarn` or `bun`, swap it. If the project's deploy target is not Railway or Cloudflare, swap those names. The structure stays; the specifics adapt.
+5. Optionally lock the section headings under `bin/check-docs-substrings.mjs` so a wholesale CLAUDE.md rewrite doesn't silently drop the discipline contract.
+
+The blocks are paste-in markdown — copy them verbatim into your project's CLAUDE.md.
+
+---
+
+## Block 1 — Verification Discipline
+
+Paste under a "Working norms" or "Coding standards" section. Adjust `pnpm` → your package manager.
+
+```markdown
+## Verification Discipline
+- Always run `pnpm typecheck` and `pnpm test` after code changes before declaring done
+- Run verification commands from the repo root; verify CWD with `pwd` if a previous command may have changed it
+- Never claim 'verified' or 'done' without showing the passing output
+```
+
+Why this block: the report flagged sessions where Claude either skipped typecheck/test until the operator prompted, or ran `tsc` from `frontend/` and incorrectly concluded deps weren't installed. The CWD line addresses the second failure mode directly.
+
+## Block 2 — Environment Notes
+
+Paste under a "Local development" or "Environment" section. Adjust the shell + tool list to match the project's actual setup.
+
+```markdown
+## Environment Notes
+- Shell is Git Bash on Windows; do NOT use `jq` (not installed) — use PowerShell or node/python for JSON parsing
+- Be careful with bash quoting in curl/psql commands; prefer heredocs or files over inline single-quoted JSON
+- CLAUDE.md is case-sensitive on some filesystems — always use uppercase
+```
+
+Why this block: the report flagged repeated jq-not-installed retries, shell-quoting failures on curl/psql, and a Windows case-sensitivity issue with `CLAUDE.md` vs `claude.md`. If your environment is different (macOS + zsh, Linux + bash, WSL2), rewrite this block to name *your* environment's grain — the goal is to surface the per-project gotchas before the agent re-discovers them at a cost of one wasted retry each.
+
+## Block 3 — Think Before Acting
+
+Paste near the top of CLAUDE.md, ideally above any task-specific instructions.
+
+```markdown
+## Think Before Acting
+- For any non-trivial request, produce a short plan before editing files
+- When the user references prior work (e.g. 'the Finnhub stuff'), verify it exists in the repo before acting on the assumption
+- Use TDD for new features: write failing test, then code, then verify
+```
+
+Why this block: the operator literally had to type "you need to think before u response" mid-session, and a separate session was wasted verifying nonexistent "Finnhub work" that was only used as a framework analogy. The first bullet generalizes the "plan first" rule from the global CLAUDE.md; the second is project-local — if your project has its own analogy-vs-real-code traps, name them here.
+
+## Block 4 — Git & Deploy Workflow
+
+Paste under a "Git workflow" or "Release process" section. Adjust the deploy provider names to match your project.
+
+```markdown
+## Git & Deploy Workflow
+- Never push directly to main — use PR workflow; harness will block direct pushes
+- After merging, verify Railway/Cloudflare actually picked up the commit before declaring deploy complete
+- For production POSTs and wrangler tail, expect harness blocks and surface them as caveats requiring user action
+```
+
+Why this block: multiple sessions hit "Railway deploy didn't pick up the latest commit" or "harness blocked merge-to-main / production POST / wrangler" — pre-emptive awareness saves retry cycles. The second bullet is what `deploy-receipt` enforces in-tooling; this CLAUDE.md text makes the same expectation visible to humans reviewing PRs.
+
+If your project deploys somewhere other than Railway or Cloudflare, swap those names. If your project does NOT auto-deploy from main (library-only / package-published), drop the second bullet entirely — receipt verification doesn't apply.
+
+---
+
+## Companion skills (already installed if you have continuous-improvement)
+
+Each block has a corresponding skill that enforces the rule when an agent is in the loop. Pasting the block tells humans the rule; installing the skill makes the agent obey it.
+
+| Block | Companion skill |
+|---|---|
+| Verification Discipline | `verification-loop` (per-project ladder via `.claude/verify-ladder.json`) |
+| Environment Notes | `workspace-surface-audit` (records environment grain at session start) |
+| Think Before Acting | `gateguard` (blocks Edit/Write/Bash before grounding) |
+| Git & Deploy Workflow | `deploy-receipt` (verifies deployed SHA + healthcheck before declaring done) |
+
+If you want both layers (CLAUDE.md text + skill enforcement), paste the block AND keep the skill installed. If you only want one, the skill is the higher-fidelity surface — it runs at the tool boundary and cannot be skipped by an agent that didn't read the markdown.

--- a/templates/verify-ladder.example.json
+++ b/templates/verify-ladder.example.json
@@ -9,39 +9,52 @@
     "Three starter shapes are provided below — pick one, delete the others, then trim."
   ],
 
+  "_synthetic_checks_doc": [
+    "synthetic_checks names a directory (relative to the repo root) containing",
+    "*.synthetic.{sh,mjs,ts,py} files. Each file is invoked once after deploy-receipt",
+    "reports COMPLETE, with BASE_URL + BASELINE_URL + EXPECTED_SHA env vars set.",
+    "Exit 0 = production matches baseline; non-zero = drift, stdout is the diff.",
+    "Set to null to skip; set to a different path (e.g. 'infra/synthetic/') to relocate.",
+    "See synthetic-checks/README.md for the full contract."
+  ],
+
   "_typescript_node_example": {
-    "build":          "npm run build",
-    "typecheck":      "npx tsc --noEmit",
-    "lint":           "npm run lint",
-    "test":           "npm test",
-    "security":       "npm audit --audit-level=high",
-    "deploy_receipt": null
+    "build":            "npm run build",
+    "typecheck":        "npx tsc --noEmit",
+    "lint":             "npm run lint",
+    "test":             "npm test",
+    "security":         "npm audit --audit-level=high",
+    "deploy_receipt":   null,
+    "synthetic_checks": null
   },
 
   "_rust_cargo_example": {
-    "build":          "cargo build --release",
-    "typecheck":      "cargo check --all-targets",
-    "lint":           "cargo clippy --all-targets -- -D warnings",
-    "test":           "cargo test --all-features",
-    "security":       "cargo audit",
-    "deploy_receipt": null
+    "build":            "cargo build --release",
+    "typecheck":        "cargo check --all-targets",
+    "lint":             "cargo clippy --all-targets -- -D warnings",
+    "test":             "cargo test --all-features",
+    "security":         "cargo audit",
+    "deploy_receipt":   null,
+    "synthetic_checks": null
   },
 
   "_python_uv_example": {
-    "build":          null,
-    "typecheck":      "uv run pyright",
-    "lint":           "uv run ruff check .",
-    "test":           "uv run pytest",
-    "security":       "uv run pip-audit",
-    "deploy_receipt": null
+    "build":            null,
+    "typecheck":        "uv run pyright",
+    "lint":             "uv run ruff check .",
+    "test":             "uv run pytest",
+    "security":         "uv run pip-audit",
+    "deploy_receipt":   null,
+    "synthetic_checks": null
   },
 
   "_cloudflare_worker_example": {
-    "build":          "npm run build",
-    "typecheck":      "npx tsc --noEmit",
-    "lint":           "npm run lint",
-    "test":           "npm test",
-    "security":       "npm audit --audit-level=high",
-    "deploy_receipt": "npx wrangler deployments list --json"
+    "build":            "npm run build",
+    "typecheck":        "npx tsc --noEmit",
+    "lint":             "npm run lint",
+    "test":             "npm test",
+    "security":         "npm audit --audit-level=high",
+    "deploy_receipt":   "npx wrangler deployments list --json",
+    "synthetic_checks": "synthetic-checks/"
   }
 }


### PR DESCRIPTION
## Summary

Closes the three remaining horizon items from the 28-day usage report (`usage-data/report.html`) that the v3.7 → v3.9 release train left as residue. Single small stack, three single-concern commits, all gates green.

| Horizon item (report) | Commit |
|---|---|
| Self-Healing Production Verification Loop — auto-rollback / hotfix-PR portion | `7c84798` deploy-receipt `--on-incomplete=open-hotfix-pr` mode |
| Self-Healing Production Verification Loop — synthetic-checks vs staging baseline | `1a37396` synthetic-checks/ rung + verification-loop Phase 9 |
| Suggested CLAUDE.md Additions — four paste-in blocks | `c77ee1c` templates/insights-claude-md.md |

Plan: [`docs/plans/2026-05-09-insights-report-residue.md`](https://github.com/naimkatiman/continuous-improvement/blob/feat/insights-report-residue/docs/plans/2026-05-09-insights-report-residue.md).

## Per-commit detail

### 1. `feat(deploy-receipt): --on-incomplete=open-hotfix-pr mode`
- New "On-Incomplete Modes" section in the skill: `report-only` (default, unchanged) and `open-hotfix-pr` (opt-in)
- New mode stages a recovery branch `hotfix/<sha>-<symptom>` with a failing repro test, opens a draft PR citing the receipt block + the documented rollback command for the detected provider, and stops
- Three new anti-patterns lock the operator-gated boundary: no auto-merge, no force-push, no rollback execution
- Skill never executes `railway redeploy` / `wrangler rollback` / `vercel rollback` — only prints them in the PR body

### 2. `feat(verification-loop): synthetic-checks/ rung + staging-baseline convention`
- New `synthetic-checks/` directory convention (README + runnable sample)
- File contract: `<name>.synthetic.{sh,mjs,ts,py}`, env inputs (`BASE_URL`, `BASELINE_URL`, `EXPECTED_SHA`), exit-0-or-diff-on-stdout
- Sample `example-version-endpoint.synthetic.sh` smoke-tested for both drift (exit 1, diff printed) and config-error (exit 2)
- `templates/verify-ladder.example.json` gains `synthetic_checks` field across all four starter shapes + `_synthetic_checks_doc` block
- `verification-loop` SKILL.md gains Phase 9 (production-vs-baseline diff), runs after Phase 8 reports COMPLETE, surfaces failed checks as INCOMPLETE with diff verbatim
- Output Format gains Deploy + Synthetic rows

### 3. `docs(templates): insights-claude-md paste-in blocks`
- `templates/insights-claude-md.md` carries the four CLAUDE.md blocks verbatim from the report
- Each block has a short preamble + 'why this block' citing the report's friction class
- Companion-skills table maps each block to the skill that enforces it (`gateguard`, `workspace-surface-audit`, `verification-loop`, `deploy-receipt`)
- README.md gains a one-line pointer in the More section

## Out of scope (logged so reviewers can hold the line)

- Webhook-driven long-lived verification agent (separate plan — different deployment shape)
- Auto-rollback execution (skill describes when, never runs `railway redeploy` etc. on its own — operator-gated by design)
- Hook-form deploy preflight in `.claude/settings.json` (already shipped as the `deploy-receipt` skill; hook form would duplicate)
- `bin/` runner script for synthetic-checks (skill authors the contract; runner is a separate PR if needed)

## Test plan

- [x] `npm run verify:all` — 14 skill pairs mirrored, 144 docs-substrings, 30 mirrored files, 37 routing targets, typecheck clean
- [x] `npm test` — 523/523 passing
- [x] Smoke-tested `example-version-endpoint.synthetic.sh` — drift path (exit 1, diff on stdout), config-error path (exit 2, error on stderr)
- [x] Plan doc cited in every commit message
- [x] 10 files of substance, +514/-24 LOC — within Surgical Changes guardrails
- [ ] Reviewer: confirm the on-incomplete `open-hotfix-pr` mode anti-patterns match the operator-gated boundary you want (no auto-merge, no force-push, no rollback execution)
- [ ] Reviewer: confirm the synthetic-checks rung surface (Phase 9) is the right place vs. a separate skill