### PR TITLE
chore(mcp): add repo-root .mcp.json for dogfooding bin/mcp-server.mjs

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "continuous-improvement-dev": {
+      "command": "node",
+      "args": ["./bin/mcp-server.mjs", "--mode", "expert"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes the audit's own-product blind spot: the plugin ships an MCP server (`bin/mcp-server.mjs`, exposing instincts/observations/reflection) but the dev environment never bound it. End users got it via the install script writing to `~/.claude/settings.json`; the team developing the server itself had no auto-load.

## Scope discipline

- **Server name `continuous-improvement-dev`** (distinct from end-user `continuous-improvement`) — dev binding never collides with an installed plugin on the same machine
- **Relative path `./bin/mcp-server.mjs`** — works from any clone location, resolved against `.mcp.json` directory by Claude Code
- **Mode `expert`** — dev sees the full tool surface; beginner/expert drift surfaces immediately

## Caveat (worth a re-read)

`bin/mcp-server.mjs` is generated by `npm run build`. A fresh clone without a build will fail to start the server, surfacing as an MCP error in the Claude Code UI on session start. Not new behavior (same gap exists for any generated bin entry point) but worth flagging because `.mcp.json` auto-loads.

## Test plan

- [x] JSON valid (`JSON.parse` succeeds)
- [x] Path resolves (`fs.accessSync` on `./bin/mcp-server.mjs`)
- [x] Server bootstraps in expert mode (`continuous-improvement MCP server v3.9.0 started (mode: expert)`)
- [x] `npm run verify:all` green (7/7 invariants, everything-mirror still 35 files — `.mcp.json` is repo-root-only, no plugin-side counterpart)
- [x] `npm test` 533/533 passing
- [ ] CI stays green