### PR TITLE
docs(gateguard): revert "runtime gate is roadmap" wording — hook is bundled

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -33,19 +33,26 @@ Without it, `/superpowers` still works — it falls back to inline behavior — 
 
 You should see the 7 Laws quick-reference card. If the command is not recognized after a restart, see Troubleshooting in [README.md](README.md#troubleshooting-install).
 
-**Check 2 — skill registered.** Run:
+**Check 2 — runtime gate is firing.** Ask Claude to write a throwaway file with no research first:
 
 ```
-/dashboard
+Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
 ```
 
-You should see the dashboard render with `Level: CAPTURE` and observation count 0 (or higher). If `/dashboard` is unrecognized after a restart, the install did not complete; rerun the marketplace install.
+You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook with a fact-list reason: list importers, list public functions affected, show data-file schemas, quote the user instruction. That block is the proof the runtime hook is wired and firing. If Claude writes the file with no pause, the hook did not load — see [README.md → Troubleshooting](README.md#troubleshooting-install).
 
-### A note on enforcement
+If you also want to confirm observation hooks: run `/dashboard` and look for a non-zero `Total` under `Observations` — that proves `observe.sh` / `observe.mjs` is recording tool calls.
 
-The 7 Laws are enforced **at the model layer, not the runtime layer**. When you ask Claude to write a file with no research, the bundled `gateguard` skill prompts Claude to investigate first — but this is model-side discipline (the model reads the skill and chooses to comply), not a runtime PreToolUse block that physically refuses the tool call. A future release may add a true runtime hook; until then, the value of the framework comes from the agent reading the Laws as part of its loaded context, not from a tripwire.
+### How enforcement works
 
-If you ever see Claude skip a Law, name it back: *"You skipped Law 1 — research first."* That correction is what trains the instinct system over time.
+The 7 Laws are enforced at **two layers**:
+
+- **Runtime layer (hooks).** `gateguard` ships as a PreToolUse hook (`hooks/gateguard.mjs`) that physically blocks Edit / Write / MultiEdit / destructive Bash on the first mutation per file until the agent presents the facts. Destructive Bash (`rm -rf`, `git push --force`, `--force-with-lease`, `DROP DATABASE`, Windows `Remove-Item -Recurse`, etc.) is gated on every call. Read-only and exploratory tools (Read, Grep, Glob, routine Bash like `git status`) bypass the gate.
+- **Model layer (skills).** When the agent does present facts and the runtime gate clears, the skills (`tdd-workflow`, `verification-loop`, `proceed-with-the-recommendation`, etc.) take over to keep the rest of the loop disciplined. These are model-side — the agent reads each skill and applies it.
+
+Together: the runtime layer catches the failure mode "agent skips investigation," and the model layer catches everything that happens after investigation succeeds.
+
+If you ever see Claude skip a Law that the runtime hook doesn't enforce, name it back: *"You skipped Law 1 — research first."* That correction is what trains the instinct system over time.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Every one of those failures is the agent skipping a step a disciplined engineer 
 ## What you get
 
 - **A 7-step discipline** the agent must follow every task — research → plan → execute one thing → verify → reflect → learn → iterate. Each Law has at least one skill or hook that enforces it.
-- **13 bundled skills** that turn the Laws from a doc into agent behavior — `gateguard` prompts the agent to investigate before Edit/Write/destructive Bash, `tdd-workflow` enforces RED → GREEN → REFACTOR, `verification-loop` runs build/types/tests/security before "done", `proceed-with-the-recommendation` walks any agent's recommendation list top-to-bottom with per-item verification. These run as model-side discipline; the agent reads each skill and applies it. The session and observation hooks (`hooks/`) wire the learning loop, not a runtime tool-call block — see [§ A note on enforcement](#a-note-on-enforcement).
+- **14 bundled skills + a runtime PreToolUse hook** that turn the Laws into enforced behavior — `gateguard` runs as a PreToolUse hook (`hooks/gateguard.mjs`) that physically blocks Edit/Write/destructive Bash until the agent presents fact-list investigation. `tdd-workflow` enforces RED → GREEN → REFACTOR, `verification-loop` runs build/types/tests/security before "done", `deploy-receipt` closes the merge-to-production gap (deployed SHA + healthcheck), `proceed-with-the-recommendation` walks any agent's recommendation list top-to-bottom with per-item verification. The runtime hook catches the "skipped investigation" failure mode at the tool-call layer; the skills run model-side once the gate clears. See [§ How enforcement works](#how-enforcement-works) for the two-layer model.
 - **Mulahazah, the auto-leveling instinct engine** — hooks capture every tool call; after ~20 observations the agent analyzes patterns and creates instincts with confidence scores. Suggestions appear at 0.5+, auto-apply at 0.7+, decay when ignored. Project-scoped, promote to global after 2+ projects. You configure nothing.
 - **A GitHub Action transcript linter** that catches skipped Laws in CI — writes without prior research, edits without verification, too many files at once.
 - **Two install paths** — Beginner is two slash commands inside Claude Code (no Node, no bash, ~90% of users). Expert adds the MCP server, observation hooks, instinct packs, and the linter.
@@ -74,11 +74,22 @@ Without the companion the dispatcher still works — every routing target has a 
 Verify: run `/discipline` in Claude Code — you should see the 7 Laws card.
 If the command is not recognized, restart your Claude Code session first; the marketplace did pick the plugin up but commands load on session start.
 
-**Second-stage verify (proves the bundle dropped beyond just the slash command).** Run `/dashboard` — the rendered card with `Level: CAPTURE` and observation counters confirms the skills + observation hooks landed.
+**Second-stage verify (proves the runtime gate is firing, not just docs claiming it).** Ask Claude to write a throwaway file with no research first:
 
-### A note on enforcement
+```
+Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
+```
 
-The 7 Laws are enforced **at the model layer, not the runtime layer**. When you ask Claude to write a file with no research, `gateguard` prompts Claude to investigate first — but this is model-side discipline (the model reads the skill and chooses to comply), not a PreToolUse hook that physically refuses the tool call. The `hooks/` directory wires observation (`observe.sh`/`observe.mjs`) and end-of-turn three-section close (`three-section-close.mjs`); neither blocks an Edit. A roadmap item tracks adding a true runtime gate — see the open issue linked in [skills/gateguard.md](skills/gateguard.md). Until then, value comes from the agent reading the Laws as part of its loaded context.
+You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook with a fact-list reason. That block is the proof the hook is wired and enforcing. If Claude writes the file with no pause, the hook did not load — see Troubleshooting below. (To also verify observation hooks, run `/dashboard` and confirm a non-zero `Total` under `Observations`.)
+
+### How enforcement works
+
+The 7 Laws are enforced at **two layers**:
+
+- **Runtime layer (hooks).** `gateguard` ships as a PreToolUse hook (`hooks/gateguard.mjs`) that physically blocks Edit / Write / MultiEdit / destructive Bash on the first mutation per file until the agent presents the facts named in [skills/gateguard.md § Gate Types](skills/gateguard.md). Destructive Bash (`rm -rf`, `git push --force`, `--force-with-lease`, `DROP DATABASE`, Windows `Remove-Item -Recurse`, etc.) is gated on every call, not just first. Read-only and exploratory tools (Read, Grep, Glob, routine Bash like `git status`) bypass the gate. Per-session state at `~/.claude/instincts/<project-hash>/gateguard-session.json` caps cumulative clearances at 50 distinct files to bound stuck-loop damage.
+- **Model layer (skills).** Once the runtime gate clears for a file, the rest of the discipline (`tdd-workflow`, `verification-loop`, `proceed-with-the-recommendation`, etc.) runs model-side — the agent reads each skill and applies it. `observe.sh` / `observe.mjs` records every tool call into the Mulahazah feed for instinct extraction; that surface is observational, not enforcement.
+
+V1 honest limitations: the runtime gate is honor-system once the agent flips `_gateguard_facts_presented: true` (the hook can't verify the investigation actually happened); the state file is deletable and parallel hook invocations can race. Documented in `src/hooks/gateguard.mts` and `src/lib/gateguard-state.mts` headers.
 
 ### Expert — adds MCP server, observation hooks, and instinct packs
 
@@ -187,28 +198,29 @@ Every bundled skill, command, and hook enforces at least one of the 7 Laws. The 
 
 ---
 
-## All 13 Skills
+## All 14 Skills
 
-The plugin ships **1 core + 1 featured + 4 tier-1 + 4 tier-2 + 3 always-bundled = 13 skills**. Source-of-truth lives in [`skills/`](skills/) (one `.md` per skill); the plugin bundle at [`plugins/continuous-improvement/skills/`](plugins/continuous-improvement/skills/) is regenerated by `npm run build`.
+The plugin ships **1 core + 1 featured + 5 tier-1 + 4 tier-2 + 3 always-bundled = 14 skills**. Source-of-truth lives in [`skills/`](skills/) (one `.md` per skill); the plugin bundle at [`plugins/continuous-improvement/skills/`](plugins/continuous-improvement/skills/) is regenerated by `npm run build`.
 
 <details>
-<summary>Show the full skill table (13 rows)</summary>
+<summary>Show the full skill table (14 rows)</summary>
 
 | # | Skill | Tier | Law | What it does |
 |---|-------|------|-----|--------------|
 | 1 | [`continuous-improvement`](SKILL.md) | core | — | The 7 Laws spec itself (research → plan → execute → verify → reflect → learn → iterate) |
 | 2 | [`proceed-with-the-recommendation`](skills/proceed-with-the-recommendation.md) ⭐ | featured | all 7 | Walks any agent's recommendation list top-to-bottom, routes each item, verifies per item, halts on `needs-approval` |
-| 3 | [`gateguard`](skills/gateguard.md) | 1 | 1 | Skill that prompts the agent to investigate (importers, schemas, user instruction) before Edit/Write/destructive Bash. Runtime PreToolUse hook is a roadmap item, not yet bundled. |
+| 3 | [`gateguard`](skills/gateguard.md) | 1 | 1 | Runtime PreToolUse hook (`hooks/gateguard.mjs`) + skill: physically blocks Edit/Write/MultiEdit and every destructive Bash until fact-list investigation is presented. Read-only and routine Bash bypass. |
 | 4 | [`para-memory-files`](skills/para-memory-files.md) | 1 | 5 + 7 | Durable file-based memory using PARA (Projects/Areas/Resources/Archives) for cross-session context |
 | 5 | [`tdd-workflow`](skills/tdd-workflow.md) | 1 | 3 + 4 | RED → GREEN → REFACTOR enforcement with 80%+ coverage across unit/integration/E2E |
 | 6 | [`verification-loop`](skills/verification-loop.md) | 1 | 4 | Six-phase verification (build, types, lint, tests, security, diff) with PASS/FAIL report |
-| 7 | [`safety-guard`](skills/safety-guard.md) | 2 | 3 | Three-mode runtime guard (careful/freeze/guard) that blocks destructive commands and locks edits to a directory |
-| 8 | [`strategic-compact`](skills/strategic-compact.md) | 2 | 5 | Suggests `/compact` at logical phase boundaries instead of arbitrary auto-compaction |
-| 9 | [`token-budget-advisor`](skills/token-budget-advisor.md) | 2 | 2 | Token estimator that offers 25/50/75/100% depth choices before answering |
-| 10 | [`wild-risa-balance`](skills/wild-risa-balance.md) | 2 | 2 | Pairs WILD (bold) generation with RISA (safe) execution; splits recommendation lists into pilots above a baseline |
-| 11 | [`ralph`](skills/ralph.md) | companion | 6 | Autonomous loop that executes a PRD story-by-story with quality checks between iterations |
-| 12 | [`superpowers`](skills/superpowers.md) | companion | activator | Law activator — routes tasks to the correct Law-aligned specialist so the right discipline fires automatically |
-| 13 | [`workspace-surface-audit`](skills/workspace-surface-audit.md) | companion | 1 | Audits the active repo, MCP servers, plugins, env, then recommends high-value skills/workflows |
+| 7 | [`deploy-receipt`](skills/deploy-receipt.md) | 1 | 4 | Closes the merge-to-production gap on auto-deploy targets (Railway, Cloudflare Workers, Vercel, Netlify, Fly.io). "Done" requires the deployed SHA matching merged HEAD + a healthcheck returning 200 — runs after the vendored `finishing-a-development-branch`. |
+| 8 | [`safety-guard`](skills/safety-guard.md) | 2 | 3 | Three-mode runtime guard (careful/freeze/guard) that blocks destructive commands and locks edits to a directory |
+| 9 | [`strategic-compact`](skills/strategic-compact.md) | 2 | 5 | Suggests `/compact` at logical phase boundaries instead of arbitrary auto-compaction |
+| 10 | [`token-budget-advisor`](skills/token-budget-advisor.md) | 2 | 2 | Token estimator that offers 25/50/75/100% depth choices before answering |
+| 11 | [`wild-risa-balance`](skills/wild-risa-balance.md) | 2 | 2 | Pairs WILD (bold) generation with RISA (safe) execution; splits recommendation lists into pilots above a baseline |
+| 12 | [`ralph`](skills/ralph.md) | companion | 6 | Autonomous loop that executes a PRD story-by-story with quality checks between iterations |
+| 13 | [`superpowers`](skills/superpowers.md) | companion | activator | Law activator — routes tasks to the correct Law-aligned specialist so the right discipline fires automatically |
+| 14 | [`workspace-surface-audit`](skills/workspace-surface-audit.md) | companion | 1 | Audits the active repo, MCP servers, plugins, env, then recommends high-value skills/workflows |
 
 </details>
 
@@ -294,7 +306,7 @@ A new skill is a fit if it provably enforces (or is a routed activator for) at l
 ### What is *not* automated (the honest limits)
 
 - The Law-coverage matrix above (`## Law Coverage`) is hand-maintained — add your new skill to the right Law row when you ship it.
-- The "All 13 Skills" count in the section header is a literal — bump it when N changes.
+- The "All 14 Skills" count in the section header is a literal — bump it when N changes.
 - Promotion between tiers (e.g. `2` → `1` after it proves itself) is a manual edit to the frontmatter `tier:` field, by design — the maintainer should make that call deliberately.
 
 ---

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -7,9 +7,9 @@ origin: community
 
 # GateGuard — Fact-Forcing Pre-Action Gate
 
-A skill that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+A runtime PreToolUse hook + skill pair that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
 
-> **Implementation status (as of v3.9.0):** GateGuard ships as **model-side discipline only** — the agent loads this skill into context and refuses Edit/Write/destructive Bash until the facts below are presented. A runtime PreToolUse hook that physically blocks the tool call is on the roadmap, tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Until that ships, the gate's strength depends on the agent reading and applying this skill, not on a tripwire that the tool runtime can't bypass.
+> **Implementation status:** GateGuard ships as a **runtime PreToolUse hook** at `hooks/gateguard.mjs`, wired as the first PreToolUse entry in the plugin bundle. The hook physically blocks Edit / Write / MultiEdit and every destructive Bash on stdin/stdout JSON, returning `{decision: "block", reason: "..."}` until the agent presents facts and retries with the per-session clearance signal. This skill file is the human-readable spec the hook implements. Originally tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106) (closed; landed as PR #108).
 
 ## When to Activate
 
@@ -126,15 +126,22 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 ## Quick Start
 
-### Today (v3.9.0): model-side skill
+### Today: runtime hook + skill (zero install beyond the plugin)
 
-The skill is registered when you install the plugin. The agent reads this file and applies the gates listed above before performing any qualifying tool call. No additional config needed — but no runtime tripwire either; the gate fires only when the agent chooses to honor it. If you observe the agent skipping the gate, name the Law back: *"You skipped Law 1 — research first."*
+`hooks/gateguard.mjs` is bundled with this plugin and wired as the first PreToolUse hook in `plugins/continuous-improvement/hooks/hooks.json`. When you install the plugin, the runtime gate is live — no extra config, no opt-in. The hook reads tool input from stdin, classifies it through a data-driven routing table (Read/Grep/Glob → allow, Write/Edit/MultiEdit → mutating-file gate, Bash → destructive-pattern check), and emits `{decision, reason?}` on stdout. Per-session state lives at `~/.claude/instincts/<project-hash>/gateguard-session.json` (override via `GATEGUARD_SESSION_DIR` for tests) and caps cumulative clearances at `MAX_CLEARED_FILES = 50`.
 
-### Roadmap: runtime PreToolUse hook
+Smoke-test the runtime gate after install: ask Claude to write a throwaway file with no research first. The hook should return a `block` decision with a fact-list reason; Claude should pause rather than write.
 
-Tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Will physically block the first Edit/Write per session and every destructive Bash via a `hooks/gateguard.mjs` script wired into `hooks/hooks.json`. Acceptance criteria, RED-GREEN-REFACTOR plan, and out-of-scope items are all in the issue.
+### V1 honest limitations (not mitigated, documented)
 
-### Roadmap: third-party `gateguard-ai` package
+- **Honor system.** Once the agent flips `_gateguard_facts_presented: true` in `tool_input`, the hook can't verify the investigation actually happened. The 50-file cap bounds damage from stuck loops or rogue agents.
+- **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
+- **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
+- **MultiEdit V1.** Currently gates on `edits[0].file_path` only. Per-file batching is a TODO.
+
+All four documented in `src/hooks/gateguard.mts` and `src/lib/gateguard-state.mts` headers.
+
+### Future: third-party `gateguard-ai` package
 
 The standalone `gateguard-ai` Python/CLI package referenced in earlier drafts of this skill is not currently part of this plugin and not a published package. It may ship later with `.gateguard.yml` per-project config; for now, treat it as design notes only.
 

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -7,9 +7,9 @@ origin: community
 
 # GateGuard — Fact-Forcing Pre-Action Gate
 
-A skill that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
+A runtime PreToolUse hook + skill pair that forces the agent to investigate before editing. Instead of self-evaluation ("are you sure?"), it demands concrete facts. The act of investigation creates awareness that self-evaluation never did.
 
-> **Implementation status (as of v3.9.0):** GateGuard ships as **model-side discipline only** — the agent loads this skill into context and refuses Edit/Write/destructive Bash until the facts below are presented. A runtime PreToolUse hook that physically blocks the tool call is on the roadmap, tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Until that ships, the gate's strength depends on the agent reading and applying this skill, not on a tripwire that the tool runtime can't bypass.
+> **Implementation status:** GateGuard ships as a **runtime PreToolUse hook** at `hooks/gateguard.mjs`, wired as the first PreToolUse entry in the plugin bundle. The hook physically blocks Edit / Write / MultiEdit and every destructive Bash on stdin/stdout JSON, returning `{decision: "block", reason: "..."}` until the agent presents facts and retries with the per-session clearance signal. This skill file is the human-readable spec the hook implements. Originally tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106) (closed; landed as PR #108).
 
 ## When to Activate
 
@@ -126,15 +126,22 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 ## Quick Start
 
-### Today (v3.9.0): model-side skill
+### Today: runtime hook + skill (zero install beyond the plugin)
 
-The skill is registered when you install the plugin. The agent reads this file and applies the gates listed above before performing any qualifying tool call. No additional config needed — but no runtime tripwire either; the gate fires only when the agent chooses to honor it. If you observe the agent skipping the gate, name the Law back: *"You skipped Law 1 — research first."*
+`hooks/gateguard.mjs` is bundled with this plugin and wired as the first PreToolUse hook in `plugins/continuous-improvement/hooks/hooks.json`. When you install the plugin, the runtime gate is live — no extra config, no opt-in. The hook reads tool input from stdin, classifies it through a data-driven routing table (Read/Grep/Glob → allow, Write/Edit/MultiEdit → mutating-file gate, Bash → destructive-pattern check), and emits `{decision, reason?}` on stdout. Per-session state lives at `~/.claude/instincts/<project-hash>/gateguard-session.json` (override via `GATEGUARD_SESSION_DIR` for tests) and caps cumulative clearances at `MAX_CLEARED_FILES = 50`.
 
-### Roadmap: runtime PreToolUse hook
+Smoke-test the runtime gate after install: ask Claude to write a throwaway file with no research first. The hook should return a `block` decision with a fact-list reason; Claude should pause rather than write.
 
-Tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106). Will physically block the first Edit/Write per session and every destructive Bash via a `hooks/gateguard.mjs` script wired into `hooks/hooks.json`. Acceptance criteria, RED-GREEN-REFACTOR plan, and out-of-scope items are all in the issue.
+### V1 honest limitations (not mitigated, documented)
 
-### Roadmap: third-party `gateguard-ai` package
+- **Honor system.** Once the agent flips `_gateguard_facts_presented: true` in `tool_input`, the hook can't verify the investigation actually happened. The 50-file cap bounds damage from stuck loops or rogue agents.
+- **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
+- **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
+- **MultiEdit V1.** Currently gates on `edits[0].file_path` only. Per-file batching is a TODO.
+
+All four documented in `src/hooks/gateguard.mts` and `src/lib/gateguard-state.mts` headers.
+
+### Future: third-party `gateguard-ai` package
 
 The standalone `gateguard-ai` Python/CLI package referenced in earlier drafts of this skill is not currently part of this plugin and not a published package. It may ship later with `.gateguard.yml` per-project config; for now, treat it as design notes only.
 


### PR DESCRIPTION
## Summary

PR #108 (commit `fa6a4e6`) shipped the runtime PreToolUse hook at `hooks/gateguard.mjs` and wired it as the first PreToolUse entry in the plugin bundle. Issue #106 closed at merge time. The user-facing docs (`QUICKSTART.md`, `README.md`, `skills/gateguard.md`, plus the bundled `plugins/continuous-improvement/skills/gateguard/SKILL.md` mirror) still claimed:

- "The 7 Laws are enforced **at the model layer, not the runtime layer**."
- "GateGuard ships as **model-side discipline only**."
- "A runtime PreToolUse hook ... is on the roadmap, tracked in [issue #106](https://github.com/naimkatiman/continuous-improvement/issues/106)."

That is inverse claim-vs-reality drift — the symmetric mistake to the pre-#108 lie that PR #105 already had to amend. New users reading the install path are told the gate is theoretical when it is in fact firing.

## Changes

- **QUICKSTART.md**: Check 2 reverted from a `/dashboard` placeholder back to the gateguard-pause smoke test (now actually fires); enforcement note rewritten as a two-layer model — runtime hook + model skills — instead of model-side-only.
- **README.md**: gateguard description on the "What you get" line names the bundled PreToolUse hook explicitly with file path; second-stage verify breadcrumb reinstated; § How enforcement works renamed and rewritten as two-layer with V1 honest limitations called out (honor-system flag, deletable state file, parallel-hook race); skill-table row 3 swapped from "Skill that prompts" to runtime+skill.
- **skills/gateguard.md**: "v3.9.0 model-side only" status banner replaced with current shipping reality + #106 closure breadcrumb; Quick Start rewritten to lead with the bundled hook (no extra install), V1 limitations named, `gateguard-ai` third-party design notes preserved as future scope.
- **plugins/continuous-improvement/skills/gateguard/SKILL.md**: build-output mirror of the source skill, regenerated by `npm run build`.

## Auto-memory captured

Saved `feedback_grep_hook_before_claim.md` so the audit-twice rule (verify hook file + wiring before user-facing copy promises runtime behavior, symmetric on bundled-but-docs-say-roadmap drift) doesn't have to be re-learned. PR #105 origin → PR #108 fix → this PR closes the symmetric inverse drift.

## Scope

Single concern: gateguard truth revert. The deploy-receipt skill count bump (13 → 14) and the new table row at index 7 were already on `main` from a prior linter / parallel-actor pass — no additional commit needed in this PR.

## Test plan

- [x] `npm run build` clean
- [x] `npm run verify:all` — all 6 lints + typecheck green
  - skill-mirror 14/14, skill-tiers 14/14, skill-law-tag 14/14, docs-substrings 144/144, everything-mirror 35/35, routing-targets 37/37
- [ ] Smoke test in fresh Claude Code session: install plugin from main with this PR merged, ask Claude to write a throwaway file with no research first. Expect a `block` decision with the fact-list reason — that proves the doc claim and the runtime gate now agree.