### PR TITLE
feat(gateguard): runtime PreToolUse hook (#106)

### DIFF
--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Runtime PreToolUse gateguard hook.
+ *
+ * Stdin  : JSON { tool_name, tool_input }
+ * Stdout : JSON { decision: "allow" | "block", reason?: string }
+ * Exit   : 0 always (decision is in stdout, fail-open on parse error).
+ *
+ * Three-stage gate per skills/gateguard.md:
+ * - DENY  : first mutating tool call per file, with fact-list reason
+ * - FORCE : agent presents facts (model-side; out of band)
+ * - ALLOW : retry once `_gateguard_facts_presented: true` is set or the
+ *           per-file marker is recorded in session state
+ *
+ * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
+ * unconditionally. Destructive Bash gates EVERY call, not just first.
+ *
+ * V1 honest limitations (see src/lib/gateguard-state.mts header):
+ *   honor-system flag, state-file deletion, parallel-hook race.
+ *
+ * MultiEdit handling (V1): gates on edits[0].file_path only. Per-file
+ * batching is not implemented — TODO: extend to gate every entry in
+ * edits[]. Tracked in issue #106 acceptance criteria item 5.
+ */
+import { readFileSync } from "node:fs";
+import { isCapReached, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
+const TOOL_ROUTE = {
+    Read: "allow",
+    Grep: "allow",
+    Glob: "allow",
+    LS: "allow",
+    NotebookRead: "allow",
+    Write: "mutating-file",
+    Edit: "mutating-file",
+    MultiEdit: "mutating-file",
+    NotebookEdit: "mutating-file",
+    Bash: "allow",
+};
+const DESTRUCTIVE_PATTERNS = [
+    "rm -rf",
+    "rm -fr",
+    "git reset --hard",
+    "git push --force",
+    "git push -f",
+    "--force-with-lease",
+    "git branch -D",
+    "drop table",
+    "drop database",
+    "drop schema",
+    "truncate ",
+    "mkfs",
+    "dd if=",
+    "format ",
+    "rmdir /s",
+    "del /f /q",
+    "del /q /f",
+    "Remove-Item -Recurse",
+    "Remove-Item -Force",
+];
+function isDestructiveBash(command) {
+    const lower = command.toLowerCase();
+    return DESTRUCTIVE_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
+}
+function classifyTool(toolName, toolInput) {
+    const route = TOOL_ROUTE[toolName] ?? "allow";
+    if (route !== "allow")
+        return route;
+    if (toolName === "Bash" && typeof toolInput.command === "string") {
+        if (isDestructiveBash(toolInput.command))
+            return "destructive-bash";
+    }
+    return "allow";
+}
+function extractFilePath(toolInput) {
+    if (typeof toolInput.file_path === "string")
+        return toolInput.file_path;
+    // MultiEdit V1: first edit's file_path is the canonical key.
+    if (Array.isArray(toolInput.edits) && toolInput.edits.length > 0) {
+        const first = toolInput.edits[0];
+        if (first && typeof first.file_path === "string")
+            return first.file_path;
+    }
+    if (typeof toolInput.command === "string")
+        return toolInput.command;
+    return "";
+}
+function buildMutatingFileReason(toolName, filePath) {
+    return [
+        `Before ${toolName === "Write" ? "creating" : "editing"} ${filePath || "<unknown>"}, present these facts:`,
+        "",
+        "  1. List ALL files that import/require this file (use Grep)",
+        "  2. List the public functions/classes affected by this change",
+        "  3. If this file reads/writes data files, show field names, structure, and date format",
+        "  4. Quote the user's current instruction verbatim",
+        "",
+        "After presenting the facts, retry with `_gateguard_facts_presented: true` in tool_input,",
+        "or with the same file_path after a previous clearance has been recorded for this session.",
+    ].join("\n");
+}
+function buildDestructiveBashReason(command) {
+    return [
+        `Destructive command requested: ${command}`,
+        "",
+        "  1. List ALL files/data this command will modify or delete",
+        "  2. Write a one-line rollback procedure",
+        "  3. Quote the user's current instruction verbatim",
+        "",
+        "Destructive Bash gates EVERY call — clearance is not cached.",
+    ].join("\n");
+}
+function buildCapReachedReason() {
+    return [
+        "Gateguard session clearance cap reached (50 distinct files).",
+        "Start a new Claude Code session to reset the gate. The cap exists to bound",
+        "stuck-loop or rogue-agent clearance from compounding within a single session.",
+    ].join("\n");
+}
+function emit(decision) {
+    process.stdout.write(`${JSON.stringify(decision)}\n`);
+    process.exit(0);
+}
+function main() {
+    let raw = "";
+    try {
+        raw = readFileSync(0, "utf8");
+    }
+    catch {
+        emit({ decision: "allow" });
+        return;
+    }
+    let payload;
+    try {
+        payload = JSON.parse(raw);
+    }
+    catch {
+        emit({ decision: "allow" }); // fail-open
+        return;
+    }
+    const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
+    const toolInput = payload.tool_input ?? {};
+    const gate = classifyTool(toolName, toolInput);
+    if (gate === "allow") {
+        emit({ decision: "allow" });
+        return;
+    }
+    if (gate === "destructive-bash") {
+        const cmd = typeof toolInput.command === "string" ? toolInput.command : "";
+        emit({ decision: "block", reason: buildDestructiveBashReason(cmd) });
+        return;
+    }
+    // mutating-file
+    const sessionDir = resolveSessionDir();
+    const state = loadState(sessionDir);
+    const filePath = extractFilePath(toolInput);
+    const factsFlagged = toolInput._gateguard_facts_presented === true;
+    const alreadyCleared = filePath !== "" && filePath in state.cleared_files;
+    if (!factsFlagged && !alreadyCleared) {
+        emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePath) });
+        return;
+    }
+    if (factsFlagged && !alreadyCleared) {
+        if (isCapReached(state)) {
+            emit({ decision: "block", reason: buildCapReachedReason() });
+            return;
+        }
+        if (filePath !== "") {
+            saveState(sessionDir, markFileCleared(state, filePath));
+        }
+    }
+    emit({ decision: "allow" });
+}
+main();

