### PR TITLE
chore(repo): ignore host-local .claude/ and stray agent-skills/ clones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,11 @@ node_modules/
 nanobanana-output/
 *.tmp
 dist/
+
+# Host-local Claude Code runtime state (scheduled_tasks.lock, worktrees/).
+# Recreated per session by the local harness; never source.
+.claude/
+
+# Stray full-clone of upstream addy/agent-skills.
+# Vendored snapshot at third-party/addy-agent-skills/ (pinned via MANIFEST.md) is the source of truth.
+agent-skills/


### PR DESCRIPTION
## Summary

Two pre-push hygiene gaps the workspace-surface-audit flagged:

- **`.claude/`** at repo root holds host-local runtime state (`scheduled_tasks.lock`, `worktrees/`) — recreated per session by the local harness, never source. Was leaking into `git status` as untracked.
- **`agent-skills/`** at repo root was a stray full-clone of upstream addy/agent-skills, duplicating `third-party/addy-agent-skills/` (pinned-SHA snapshot 742dca5 per `third-party/MANIFEST.md`). Risk: accidentally commit and ship two copies.

The vendored snapshot under `third-party/` remains the single source of truth.

## Test plan

- [x] `git status` clean after the .gitignore additions
- [x] `npm run typecheck` passes
- [ ] CI verify:all stays green