### PR TITLE
fix(mcp): emit NDJSON over stdio (MCP transport spec, not LSP framing)

### DIFF
--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -787,8 +787,11 @@ rl.on("line", (line) => {
     }
 });
 function send(response) {
-    const json = JSON.stringify(response);
-    process.stdout.write(`Content-Length: ${Buffer.byteLength(json)}\r\n\r\n${json}`);
+    // MCP stdio transport spec: newline-delimited JSON-RPC over stdout, no
+    // Content-Length headers. Claude Code and every @modelcontextprotocol/sdk
+    // host parse stdout line-by-line; LSP-style framing produces a silent
+    // "Connecting…" hang because no line ever resolves to JSON.
+    process.stdout.write(`${JSON.stringify(response)}\n`);
 }
 function handleMessage(message) {
     const id = message.id;

--- a/plugins/continuous-improvement/bin/mcp-server.mjs
+++ b/plugins/continuous-improvement/bin/mcp-server.mjs
@@ -787,8 +787,11 @@ rl.on("line", (line) => {
     }
 });
 function send(response) {
-    const json = JSON.stringify(response);
-    process.stdout.write(`Content-Length: ${Buffer.byteLength(json)}\r\n\r\n${json}`);
+    // MCP stdio transport spec: newline-delimited JSON-RPC over stdout, no
+    // Content-Length headers. Claude Code and every @modelcontextprotocol/sdk
+    // host parse stdout line-by-line; LSP-style framing produces a silent
+    // "Connecting…" hang because no line ever resolves to JSON.
+    process.stdout.write(`${JSON.stringify(response)}\n`);
 }
 function handleMessage(message) {
     const id = message.id;

--- a/src/bin/mcp-server.mts
+++ b/src/bin/mcp-server.mts
@@ -973,8 +973,11 @@ rl.on("line", (line: string) => {
 });
 
 function send(response: JsonRpcResponse): void {
-  const json = JSON.stringify(response);
-  process.stdout.write(`Content-Length: ${Buffer.byteLength(json)}\r\n\r\n${json}`);
+  // MCP stdio transport spec: newline-delimited JSON-RPC over stdout, no
+  // Content-Length headers. Claude Code and every @modelcontextprotocol/sdk
+  // host parse stdout line-by-line; LSP-style framing produces a silent
+  // "Connecting…" hang because no line ever resolves to JSON.
+  process.stdout.write(`${JSON.stringify(response)}\n`);
 }
 
 function handleMessage(message: JsonRpcMessage): void {

--- a/src/test/mcp-server.test.mts
+++ b/src/test/mcp-server.test.mts
@@ -47,21 +47,20 @@ class McpTestClient {
   }
 
   private drain(): void {
+    // MCP stdio transport spec: NDJSON. Each newline-terminated chunk is one
+    // JSON-RPC message; partial lines stay in the buffer until a newline arrives.
     while (this.resolvers.length > 0) {
-      const bufferString = this.buffer.toString("utf8");
-      const headerMatch = bufferString.match(/^Content-Length: (\d+)\r\n\r\n/);
-      if (!headerMatch) {
+      const newlineIndex = this.buffer.indexOf(0x0a); // '\n'
+      if (newlineIndex === -1) {
         break;
       }
 
-      const headerLength = headerMatch[0].length;
-      const bodyLength = Number.parseInt(headerMatch[1], 10);
-      if (this.buffer.length < headerLength + bodyLength) {
-        break;
+      const lineBytes = this.buffer.slice(0, newlineIndex);
+      this.buffer = this.buffer.slice(newlineIndex + 1);
+      const line = lineBytes.toString("utf8").replace(/\r$/, "");
+      if (line.length === 0) {
+        continue;
       }
-
-      const bodyString = this.buffer.slice(headerLength, headerLength + bodyLength).toString("utf8");
-      this.buffer = this.buffer.slice(headerLength + bodyLength);
 
       const next = this.resolvers.shift();
       if (!next) {
@@ -70,7 +69,7 @@ class McpTestClient {
 
       clearTimeout(next.timer);
       try {
-        next.resolve(JSON.parse(bodyString) as JsonRpcResponse);
+        next.resolve(JSON.parse(line) as JsonRpcResponse);
       } catch (error) {
         next.resolve({
           error: {
@@ -108,6 +107,59 @@ class McpTestClient {
 
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const MCP_SERVER = join(__dirname, "..", "bin", "mcp-server.mjs");
+
+describe("MCP server — stdio wire format", () => {
+  // The MCP stdio transport spec requires newline-delimited JSON-RPC
+  // (NDJSON) over stdout/stdin. NOT LSP-style Content-Length framing.
+  // Claude Code, the @modelcontextprotocol/sdk reference clients, and every
+  // other host parse stdout one line at a time and JSON.parse each line.
+  // A server that emits "Content-Length: ...\r\n\r\n{...}" silently hangs
+  // in the host's "Connecting…" state because no line ever resolves to JSON.
+  it("emits NDJSON responses on stdout (not LSP Content-Length framing)", async () => {
+    const tempHome = join(tmpdir(), `ci-mcp-wire-${Date.now()}`);
+    mkdirSync(join(tempHome, ".claude", "instincts", "global"), { recursive: true });
+
+    const proc = spawn("node", [MCP_SERVER, "--mode", "beginner"], {
+      env: { ...process.env, HOME: tempHome },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    proc.stdout.on("data", (chunk: Buffer) => stdoutChunks.push(chunk));
+
+    proc.stdin.write(
+      `${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`,
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 600));
+
+    const stdoutText = Buffer.concat(stdoutChunks).toString("utf8");
+    proc.kill();
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    try {
+      rmSync(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    } catch {
+      // Windows stdio handle linger
+    }
+
+    assert.ok(
+      !stdoutText.includes("Content-Length:"),
+      `MCP stdio transport must NOT use LSP-style Content-Length framing. ` +
+        `Saw "${stdoutText.slice(0, 80)}". This breaks every host parser, including Claude Code.`,
+    );
+
+    const firstLine = stdoutText.split("\n")[0];
+    assert.ok(firstLine.length > 0, "Expected at least one line of output");
+    const parsed = JSON.parse(firstLine);
+    assert.equal(parsed.jsonrpc, "2.0");
+    assert.equal(parsed.id, 1);
+    assert.ok(parsed.result, "Initialize should return a result");
+    assert.ok(
+      stdoutText.startsWith(firstLine + "\n"),
+      "Each NDJSON message must terminate with a newline",
+    );
+  });
+});
 
 describe("MCP server — beginner mode", () => {
   let client: McpTestClient;

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -18,26 +18,26 @@ class McpTestClient {
         });
     }
     drain() {
+        // MCP stdio transport spec: NDJSON. Each newline-terminated chunk is one
+        // JSON-RPC message; partial lines stay in the buffer until a newline arrives.
         while (this.resolvers.length > 0) {
-            const bufferString = this.buffer.toString("utf8");
-            const headerMatch = bufferString.match(/^Content-Length: (\d+)\r\n\r\n/);
-            if (!headerMatch) {
+            const newlineIndex = this.buffer.indexOf(0x0a); // '\n'
+            if (newlineIndex === -1) {
                 break;
             }
-            const headerLength = headerMatch[0].length;
-            const bodyLength = Number.parseInt(headerMatch[1], 10);
-            if (this.buffer.length < headerLength + bodyLength) {
-                break;
+            const lineBytes = this.buffer.slice(0, newlineIndex);
+            this.buffer = this.buffer.slice(newlineIndex + 1);
+            const line = lineBytes.toString("utf8").replace(/\r$/, "");
+            if (line.length === 0) {
+                continue;
             }
-            const bodyString = this.buffer.slice(headerLength, headerLength + bodyLength).toString("utf8");
-            this.buffer = this.buffer.slice(headerLength + bodyLength);
             const next = this.resolvers.shift();
             if (!next) {
                 break;
             }
             clearTimeout(next.timer);
             try {
-                next.resolve(JSON.parse(bodyString));
+                next.resolve(JSON.parse(line));
             }
             catch (error) {
                 next.resolve({
@@ -72,6 +72,44 @@ class McpTestClient {
 }
 const __dirname = fileURLToPath(new URL(".", import.meta.url));
 const MCP_SERVER = join(__dirname, "..", "bin", "mcp-server.mjs");
+describe("MCP server — stdio wire format", () => {
+    // The MCP stdio transport spec requires newline-delimited JSON-RPC
+    // (NDJSON) over stdout/stdin. NOT LSP-style Content-Length framing.
+    // Claude Code, the @modelcontextprotocol/sdk reference clients, and every
+    // other host parse stdout one line at a time and JSON.parse each line.
+    // A server that emits "Content-Length: ...\r\n\r\n{...}" silently hangs
+    // in the host's "Connecting…" state because no line ever resolves to JSON.
+    it("emits NDJSON responses on stdout (not LSP Content-Length framing)", async () => {
+        const tempHome = join(tmpdir(), `ci-mcp-wire-${Date.now()}`);
+        mkdirSync(join(tempHome, ".claude", "instincts", "global"), { recursive: true });
+        const proc = spawn("node", [MCP_SERVER, "--mode", "beginner"], {
+            env: { ...process.env, HOME: tempHome },
+            stdio: ["pipe", "pipe", "pipe"],
+        });
+        const stdoutChunks = [];
+        proc.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+        proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} })}\n`);
+        await new Promise((resolve) => setTimeout(resolve, 600));
+        const stdoutText = Buffer.concat(stdoutChunks).toString("utf8");
+        proc.kill();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        try {
+            rmSync(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+        }
+        catch {
+            // Windows stdio handle linger
+        }
+        assert.ok(!stdoutText.includes("Content-Length:"), `MCP stdio transport must NOT use LSP-style Content-Length framing. ` +
+            `Saw "${stdoutText.slice(0, 80)}". This breaks every host parser, including Claude Code.`);
+        const firstLine = stdoutText.split("\n")[0];
+        assert.ok(firstLine.length > 0, "Expected at least one line of output");
+        const parsed = JSON.parse(firstLine);
+        assert.equal(parsed.jsonrpc, "2.0");
+        assert.equal(parsed.id, 1);
+        assert.ok(parsed.result, "Initialize should return a result");
+        assert.ok(stdoutText.startsWith(firstLine + "\n"), "Each NDJSON message must terminate with a newline");
+    });
+});
 describe("MCP server — beginner mode", () => {
     let client;
     let tempHome = "";


### PR DESCRIPTION
## Root cause

The MCP server framed responses with LSP-style Content-Length headers:

```
Content-Length: 230\r\n\r\n{...}
```

That is the **Language Server Protocol** wire format. The **Model Context Protocol** stdio transport spec requires **newline-delimited JSON-RPC** — each message is one line of JSON terminated by `\n`. Hosts (Claude Code, every `@modelcontextprotocol/sdk` reference client) parse stdout line-by-line. A line that starts with `Content-Length:` never resolves to JSON, so the host hangs in `Connecting…` forever.

This is exactly what was observed when the dogfood `.mcp.json` from #113 tried to load the server: `continuous-improvement-dev` stuck on Connecting indefinitely while every other MCP server in the same UI (pencil, sequential-thinking, plugin:context7) connected normally — because they all use NDJSON.

## Why tests didn't catch this

The test client in `src/test/mcp-server.test.mts` parsed the same broken framing. 533 tests passed against a server that no real host could talk to. Classic case of a test stub mirroring the bug.

## Fix

- **[`src/bin/mcp-server.mts:975`](src/bin/mcp-server.mts#L975)** — `send()` writes `JSON.stringify + '\n'`, no headers
- **[`src/test/mcp-server.test.mts`](src/test/mcp-server.test.mts)** — `McpTestClient.drain()` now reads NDJSON lines
- **New `stdio wire format` test** — asserts raw stdout has no `Content-Length:` and starts with a valid JSON line followed by `\n`. Added BEFORE the fix per RED-GREEN-REFACTOR; observed failing on LSP framing, observed passing on NDJSON. This guard would have caught the shipping regression.

## Test plan

- [x] Wire-format test fails on LSP framing (RED), passes on NDJSON (GREEN)
- [x] `npm test`: 534/534 (was 533, +1 guard)
- [x] `npm run verify:all`: 7/7 invariants green
- [x] Raw smoke: `echo initialize | node bin/mcp-server.mjs` returns one line of pure NDJSON with no headers — matches what every other working MCP server emits
- [ ] CI stays green
- [ ] After merge: restart Claude Code session in this repo, confirm `continuous-improvement-dev` reaches Connected (not stuck on Connecting)

## Scope

Affects every install of this server, end-user and dev. No data-path change; only response framing.