--- a/lib/gateguard-state.mjs
+++ b/lib/gateguard-state.mjs
@@ -1,0 +1,85 @@
+/**
+ * Gateguard per-session state.
+ *
+ * State file: <sessionDir>/gateguard-session.json. sessionDir resolves to
+ * GATEGUARD_SESSION_DIR (env override, used by tests) or
+ * ~/.claude/instincts/<projectHash>/ in production.
+ *
+ * V1 limitations (documented for honesty, not mitigated in code):
+ * - Honor system: clearance is granted whenever the agent sets
+ *   `_gateguard_facts_presented: true` in tool_input or has a prior per-file
+ *   marker. The hook cannot verify that real investigation occurred.
+ * - State-file deletion: rm'ing the state file resets every gate in the
+ *   session. Defensible because the session itself is the trust boundary;
+ *   the cap below limits cumulative damage.
+ * - Concurrency: two parallel hook invocations can race the read+write.
+ *   Acceptable trade-off vs OS-specific atomic-rename complexity on Windows.
+ * - Cap: MAX_CLEARED_FILES caps the number of distinct files a single
+ *   session can clear, bounding stuck-loop / rogue-agent damage.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+export const MAX_CLEARED_FILES = 50;
+export function resolveSessionDir() {
+    const fromEnv = process.env.GATEGUARD_SESSION_DIR;
+    if (fromEnv)
+        return fromEnv;
+    const home = process.env.HOME || process.env.USERPROFILE || homedir();
+    const projectRoot = resolveProjectRoot();
+    const projectHash = createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+    return join(home, ".claude", "instincts", projectHash);
+}
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+export function loadState(sessionDir) {
+    const path = join(sessionDir, "gateguard-session.json");
+    if (!existsSync(path)) {
+        return { created_at: new Date().toISOString(), cleared_files: {} };
+    }
+    try {
+        const raw = readFileSync(path, "utf8");
+        const parsed = JSON.parse(raw);
+        return {
+            created_at: parsed.created_at ?? new Date().toISOString(),
+            cleared_files: parsed.cleared_files ?? {},
+        };
+    }
+    catch {
+        return { created_at: new Date().toISOString(), cleared_files: {} };
+    }
+}
+export function saveState(sessionDir, state) {
+    if (!existsSync(sessionDir))
+        mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "gateguard-session.json"), `${JSON.stringify(state, null, 2)}\n`);
+}
+export function isCapReached(state) {
+    return Object.keys(state.cleared_files).length >= MAX_CLEARED_FILES;
+}
+export function markFileCleared(state, filePath) {
+    return {
+        ...state,
+        cleared_files: {
+            ...state.cleared_files,
+            [filePath]: { cleared_at: new Date().toISOString() },
+        },
+    };
+}

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -352,6 +352,11 @@ export function getClaudePluginManifest() {
     };
 }
 export function getPluginHooksConfig() {
+    const gateguardCommand = {
+        type: "command",
+        command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gateguard.mjs\"",
+        timeout: 5,
+    };
     const observeCommand = {
         type: "command",
         command: "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/observe.sh\"",
@@ -368,9 +373,13 @@ export function getPluginHooksConfig() {
         timeout: 5,
     };
     return {
-        description: "Observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+        description: "Gateguard fact-forcing PreToolUse, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
         hooks: {
-            PreToolUse: [{ hooks: [observeCommand] }],
+            // gateguard runs FIRST so its block decision short-circuits before
+            // observe.sh records the tool call. observe.sh stays in PreToolUse for
+            // the observation feed; the Claude Code host runs both regardless of
+            // gateguard's decision.
+            PreToolUse: [{ hooks: [gateguardCommand, observeCommand] }],
             PostToolUse: [{ hooks: [observeCommand] }],
             SessionStart: [{ hooks: [sessionCommand] }],
             SessionEnd: [{ hooks: [sessionCommand] }],

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Runtime PreToolUse gateguard hook.
+ *
+ * Stdin  : JSON { tool_name, tool_input }
+ * Stdout : JSON { decision: "allow" | "block", reason?: string }
+ * Exit   : 0 always (decision is in stdout, fail-open on parse error).
+ *
+ * Three-stage gate per skills/gateguard.md:
+ * - DENY  : first mutating tool call per file, with fact-list reason
+ * - FORCE : agent presents facts (model-side; out of band)
+ * - ALLOW : retry once `_gateguard_facts_presented: true` is set or the
+ *           per-file marker is recorded in session state
+ *
+ * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
+ * unconditionally. Destructive Bash gates EVERY call, not just first.
+ *
+ * V1 honest limitations (see src/lib/gateguard-state.mts header):
+ *   honor-system flag, state-file deletion, parallel-hook race.
+ *
+ * MultiEdit handling (V1): gates on edits[0].file_path only. Per-file
+ * batching is not implemented — TODO: extend to gate every entry in
+ * edits[]. Tracked in issue #106 acceptance criteria item 5.
+ */
+import { readFileSync } from "node:fs";
+import { isCapReached, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
+const TOOL_ROUTE = {
+    Read: "allow",
+    Grep: "allow",
+    Glob: "allow",
+    LS: "allow",
+    NotebookRead: "allow",
+    Write: "mutating-file",
+    Edit: "mutating-file",
+    MultiEdit: "mutating-file",
+    NotebookEdit: "mutating-file",
+    Bash: "allow",
+};
+const DESTRUCTIVE_PATTERNS = [
+    "rm -rf",
+    "rm -fr",
+    "git reset --hard",
+    "git push --force",
+    "git push -f",
+    "--force-with-lease",
+    "git branch -D",
+    "drop table",
+    "drop database",
+    "drop schema",
+    "truncate ",
+    "mkfs",
+    "dd if=",
+    "format ",
+    "rmdir /s",
+    "del /f /q",
+    "del /q /f",
+    "Remove-Item -Recurse",
+    "Remove-Item -Force",
+];
+function isDestructiveBash(command) {
+    const lower = command.toLowerCase();
+    return DESTRUCTIVE_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
+}
+function classifyTool(toolName, toolInput) {
+    const route = TOOL_ROUTE[toolName] ?? "allow";
+    if (route !== "allow")
+        return route;
+    if (toolName === "Bash" && typeof toolInput.command === "string") {
+        if (isDestructiveBash(toolInput.command))
+            return "destructive-bash";
+    }
+    return "allow";
+}
+function extractFilePath(toolInput) {
+    if (typeof toolInput.file_path === "string")
+        return toolInput.file_path;
+    // MultiEdit V1: first edit's file_path is the canonical key.
+    if (Array.isArray(toolInput.edits) && toolInput.edits.length > 0) {
+        const first = toolInput.edits[0];
+        if (first && typeof first.file_path === "string")
+            return first.file_path;
+    }
+    if (typeof toolInput.command === "string")
+        return toolInput.command;
+    return "";
+}
+function buildMutatingFileReason(toolName, filePath) {
+    return [
+        `Before ${toolName === "Write" ? "creating" : "editing"} ${filePath || "<unknown>"}, present these facts:`,
+        "",
+        "  1. List ALL files that import/require this file (use Grep)",
+        "  2. List the public functions/classes affected by this change",
+        "  3. If this file reads/writes data files, show field names, structure, and date format",
+        "  4. Quote the user's current instruction verbatim",
+        "",
+        "After presenting the facts, retry with `_gateguard_facts_presented: true` in tool_input,",
+        "or with the same file_path after a previous clearance has been recorded for this session.",
+    ].join("\n");
+}
+function buildDestructiveBashReason(command) {
+    return [
+        `Destructive command requested: ${command}`,
+        "",
+        "  1. List ALL files/data this command will modify or delete",
+        "  2. Write a one-line rollback procedure",
+        "  3. Quote the user's current instruction verbatim",
+        "",
+        "Destructive Bash gates EVERY call — clearance is not cached.",
+    ].join("\n");
+}
+function buildCapReachedReason() {
+    return [
+        "Gateguard session clearance cap reached (50 distinct files).",
+        "Start a new Claude Code session to reset the gate. The cap exists to bound",
+        "stuck-loop or rogue-agent clearance from compounding within a single session.",
+    ].join("\n");
+}
+function emit(decision) {
+    process.stdout.write(`${JSON.stringify(decision)}\n`);
+    process.exit(0);
+}
+function main() {
+    let raw = "";
+    try {
+        raw = readFileSync(0, "utf8");
+    }
+    catch {
+        emit({ decision: "allow" });
+        return;
+    }
+    let payload;
+    try {
+        payload = JSON.parse(raw);
+    }
+    catch {
+        emit({ decision: "allow" }); // fail-open
+        return;
+    }
+    const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
+    const toolInput = payload.tool_input ?? {};
+    const gate = classifyTool(toolName, toolInput);
+    if (gate === "allow") {
+        emit({ decision: "allow" });
+        return;
+    }
+    if (gate === "destructive-bash") {
+        const cmd = typeof toolInput.command === "string" ? toolInput.command : "";
+        emit({ decision: "block", reason: buildDestructiveBashReason(cmd) });
+        return;
+    }
+    // mutating-file
+    const sessionDir = resolveSessionDir();
+    const state = loadState(sessionDir);
+    const filePath = extractFilePath(toolInput);
+    const factsFlagged = toolInput._gateguard_facts_presented === true;
+    const alreadyCleared = filePath !== "" && filePath in state.cleared_files;
+    if (!factsFlagged && !alreadyCleared) {
+        emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePath) });
+        return;
+    }
+    if (factsFlagged && !alreadyCleared) {
+        if (isCapReached(state)) {
+            emit({ decision: "block", reason: buildCapReachedReason() });
+            return;
+        }
+        if (filePath !== "") {
+            saveState(sessionDir, markFileCleared(state, filePath));
+        }
+    }
+    emit({ decision: "allow" });
+}
+main();

--- a/plugins/continuous-improvement/hooks/hooks.json
+++ b/plugins/continuous-improvement/hooks/hooks.json
@@ -1,9 +1,14 @@
 {
-  "description": "Observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+  "description": "Gateguard fact-forcing PreToolUse, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
   "hooks": {
     "PreToolUse": [
       {
         "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gateguard.mjs\"",
+            "timeout": 5
+          },
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/observe.sh\"",

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -352,6 +352,11 @@ export function getClaudePluginManifest() {
     };
 }
 export function getPluginHooksConfig() {
+    const gateguardCommand = {
+        type: "command",
+        command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gateguard.mjs\"",
+        timeout: 5,
+    };
     const observeCommand = {
         type: "command",
         command: "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/observe.sh\"",
@@ -368,9 +373,13 @@ export function getPluginHooksConfig() {
         timeout: 5,
     };
     return {
-        description: "Observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+        description: "Gateguard fact-forcing PreToolUse, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
         hooks: {
-            PreToolUse: [{ hooks: [observeCommand] }],
+            // gateguard runs FIRST so its block decision short-circuits before
+            // observe.sh records the tool call. observe.sh stays in PreToolUse for
+            // the observation feed; the Claude Code host runs both regardless of
+            // gateguard's decision.
+            PreToolUse: [{ hooks: [gateguardCommand, observeCommand] }],
             PostToolUse: [{ hooks: [observeCommand] }],
             SessionStart: [{ hooks: [sessionCommand] }],
             SessionEnd: [{ hooks: [sessionCommand] }],

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/**
+ * Runtime PreToolUse gateguard hook.
+ *
+ * Stdin  : JSON { tool_name, tool_input }
+ * Stdout : JSON { decision: "allow" | "block", reason?: string }
+ * Exit   : 0 always (decision is in stdout, fail-open on parse error).
+ *
+ * Three-stage gate per skills/gateguard.md:
+ * - DENY  : first mutating tool call per file, with fact-list reason
+ * - FORCE : agent presents facts (model-side; out of band)
+ * - ALLOW : retry once `_gateguard_facts_presented: true` is set or the
+ *           per-file marker is recorded in session state
+ *
+ * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
+ * unconditionally. Destructive Bash gates EVERY call, not just first.
+ *
+ * V1 honest limitations (see src/lib/gateguard-state.mts header):
+ *   honor-system flag, state-file deletion, parallel-hook race.
+ *
+ * MultiEdit handling (V1): gates on edits[0].file_path only. Per-file
+ * batching is not implemented — TODO: extend to gate every entry in
+ * edits[]. Tracked in issue #106 acceptance criteria item 5.
+ */
+
+import { readFileSync } from "node:fs";
+import {
+  isCapReached,
+  loadState,
+  markFileCleared,
+  resolveSessionDir,
+  saveState,
+} from "../lib/gateguard-state.mjs";
+
+type GateType = "allow" | "mutating-file" | "destructive-bash";
+
+interface ToolInput {
+  file_path?: unknown;
+  command?: unknown;
+  edits?: Array<{ file_path?: unknown }>;
+  _gateguard_facts_presented?: unknown;
+  [key: string]: unknown;
+}
+
+interface Payload {
+  tool_name?: unknown;
+  tool_input?: ToolInput;
+}
+
+interface Decision {
+  decision: "allow" | "block";
+  reason?: string;
+}
+
+const TOOL_ROUTE: Record<string, GateType> = {
+  Read: "allow",
+  Grep: "allow",
+  Glob: "allow",
+  LS: "allow",
+  NotebookRead: "allow",
+  Write: "mutating-file",
+  Edit: "mutating-file",
+  MultiEdit: "mutating-file",
+  NotebookEdit: "mutating-file",
+  Bash: "allow",
+};
+
+const DESTRUCTIVE_PATTERNS: readonly string[] = [
+  "rm -rf",
+  "rm -fr",
+  "git reset --hard",
+  "git push --force",
+  "git push -f",
+  "--force-with-lease",
+  "git branch -D",
+  "drop table",
+  "drop database",
+  "drop schema",
+  "truncate ",
+  "mkfs",
+  "dd if=",
+  "format ",
+  "rmdir /s",
+  "del /f /q",
+  "del /q /f",
+  "Remove-Item -Recurse",
+  "Remove-Item -Force",
+];
+
+function isDestructiveBash(command: string): boolean {
+  const lower = command.toLowerCase();
+  return DESTRUCTIVE_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
+}
+
+function classifyTool(toolName: string, toolInput: ToolInput): GateType {
+  const route = TOOL_ROUTE[toolName] ?? "allow";
+  if (route !== "allow") return route;
+  if (toolName === "Bash" && typeof toolInput.command === "string") {
+    if (isDestructiveBash(toolInput.command)) return "destructive-bash";
+  }
+  return "allow";
+}
+
+function extractFilePath(toolInput: ToolInput): string {
+  if (typeof toolInput.file_path === "string") return toolInput.file_path;
+  // MultiEdit V1: first edit's file_path is the canonical key.
+  if (Array.isArray(toolInput.edits) && toolInput.edits.length > 0) {
+    const first = toolInput.edits[0];
+    if (first && typeof first.file_path === "string") return first.file_path;
+  }
+  if (typeof toolInput.command === "string") return toolInput.command;
+  return "";
+}
+
+function buildMutatingFileReason(toolName: string, filePath: string): string {
+  return [
+    `Before ${toolName === "Write" ? "creating" : "editing"} ${filePath || "<unknown>"}, present these facts:`,
+    "",
+    "  1. List ALL files that import/require this file (use Grep)",
+    "  2. List the public functions/classes affected by this change",
+    "  3. If this file reads/writes data files, show field names, structure, and date format",
+    "  4. Quote the user's current instruction verbatim",
+    "",
+    "After presenting the facts, retry with `_gateguard_facts_presented: true` in tool_input,",
+    "or with the same file_path after a previous clearance has been recorded for this session.",
+  ].join("\n");
+}
+
+function buildDestructiveBashReason(command: string): string {
+  return [
+    `Destructive command requested: ${command}`,
+    "",
+    "  1. List ALL files/data this command will modify or delete",
+    "  2. Write a one-line rollback procedure",
+    "  3. Quote the user's current instruction verbatim",
+    "",
+    "Destructive Bash gates EVERY call — clearance is not cached.",
+  ].join("\n");
+}
+
+function buildCapReachedReason(): string {
+  return [
+    "Gateguard session clearance cap reached (50 distinct files).",
+    "Start a new Claude Code session to reset the gate. The cap exists to bound",
+    "stuck-loop or rogue-agent clearance from compounding within a single session.",
+  ].join("\n");
+}
+
+function emit(decision: Decision): void {
+  process.stdout.write(`${JSON.stringify(decision)}\n`);
+  process.exit(0);
+}
+
+function main(): void {
+  let raw = "";
+  try {
+    raw = readFileSync(0, "utf8");
+  } catch {
+    emit({ decision: "allow" });
+    return;
+  }
+  let payload: Payload;
+  try {
+    payload = JSON.parse(raw) as Payload;
+  } catch {
+    emit({ decision: "allow" }); // fail-open
+    return;
+  }
+  const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
+  const toolInput: ToolInput = payload.tool_input ?? {};
+  const gate = classifyTool(toolName, toolInput);
+
+  if (gate === "allow") {
+    emit({ decision: "allow" });
+    return;
+  }
+
+  if (gate === "destructive-bash") {
+    const cmd = typeof toolInput.command === "string" ? toolInput.command : "";
+    emit({ decision: "block", reason: buildDestructiveBashReason(cmd) });
+    return;
+  }
+
+  // mutating-file
+  const sessionDir = resolveSessionDir();
+  const state = loadState(sessionDir);
+  const filePath = extractFilePath(toolInput);
+  const factsFlagged = toolInput._gateguard_facts_presented === true;
+  const alreadyCleared = filePath !== "" && filePath in state.cleared_files;
+
+  if (!factsFlagged && !alreadyCleared) {
+    emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePath) });
+    return;
+  }
+
+  if (factsFlagged && !alreadyCleared) {
+    if (isCapReached(state)) {
+      emit({ decision: "block", reason: buildCapReachedReason() });
+      return;
+    }
+    if (filePath !== "") {
+      saveState(sessionDir, markFileCleared(state, filePath));
+    }
+  }
+
+  emit({ decision: "allow" });
+}
+
+main();

--- a/src/lib/gateguard-state.mts
+++ b/src/lib/gateguard-state.mts
@@ -1,0 +1,95 @@
+/**
+ * Gateguard per-session state.
+ *
+ * State file: <sessionDir>/gateguard-session.json. sessionDir resolves to
+ * GATEGUARD_SESSION_DIR (env override, used by tests) or
+ * ~/.claude/instincts/<projectHash>/ in production.
+ *
+ * V1 limitations (documented for honesty, not mitigated in code):
+ * - Honor system: clearance is granted whenever the agent sets
+ *   `_gateguard_facts_presented: true` in tool_input or has a prior per-file
+ *   marker. The hook cannot verify that real investigation occurred.
+ * - State-file deletion: rm'ing the state file resets every gate in the
+ *   session. Defensible because the session itself is the trust boundary;
+ *   the cap below limits cumulative damage.
+ * - Concurrency: two parallel hook invocations can race the read+write.
+ *   Acceptable trade-off vs OS-specific atomic-rename complexity on Windows.
+ * - Cap: MAX_CLEARED_FILES caps the number of distinct files a single
+ *   session can clear, bounding stuck-loop / rogue-agent damage.
+ */
+
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export const MAX_CLEARED_FILES = 50;
+
+export interface GateguardState {
+  created_at: string;
+  cleared_files: Record<string, { cleared_at: string }>;
+}
+
+export function resolveSessionDir(): string {
+  const fromEnv = process.env.GATEGUARD_SESSION_DIR;
+  if (fromEnv) return fromEnv;
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  const projectRoot = resolveProjectRoot();
+  const projectHash = createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+  return join(home, ".claude", "instincts", projectHash);
+}
+
+function resolveProjectRoot(): string {
+  const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+  if (fromEnv) return fromEnv;
+  try {
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (root) return root;
+  } catch {
+    // not in a git repo
+  }
+  return "global";
+}
+
+export function loadState(sessionDir: string): GateguardState {
+  const path = join(sessionDir, "gateguard-session.json");
+  if (!existsSync(path)) {
+    return { created_at: new Date().toISOString(), cleared_files: {} };
+  }
+  try {
+    const raw = readFileSync(path, "utf8");
+    const parsed = JSON.parse(raw) as Partial<GateguardState>;
+    return {
+      created_at: parsed.created_at ?? new Date().toISOString(),
+      cleared_files: parsed.cleared_files ?? {},
+    };
+  } catch {
+    return { created_at: new Date().toISOString(), cleared_files: {} };
+  }
+}
+
+export function saveState(sessionDir: string, state: GateguardState): void {
+  if (!existsSync(sessionDir)) mkdirSync(sessionDir, { recursive: true });
+  writeFileSync(
+    join(sessionDir, "gateguard-session.json"),
+    `${JSON.stringify(state, null, 2)}\n`,
+  );
+}
+
+export function isCapReached(state: GateguardState): boolean {
+  return Object.keys(state.cleared_files).length >= MAX_CLEARED_FILES;
+}
+
+export function markFileCleared(state: GateguardState, filePath: string): GateguardState {
+  return {
+    ...state,
+    cleared_files: {
+      ...state.cleared_files,
+      [filePath]: { cleared_at: new Date().toISOString() },
+    },
+  };
+}

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -496,6 +496,11 @@ export function getClaudePluginManifest(): ClaudePluginManifest {
 }
 
 export function getPluginHooksConfig(): PluginHooksConfig {
+  const gateguardCommand = {
+    type: "command" as const,
+    command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/gateguard.mjs\"",
+    timeout: 5,
+  };
   const observeCommand = {
     type: "command" as const,
     command: "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/observe.sh\"",
@@ -514,9 +519,13 @@ export function getPluginHooksConfig(): PluginHooksConfig {
 
   return {
     description:
-      "Observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+      "Gateguard fact-forcing PreToolUse, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
     hooks: {
-      PreToolUse: [{ hooks: [observeCommand] }],
+      // gateguard runs FIRST so its block decision short-circuits before
+      // observe.sh records the tool call. observe.sh stays in PreToolUse for
+      // the observation feed; the Claude Code host runs both regardless of
+      // gateguard's decision.
+      PreToolUse: [{ hooks: [gateguardCommand, observeCommand] }],
       PostToolUse: [{ hooks: [observeCommand] }],
       SessionStart: [{ hooks: [sessionCommand] }],
       SessionEnd: [{ hooks: [sessionCommand] }],

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -22,7 +22,7 @@
 
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, before, after } from "node:test";
@@ -74,10 +74,12 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
       );
     });
 
-    it("hooks/gateguard.mjs is wired as the first PreToolUse hook in the plugin bundle", async () => {
+    it("hooks/gateguard.mjs is wired as the first PreToolUse hook in the plugin bundle", () => {
       // The runtime hooks.json is generated into the plugin bundle by the build,
       // not into the repo-root hooks/. Source-of-truth lives in
       // src/lib/plugin-metadata.mts → getPluginHooksConfig().
+      // readFileSync + JSON.parse — avoids Node's ESM URL scheme requirement on
+      // Windows (`import("d:\\...")` fails with ERR_UNSUPPORTED_ESM_URL_SCHEME).
       const hooksJsonPath = join(
         REPO_ROOT,
         "plugins",
@@ -85,11 +87,13 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         "hooks",
         "hooks.json",
       );
-      const hooksJson = await import(hooksJsonPath, { with: { type: "json" } });
-      const preToolUse = (hooksJson.default as { hooks: { PreToolUse?: unknown[] } }).hooks
-        .PreToolUse;
+      assert.ok(existsSync(hooksJsonPath), "plugin-bundle hooks.json should exist");
+      const hooksJson = JSON.parse(readFileSync(hooksJsonPath, "utf8")) as {
+        hooks: { PreToolUse?: Array<{ hooks: Array<{ command: string }> }> };
+      };
+      const preToolUse = hooksJson.hooks.PreToolUse;
       assert.ok(Array.isArray(preToolUse) && preToolUse.length > 0, "PreToolUse hooks present");
-      const first = (preToolUse[0] as { hooks: Array<{ command: string }> }).hooks[0];
+      const first = preToolUse[0]!.hooks[0]!;
       assert.match(first.command, /gateguard\.mjs/, "first PreToolUse hook must be gateguard");
     });
   });

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -74,10 +74,18 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
       );
     });
 
-    it("hooks/gateguard.mjs is wired as the first PreToolUse hook", async () => {
-      const hooksJson = await import(join(REPO_ROOT, "hooks", "hooks.json"), {
-        with: { type: "json" },
-      });
+    it("hooks/gateguard.mjs is wired as the first PreToolUse hook in the plugin bundle", async () => {
+      // The runtime hooks.json is generated into the plugin bundle by the build,
+      // not into the repo-root hooks/. Source-of-truth lives in
+      // src/lib/plugin-metadata.mts → getPluginHooksConfig().
+      const hooksJsonPath = join(
+        REPO_ROOT,
+        "plugins",
+        "continuous-improvement",
+        "hooks",
+        "hooks.json",
+      );
+      const hooksJson = await import(hooksJsonPath, { with: { type: "json" } });
       const preToolUse = (hooksJson.default as { hooks: { PreToolUse?: unknown[] } }).hooks
         .PreToolUse;
       assert.ok(Array.isArray(preToolUse) && preToolUse.length > 0, "PreToolUse hooks present");

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -1,0 +1,158 @@
+/**
+ * RED-phase test for the runtime PreToolUse gateguard hook.
+ *
+ * Spec: docs(gateguard) PR #105 amended the docs to call the runtime hook
+ * "roadmap, not bundled." Issue #106 tracks the actual hook implementation.
+ * This file is the failing test that GREEN-phase work must turn green.
+ *
+ * The hook contract follows Claude Code's PreToolUse format:
+ *   stdin  : JSON { tool_name, tool_input }
+ *   stdout : JSON { decision: "allow" | "block", reason?: string }
+ *   exit   : 0 always (decision is in stdout)
+ *
+ * Three-stage gate (per skills/gateguard.md):
+ *   1. DENY  — first Edit/Write/MultiEdit/destructive-Bash blocked, message
+ *              names the facts the agent must present
+ *   2. FORCE — agent presents facts (out of band — model-side discipline)
+ *   3. ALLOW — once a per-session marker exists for the file, retry passes
+ *
+ * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
+ * the gate so the agent can investigate without tripping itself.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, before, after } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const HOOK_PATH = join(REPO_ROOT, "hooks", "gateguard.mjs");
+
+interface HookDecision {
+  decision: "allow" | "block";
+  reason?: string;
+}
+
+function runHook(toolName: string, toolInput: Record<string, unknown>, sessionDir: string): HookDecision {
+  const payload = JSON.stringify({ tool_name: toolName, tool_input: toolInput });
+  const result = spawnSync(process.execPath, [HOOK_PATH], {
+    input: payload,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GATEGUARD_SESSION_DIR: sessionDir,
+    },
+  });
+  assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`);
+  const stdout = result.stdout.trim();
+  assert.notEqual(stdout, "", "hook must emit a JSON decision on stdout");
+  return JSON.parse(stdout) as HookDecision;
+}
+
+describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
+  let sessionDir = "";
+
+  before(() => {
+    sessionDir = mkdtempSync(join(tmpdir(), "gateguard-test-"));
+  });
+
+  after(() => {
+    if (sessionDir) {
+      rmSync(sessionDir, { recursive: true, force: true });
+    }
+  });
+
+  describe("existence", () => {
+    it("hooks/gateguard.mjs is present in the repo", () => {
+      assert.ok(
+        existsSync(HOOK_PATH),
+        `expected ${HOOK_PATH} to exist — see issue #106 acceptance criteria`,
+      );
+    });
+
+    it("hooks/gateguard.mjs is wired as the first PreToolUse hook", async () => {
+      const hooksJson = await import(join(REPO_ROOT, "hooks", "hooks.json"), {
+        with: { type: "json" },
+      });
+      const preToolUse = (hooksJson.default as { hooks: { PreToolUse?: unknown[] } }).hooks
+        .PreToolUse;
+      assert.ok(Array.isArray(preToolUse) && preToolUse.length > 0, "PreToolUse hooks present");
+      const first = (preToolUse[0] as { hooks: Array<{ command: string }> }).hooks[0];
+      assert.match(first.command, /gateguard\.mjs/, "first PreToolUse hook must be gateguard");
+    });
+  });
+
+  describe("DENY stage — first mutating tool call blocks", () => {
+    it("first Write call is blocked with a fact-list reason", () => {
+      const decision = runHook(
+        "Write",
+        { file_path: "scratch.txt", content: "hello" },
+        sessionDir,
+      );
+      assert.equal(decision.decision, "block");
+      assert.match(decision.reason ?? "", /import|require|Glob|user'?s? .*instruction/i);
+    });
+
+    it("first Edit call is blocked with a fact-list reason", () => {
+      const decision = runHook(
+        "Edit",
+        { file_path: "src/lib/plugin-metadata.mts", old_string: "x", new_string: "y" },
+        sessionDir,
+      );
+      assert.equal(decision.decision, "block");
+      assert.match(decision.reason ?? "", /import|public function|user'?s? .*instruction/i);
+    });
+
+    it("destructive Bash (rm -rf) is blocked with rollback-plan demand", () => {
+      const decision = runHook("Bash", { command: "rm -rf node_modules" }, sessionDir);
+      assert.equal(decision.decision, "block");
+      assert.match(decision.reason ?? "", /rollback|delete|destructive/i);
+    });
+  });
+
+  describe("ALLOW stage — read-only and exploratory tools bypass the gate", () => {
+    it("Read is allowed without facts", () => {
+      const decision = runHook("Read", { file_path: "README.md" }, sessionDir);
+      assert.equal(decision.decision, "allow");
+    });
+
+    it("Grep is allowed without facts", () => {
+      const decision = runHook("Grep", { pattern: "TODO" }, sessionDir);
+      assert.equal(decision.decision, "allow");
+    });
+
+    it("Glob is allowed without facts", () => {
+      const decision = runHook("Glob", { pattern: "**/*.ts" }, sessionDir);
+      assert.equal(decision.decision, "allow");
+    });
+
+    it("routine Bash (git status) is allowed", () => {
+      const decision = runHook("Bash", { command: "git status" }, sessionDir);
+      assert.equal(decision.decision, "allow");
+    });
+  });
+
+  describe("ALLOW stage — retry after gate clearance passes", () => {
+    it("Write to a path that has cleared the gate is allowed", () => {
+      const file = "scratch-cleared.txt";
+      const blocked = runHook("Write", { file_path: file, content: "x" }, sessionDir);
+      assert.equal(blocked.decision, "block", "first write blocks");
+
+      // FORCE stage is model-side — the agent presents facts out of band.
+      // The hook records gate clearance via per-session state. Simulate that
+      // clearance by re-invoking with a clearance signal: the second call
+      // carries `_gateguard_facts_presented: true` to indicate the agent has
+      // satisfied the gate. Implementation detail of the hook contract.
+      const allowed = runHook(
+        "Write",
+        { file_path: file, content: "x", _gateguard_facts_presented: true },
+        sessionDir,
+      );
+      assert.equal(allowed.decision, "allow", "second write with facts allowed");
+    });
+  });
+});

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -58,10 +58,12 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         it("hooks/gateguard.mjs is present in the repo", () => {
             assert.ok(existsSync(HOOK_PATH), `expected ${HOOK_PATH} to exist — see issue #106 acceptance criteria`);
         });
-        it("hooks/gateguard.mjs is wired as the first PreToolUse hook", async () => {
-            const hooksJson = await import(join(REPO_ROOT, "hooks", "hooks.json"), {
-                with: { type: "json" },
-            });
+        it("hooks/gateguard.mjs is wired as the first PreToolUse hook in the plugin bundle", async () => {
+            // The runtime hooks.json is generated into the plugin bundle by the build,
+            // not into the repo-root hooks/. Source-of-truth lives in
+            // src/lib/plugin-metadata.mts → getPluginHooksConfig().
+            const hooksJsonPath = join(REPO_ROOT, "plugins", "continuous-improvement", "hooks", "hooks.json");
+            const hooksJson = await import(hooksJsonPath, { with: { type: "json" } });
             const preToolUse = hooksJson.default.hooks
                 .PreToolUse;
             assert.ok(Array.isArray(preToolUse) && preToolUse.length > 0, "PreToolUse hooks present");

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -1,0 +1,121 @@
+/**
+ * RED-phase test for the runtime PreToolUse gateguard hook.
+ *
+ * Spec: docs(gateguard) PR #105 amended the docs to call the runtime hook
+ * "roadmap, not bundled." Issue #106 tracks the actual hook implementation.
+ * This file is the failing test that GREEN-phase work must turn green.
+ *
+ * The hook contract follows Claude Code's PreToolUse format:
+ *   stdin  : JSON { tool_name, tool_input }
+ *   stdout : JSON { decision: "allow" | "block", reason?: string }
+ *   exit   : 0 always (decision is in stdout)
+ *
+ * Three-stage gate (per skills/gateguard.md):
+ *   1. DENY  — first Edit/Write/MultiEdit/destructive-Bash blocked, message
+ *              names the facts the agent must present
+ *   2. FORCE — agent presents facts (out of band — model-side discipline)
+ *   3. ALLOW — once a per-session marker exists for the file, retry passes
+ *
+ * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
+ * the gate so the agent can investigate without tripping itself.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it, before, after } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const HOOK_PATH = join(REPO_ROOT, "hooks", "gateguard.mjs");
+function runHook(toolName, toolInput, sessionDir) {
+    const payload = JSON.stringify({ tool_name: toolName, tool_input: toolInput });
+    const result = spawnSync(process.execPath, [HOOK_PATH], {
+        input: payload,
+        encoding: "utf8",
+        env: {
+            ...process.env,
+            GATEGUARD_SESSION_DIR: sessionDir,
+        },
+    });
+    assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`);
+    const stdout = result.stdout.trim();
+    assert.notEqual(stdout, "", "hook must emit a JSON decision on stdout");
+    return JSON.parse(stdout);
+}
+describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
+    let sessionDir = "";
+    before(() => {
+        sessionDir = mkdtempSync(join(tmpdir(), "gateguard-test-"));
+    });
+    after(() => {
+        if (sessionDir) {
+            rmSync(sessionDir, { recursive: true, force: true });
+        }
+    });
+    describe("existence", () => {
+        it("hooks/gateguard.mjs is present in the repo", () => {
+            assert.ok(existsSync(HOOK_PATH), `expected ${HOOK_PATH} to exist — see issue #106 acceptance criteria`);
+        });
+        it("hooks/gateguard.mjs is wired as the first PreToolUse hook", async () => {
+            const hooksJson = await import(join(REPO_ROOT, "hooks", "hooks.json"), {
+                with: { type: "json" },
+            });
+            const preToolUse = hooksJson.default.hooks
+                .PreToolUse;
+            assert.ok(Array.isArray(preToolUse) && preToolUse.length > 0, "PreToolUse hooks present");
+            const first = preToolUse[0].hooks[0];
+            assert.match(first.command, /gateguard\.mjs/, "first PreToolUse hook must be gateguard");
+        });
+    });
+    describe("DENY stage — first mutating tool call blocks", () => {
+        it("first Write call is blocked with a fact-list reason", () => {
+            const decision = runHook("Write", { file_path: "scratch.txt", content: "hello" }, sessionDir);
+            assert.equal(decision.decision, "block");
+            assert.match(decision.reason ?? "", /import|require|Glob|user'?s? .*instruction/i);
+        });
+        it("first Edit call is blocked with a fact-list reason", () => {
+            const decision = runHook("Edit", { file_path: "src/lib/plugin-metadata.mts", old_string: "x", new_string: "y" }, sessionDir);
+            assert.equal(decision.decision, "block");
+            assert.match(decision.reason ?? "", /import|public function|user'?s? .*instruction/i);
+        });
+        it("destructive Bash (rm -rf) is blocked with rollback-plan demand", () => {
+            const decision = runHook("Bash", { command: "rm -rf node_modules" }, sessionDir);
+            assert.equal(decision.decision, "block");
+            assert.match(decision.reason ?? "", /rollback|delete|destructive/i);
+        });
+    });
+    describe("ALLOW stage — read-only and exploratory tools bypass the gate", () => {
+        it("Read is allowed without facts", () => {
+            const decision = runHook("Read", { file_path: "README.md" }, sessionDir);
+            assert.equal(decision.decision, "allow");
+        });
+        it("Grep is allowed without facts", () => {
+            const decision = runHook("Grep", { pattern: "TODO" }, sessionDir);
+            assert.equal(decision.decision, "allow");
+        });
+        it("Glob is allowed without facts", () => {
+            const decision = runHook("Glob", { pattern: "**/*.ts" }, sessionDir);
+            assert.equal(decision.decision, "allow");
+        });
+        it("routine Bash (git status) is allowed", () => {
+            const decision = runHook("Bash", { command: "git status" }, sessionDir);
+            assert.equal(decision.decision, "allow");
+        });
+    });
+    describe("ALLOW stage — retry after gate clearance passes", () => {
+        it("Write to a path that has cleared the gate is allowed", () => {
+            const file = "scratch-cleared.txt";
+            const blocked = runHook("Write", { file_path: file, content: "x" }, sessionDir);
+            assert.equal(blocked.decision, "block", "first write blocks");
+            // FORCE stage is model-side — the agent presents facts out of band.
+            // The hook records gate clearance via per-session state. Simulate that
+            // clearance by re-invoking with a clearance signal: the second call
+            // carries `_gateguard_facts_presented: true` to indicate the agent has
+            // satisfied the gate. Implementation detail of the hook contract.
+            const allowed = runHook("Write", { file_path: file, content: "x", _gateguard_facts_presented: true }, sessionDir);
+            assert.equal(allowed.decision, "allow", "second write with facts allowed");
+        });
+    });
+});

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -21,7 +21,7 @@
  */
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, it, before, after } from "node:test";
@@ -58,14 +58,16 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         it("hooks/gateguard.mjs is present in the repo", () => {
             assert.ok(existsSync(HOOK_PATH), `expected ${HOOK_PATH} to exist — see issue #106 acceptance criteria`);
         });
-        it("hooks/gateguard.mjs is wired as the first PreToolUse hook in the plugin bundle", async () => {
+        it("hooks/gateguard.mjs is wired as the first PreToolUse hook in the plugin bundle", () => {
             // The runtime hooks.json is generated into the plugin bundle by the build,
             // not into the repo-root hooks/. Source-of-truth lives in
             // src/lib/plugin-metadata.mts → getPluginHooksConfig().
+            // readFileSync + JSON.parse — avoids Node's ESM URL scheme requirement on
+            // Windows (`import("d:\\...")` fails with ERR_UNSUPPORTED_ESM_URL_SCHEME).
             const hooksJsonPath = join(REPO_ROOT, "plugins", "continuous-improvement", "hooks", "hooks.json");
-            const hooksJson = await import(hooksJsonPath, { with: { type: "json" } });
-            const preToolUse = hooksJson.default.hooks
-                .PreToolUse;
+            assert.ok(existsSync(hooksJsonPath), "plugin-bundle hooks.json should exist");
+            const hooksJson = JSON.parse(readFileSync(hooksJsonPath, "utf8"));
+            const preToolUse = hooksJson.hooks.PreToolUse;
             assert.ok(Array.isArray(preToolUse) && preToolUse.length > 0, "PreToolUse hooks present");
             const first = preToolUse[0].hooks[0];
             assert.match(first.command, /gateguard\.mjs/, "first PreToolUse hook must be gateguard");


### PR DESCRIPTION
## Summary

Closes #106. Implements the runtime PreToolUse gateguard hook that PR #105 docs called "roadmap, not bundled." The fact-forcing gate now runs as a real Node.js script that physically blocks Edit/Write/destructive-Bash until investigation is presented, rather than relying on model-side discipline alone.

## Process

This PR went through the dispatcher's two-stage subagent-driven development gate before any GREEN code was written:

- **Stage 1 — feature-dev:code-architect** designed a ~148-LOC two-file solution splitting cleanly into 2 commits, raised 4 open questions.
- **Stage 2 — code-reviewer** issued PROCEED WITH MODIFICATIONS, surfaced 1 CRITICAL (RED test referenced a hooks.json path that doesn't exist at repo root) + 3 HIGH + 2 lower.
- **Stage 3 — implementation** against the modified design with all 5 deltas applied.

The reviewer's CRITICAL caught a defect in my own RED test before any GREEN code was written. That alone justified the second-opinion gate.

## Three-stage gate (per skills/gateguard.md)

- **DENY** — first mutating tool call per file is blocked with a fact-list reason naming importers, public functions affected, data-file schemas, and the user's instruction verbatim.
- **FORCE** — the agent presents facts (model-side, out of band).
- **ALLOW** — retry passes once `_gateguard_facts_presented: true` is set in tool_input or a per-file marker exists in the session state.

Read-only and exploratory tools (Read, Grep, Glob, LS, NotebookRead, routine Bash) bypass unconditionally. Destructive Bash (rm -rf, git reset --hard, --force-with-lease, push --force, DROP DATABASE/SCHEMA, Windows variants like rmdir /s and Remove-Item -Recurse) gates EVERY call, not just first.

## V1 limitations (documented honestly, not mitigated)

- **Honor-system flag** — the hook can't verify the agent actually investigated before flipping `_gateguard_facts_presented: true`. `MAX_CLEARED_FILES = 50` caps stuck-loop / rogue-agent damage to 50 distinct files per session.
- **State-file deletion** — rm'ing the state file resets every gate. Defensible because the session itself is the trust boundary.
- **Parallel-hook race** — two simultaneous hook invocations can race the read+write. Acceptable trade-off vs Windows atomic-rename complexity.
- **MultiEdit** — V1 gates on `edits[0].file_path` only. TODO in module header for full per-file batching.

All four documented in `src/hooks/gateguard.mts` and `src/lib/gateguard-state.mts` headers.

## Commits (5, single-concern)

```
e43349d feat(gateguard): wire as first PreToolUse hook before observe.sh
a574a14 test(gateguard): use readFileSync for hooks.json (Windows ESM URL fix)
bf60c7d feat(gateguard): runtime PreToolUse hook + per-session state lib
02603ee test(gateguard): correct hooks.json import path to plugin-bundle location
b8d56e3 test(gateguard): RED-phase failing test for runtime PreToolUse hook
```

## Test plan

- [x] RED → GREEN: 10/10 gateguard assertions pass after wiring lands
- [x] Full suite: 86 tests, 0 fails (76 pre-existing + 10 new)
- [x] `npm run verify:all` — all 6 lints + typecheck green; everything-mirror grew 30 → 31
- [x] `npm run verify:generated` — no drift between source and bundle outputs
- [ ] Smoke test in fresh Claude Code session: install this branch, ask Claude to write a throwaway file with no research, expect a `block` decision with the fact-list reason. (Becomes the new Check 2 in QUICKSTART once #106 is merged — see #106 acceptance criteria item 8.)

## Follow-up

Once this merges, revert the "runtime gate is roadmap" wording in:
- `QUICKSTART.md` § A note on enforcement
- `README.md` line 41 + § A note on enforcement + skill-table row 3
- `skills/gateguard.md` status banner + Quick Start

That revert ships as a separate single-concern docs PR per CLAUDE.md, not in this feature PR.

## LOC

| File | LOC |
|---|---|
| `src/hooks/gateguard.mts` | ~165 |
| `src/lib/gateguard-state.mts` | ~95 |
| `src/lib/plugin-metadata.mts` delta | +13 net |
| `src/test/gateguard-hook.test.mts` | ~155 (RED+test fixes) |

Total feature surface (excluding tests): ~273 LOC. Came in over the architect's original 200-LOC budget by ~73, mostly from headers/comments documenting V1 limitations and from reviewer-mandated additions to `DESTRUCTIVE_PATTERNS`.

Closes #106.