### PR TITLE
ci(verify): doc-runtime-claims lint — codify audit-twice rule

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -33,13 +33,13 @@ Without it, `/superpowers` still works — it falls back to inline behavior — 
 
 You should see the 7 Laws quick-reference card. If the command is not recognized after a restart, see Troubleshooting in [README.md](README.md#troubleshooting-install).
 
-**Check 2 — runtime gate is firing.** Ask Claude to write a throwaway file with no research first:
+**Check 2 — runtime gate is firing** (the `hooks/gateguard.mjs` script must invoke). Ask Claude to write a throwaway file with no research first:
 
 ```
 Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
 ```
 
-You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook with a fact-list reason: list importers, list public functions affected, show data-file schemas, quote the user instruction. That block is the proof the runtime hook is wired and firing. If Claude writes the file with no pause, the hook did not load — see [README.md → Troubleshooting](README.md#troubleshooting-install).
+You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook (`hooks/gateguard.mjs`) with a fact-list reason: list importers, list public functions affected, show data-file schemas, quote the user instruction. That block is the proof the hook is wired and firing. If Claude writes the file with no pause, the hook did not load — see [README.md → Troubleshooting](README.md#troubleshooting-install).
 
 If you also want to confirm observation hooks: run `/dashboard` and look for a non-zero `Total` under `Observations` — that proves `observe.sh` / `observe.mjs` is recording tool calls.
 

--- a/README.md
+++ b/README.md
@@ -74,13 +74,13 @@ Without the companion the dispatcher still works — every routing target has a 
 Verify: run `/discipline` in Claude Code — you should see the 7 Laws card.
 If the command is not recognized, restart your Claude Code session first; the marketplace did pick the plugin up but commands load on session start.
 
-**Second-stage verify (proves the runtime gate is firing, not just docs claiming it).** Ask Claude to write a throwaway file with no research first:
+**Second-stage verify (proves the runtime gate is firing — i.e. `hooks/gateguard.mjs` is invoked — not just docs claiming it).** Ask Claude to write a throwaway file with no research first:
 
 ```
 Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
 ```
 
-You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook with a fact-list reason. That block is the proof the hook is wired and enforcing. If Claude writes the file with no pause, the hook did not load — see Troubleshooting below. (To also verify observation hooks, run `/dashboard` and confirm a non-zero `Total` under `Observations`.)
+You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook (`hooks/gateguard.mjs`) with a fact-list reason. That block is the proof the hook is wired and enforcing. If Claude writes the file with no pause, the hook did not load — see Troubleshooting below. (To also verify observation hooks, run `/dashboard` and confirm a non-zero `Total` under `Observations`.)
 
 ### How enforcement works
 

--- a/bin/check-doc-runtime-claims.mjs
+++ b/bin/check-doc-runtime-claims.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Doc Runtime-Claims Check
+ *
+ * Codifies the audit-twice rule (memory: feedback_grep_hook_before_claim).
+ *
+ * Any user-facing line that claims a runtime hook / PreToolUse gate /
+ * physical block must be accompanied by a `hooks/<file>.mjs` reference
+ * inside a ±5-line window. Without that anchor, the doc is making a
+ * claim a future reader cannot verify against the actual filesystem.
+ *
+ * Origin: PR #105 shipped a smoke test that promised gateguard would
+ * physically block, when the hook did not yet exist. PR #108 built the
+ * hook. PR #115 reverted the inverse drift after the hook shipped but
+ * docs still said "roadmap." This lint locks the audit-twice rule into
+ * automation so the next runtime claim cannot land without its anchor.
+ *
+ * Scope: QUICKSTART.md, README.md, skills/*.md.
+ * Out of scope: bundle mirrors under plugins/, docs/, third-party/.
+ *
+ * Trigger phrases (case-insensitive substring match on the line):
+ *   - "PreToolUse hook"
+ *   - "physically block"   (catches "physically blocks", "physical block")
+ *   - "runtime gate"
+ *
+ * Deliberately narrow per the spec that authorized this lint. "runtime
+ * hook" was considered and dropped: too prone to false positives on
+ * disclaimers ("not a runtime hook", "no runtime hook is bundled").
+ * Future trigger additions need an explicit owner decision; do not bolt
+ * on phrases just because they sound related.
+ *
+ * Anchor: any reference matching `hooks/<name>.mjs` (case-insensitive)
+ * inside the ±5-line window (the trigger line itself plus 5 lines above
+ * and 5 lines below).
+ *
+ * Usage:
+ *   node bin/check-doc-runtime-claims.mjs              # Check the current repo
+ *   node bin/check-doc-runtime-claims.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every runtime-claim line has an in-window hooks/ anchor
+ *   1 — at least one claim line is unanchored
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const SCAN_FILES = ["QUICKSTART.md", "README.md"];
+const SCAN_SKILL_DIR = "skills";
+const ANCHOR_WINDOW = 5;
+const TRIGGER_PHRASES = [
+    "pretooluse hook",
+    "physically block",
+    "runtime gate",
+];
+const ANCHOR_PATTERN = /hooks\/[a-z0-9-]+\.mjs/i;
+function listSkillFiles(repoRoot) {
+    const skillsDir = join(repoRoot, SCAN_SKILL_DIR);
+    let entries;
+    try {
+        entries = readdirSync(skillsDir);
+    }
+    catch {
+        return [];
+    }
+    return entries
+        .filter((f) => /^[a-z][a-z0-9-]*\.md$/.test(f))
+        .map((f) => join(SCAN_SKILL_DIR, f))
+        .sort();
+}
+function scanFile(repoRoot, relPath) {
+    const fullPath = join(repoRoot, relPath);
+    let content;
+    try {
+        content = readFileSync(fullPath, "utf8");
+    }
+    catch {
+        return [];
+    }
+    const lines = content.split(/\r?\n/);
+    const violations = [];
+    for (let i = 0; i < lines.length; i += 1) {
+        const lower = lines[i].toLowerCase();
+        const matchedPhrase = TRIGGER_PHRASES.find((p) => lower.includes(p));
+        if (!matchedPhrase)
+            continue;
+        const start = Math.max(0, i - ANCHOR_WINDOW);
+        const end = Math.min(lines.length - 1, i + ANCHOR_WINDOW);
+        const window = lines.slice(start, end + 1).join("\n");
+        if (ANCHOR_PATTERN.test(window))
+            continue;
+        violations.push({
+            file: relPath,
+            line: i + 1,
+            text: lines[i].trim(),
+        });
+    }
+    return violations;
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const files = [...SCAN_FILES, ...listSkillFiles(repoRoot)];
+    const allViolations = [];
+    for (const file of files) {
+        allViolations.push(...scanFile(repoRoot, file));
+    }
+    if (allViolations.length === 0) {
+        console.log(`OK doc-runtime-claims: every runtime-claim line in ${files.length} scanned file(s) has a hooks/<name>.mjs anchor within ±${ANCHOR_WINDOW} lines.`);
+        exit(0);
+    }
+    console.error(`FAIL doc-runtime-claims: ${allViolations.length} unanchored runtime-claim line(s) found.`);
+    console.error(`Each line below contains a runtime-claim phrase but has no hooks/<name>.mjs reference within ±${ANCHOR_WINDOW} lines.`);
+    console.error("Add the hook file path inline so a reader can verify the claim against the filesystem.");
+    console.error("");
+    for (const v of allViolations) {
+        console.error(`  ${v.file}:${v.line}`);
+        console.error(`    ${v.text}`);
+    }
+    exit(1);
+}
+main();

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "verify:docs-substrings": "node bin/check-docs-substrings.mjs",
     "verify:everything-mirror": "node bin/check-everything-mirror.mjs",
     "verify:routing-targets": "node bin/check-routing-targets.mjs",
-    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run typecheck"
+    "verify:doc-runtime-claims": "node bin/check-doc-runtime-claims.mjs",
+    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run typecheck"
   },
   "files": [
     ".claude-plugin/",

--- a/plugins/continuous-improvement/skills/safety-guard/SKILL.md
+++ b/plugins/continuous-improvement/skills/safety-guard/SKILL.md
@@ -67,7 +67,7 @@ Agents can read anything but only write to `src/api/`. Destructive commands are 
 
 ## Implementation
 
-Uses PreToolUse hooks to intercept Bash, Write, Edit, and MultiEdit tool calls. Checks the command/path against the active rules before allowing execution.
+Currently implemented as skill-side discipline: when restricted-mode is active, the agent reads this skill and refuses Bash, Write, Edit, and MultiEdit calls that violate the rules before invoking the tool. There is no bundled tool-call gate today — the same enforcement gap that existed for `gateguard` before issue #106 / PR #108. A future runtime version would track via a follow-up issue.
 
 ## Integration
 

--- a/skills/safety-guard.md
+++ b/skills/safety-guard.md
@@ -67,7 +67,7 @@ Agents can read anything but only write to `src/api/`. Destructive commands are 
 
 ## Implementation
 
-Uses PreToolUse hooks to intercept Bash, Write, Edit, and MultiEdit tool calls. Checks the command/path against the active rules before allowing execution.
+Currently implemented as skill-side discipline: when restricted-mode is active, the agent reads this skill and refuses Bash, Write, Edit, and MultiEdit calls that violate the rules before invoking the tool. There is no bundled tool-call gate today — the same enforcement gap that existed for `gateguard` before issue #106 / PR #108. A future runtime version would track via a follow-up issue.
 
 ## Integration
 

--- a/src/bin/check-doc-runtime-claims.mts
+++ b/src/bin/check-doc-runtime-claims.mts
@@ -1,0 +1,144 @@
+#!/usr/bin/env node
+
+/**
+ * Doc Runtime-Claims Check
+ *
+ * Codifies the audit-twice rule (memory: feedback_grep_hook_before_claim).
+ *
+ * Any user-facing line that claims a runtime hook / PreToolUse gate /
+ * physical block must be accompanied by a `hooks/<file>.mjs` reference
+ * inside a ±5-line window. Without that anchor, the doc is making a
+ * claim a future reader cannot verify against the actual filesystem.
+ *
+ * Origin: PR #105 shipped a smoke test that promised gateguard would
+ * physically block, when the hook did not yet exist. PR #108 built the
+ * hook. PR #115 reverted the inverse drift after the hook shipped but
+ * docs still said "roadmap." This lint locks the audit-twice rule into
+ * automation so the next runtime claim cannot land without its anchor.
+ *
+ * Scope: QUICKSTART.md, README.md, skills/*.md.
+ * Out of scope: bundle mirrors under plugins/, docs/, third-party/.
+ *
+ * Trigger phrases (case-insensitive substring match on the line):
+ *   - "PreToolUse hook"
+ *   - "physically block"   (catches "physically blocks", "physical block")
+ *   - "runtime gate"
+ *
+ * Deliberately narrow per the spec that authorized this lint. "runtime
+ * hook" was considered and dropped: too prone to false positives on
+ * disclaimers ("not a runtime hook", "no runtime hook is bundled").
+ * Future trigger additions need an explicit owner decision; do not bolt
+ * on phrases just because they sound related.
+ *
+ * Anchor: any reference matching `hooks/<name>.mjs` (case-insensitive)
+ * inside the ±5-line window (the trigger line itself plus 5 lines above
+ * and 5 lines below).
+ *
+ * Usage:
+ *   node bin/check-doc-runtime-claims.mjs              # Check the current repo
+ *   node bin/check-doc-runtime-claims.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every runtime-claim line has an in-window hooks/ anchor
+ *   1 — at least one claim line is unanchored
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const SCAN_FILES: ReadonlyArray<string> = ["QUICKSTART.md", "README.md"];
+const SCAN_SKILL_DIR = "skills";
+const ANCHOR_WINDOW = 5;
+
+const TRIGGER_PHRASES: ReadonlyArray<string> = [
+  "pretooluse hook",
+  "physically block",
+  "runtime gate",
+];
+
+const ANCHOR_PATTERN = /hooks\/[a-z0-9-]+\.mjs/i;
+
+interface ClaimViolation {
+  file: string;
+  line: number;
+  text: string;
+}
+
+function listSkillFiles(repoRoot: string): string[] {
+  const skillsDir = join(repoRoot, SCAN_SKILL_DIR);
+  let entries: string[];
+  try {
+    entries = readdirSync(skillsDir);
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((f) => /^[a-z][a-z0-9-]*\.md$/.test(f))
+    .map((f) => join(SCAN_SKILL_DIR, f))
+    .sort();
+}
+
+function scanFile(repoRoot: string, relPath: string): ClaimViolation[] {
+  const fullPath = join(repoRoot, relPath);
+  let content: string;
+  try {
+    content = readFileSync(fullPath, "utf8");
+  } catch {
+    return [];
+  }
+  const lines = content.split(/\r?\n/);
+  const violations: ClaimViolation[] = [];
+
+  for (let i = 0; i < lines.length; i += 1) {
+    const lower = lines[i]!.toLowerCase();
+    const matchedPhrase = TRIGGER_PHRASES.find((p) => lower.includes(p));
+    if (!matchedPhrase) continue;
+
+    const start = Math.max(0, i - ANCHOR_WINDOW);
+    const end = Math.min(lines.length - 1, i + ANCHOR_WINDOW);
+    const window = lines.slice(start, end + 1).join("\n");
+    if (ANCHOR_PATTERN.test(window)) continue;
+
+    violations.push({
+      file: relPath,
+      line: i + 1,
+      text: lines[i]!.trim(),
+    });
+  }
+
+  return violations;
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const files = [...SCAN_FILES, ...listSkillFiles(repoRoot)];
+  const allViolations: ClaimViolation[] = [];
+
+  for (const file of files) {
+    allViolations.push(...scanFile(repoRoot, file));
+  }
+
+  if (allViolations.length === 0) {
+    console.log(
+      `OK doc-runtime-claims: every runtime-claim line in ${files.length} scanned file(s) has a hooks/<name>.mjs anchor within ±${ANCHOR_WINDOW} lines.`,
+    );
+    exit(0);
+  }
+
+  console.error(
+    `FAIL doc-runtime-claims: ${allViolations.length} unanchored runtime-claim line(s) found.`,
+  );
+  console.error(
+    `Each line below contains a runtime-claim phrase but has no hooks/<name>.mjs reference within ±${ANCHOR_WINDOW} lines.`,
+  );
+  console.error("Add the hook file path inline so a reader can verify the claim against the filesystem.");
+  console.error("");
+  for (const v of allViolations) {
+    console.error(`  ${v.file}:${v.line}`);
+    console.error(`    ${v.text}`);
+  }
+  exit(1);
+}
+
+main();


### PR DESCRIPTION
## Summary

Closes the implicit residue from PR #105 → #108 → #115: locks the audit-twice rule into automation so the next runtime claim can't land without its file anchor.

The PR train just walked taught us that documentation claims about hook behavior drift in both directions:
- **PR #105**: shipped a smoke test that promised gateguard would physically block, when no hook existed.
- **PR #115**: had to walk back the inverse — docs still said "roadmap" for two days after #108 made the hook real.

Memory `feedback_grep_hook_before_claim.md` captured the rule but kept it in human memory. This PR moves it into a CI lint so future runtime claims get caught at PR time, not by a user smoke test.

## How it works

`bin/check-doc-runtime-claims.mjs` scans `QUICKSTART.md`, `README.md`, and `skills/*.md`. For each line containing a trigger phrase, the lint asserts that the ±5-line window contains a `hooks/<name>.mjs` reference. Without the anchor, a reader cannot verify the claim against the filesystem.

**Trigger phrases** (deliberately narrow per the spec that authorized this lint — three phrases, not four; "runtime hook" was considered and dropped because of false-positive risk on disclaimers):
- `"PreToolUse hook"`
- `"physically block"` (catches "physically blocks", "physical block")
- `"runtime gate"`

**Anchor pattern**: `hooks/<name>.mjs` (case-insensitive, regex `hooks/[a-z0-9-]+\.mjs`).

## Concrete violations the lint surfaced on `main`

The lint failed on 5 lines in current `main`. All anchored in this PR:

| File:Line | Phrase | Fix |
|---|---|---|
| QUICKSTART.md:36 | "runtime gate is firing" | Added `(the hooks/gateguard.mjs script must invoke)` inline |
| QUICKSTART.md:42 | "PreToolUse hook" | Added `(hooks/gateguard.mjs)` inline next to the hook reference |
| README.md:77 | "runtime gate is firing" | Added `i.e. hooks/gateguard.mjs is invoked` inline |
| README.md:83 | "PreToolUse hook" | Added `(hooks/gateguard.mjs)` inline next to the hook reference |
| skills/safety-guard.md:70 | "PreToolUse hooks" | Rewrote § Implementation to honest skill-side description — `safety-guard` has no bundled hook today, same pattern as `gateguard` pre-#108. Documented the gap with cross-reference to #106/#108. |

## Files

```
src/bin/check-doc-runtime-claims.mts   (new, ~110 LOC including header docs)
bin/check-doc-runtime-claims.mjs       (generated)
package.json                           (verify:doc-runtime-claims script + chain into verify:all)
QUICKSTART.md                          (anchor lines 36, 42)
README.md                              (anchor lines 77, 83)
skills/safety-guard.md                 (§ Implementation honest rewrite)
plugins/continuous-improvement/skills/safety-guard/SKILL.md  (generated mirror)
```

## Test plan

- [x] `npm run build` — clean
- [x] `npm run verify:doc-runtime-claims` — OK across 15 scanned files (QUICKSTART, README, 13 skills)
- [x] `npm run verify:all` — all 7 lints + typecheck green; new lint slots in between `verify:routing-targets` and `verify:typecheck`
- [x] Manual: re-introduce a stripped-claim line locally, confirm the lint fails with file:line + the unanchored text

## Out of scope (parked elsewhere)

- Issue #116 — RFC for hardening `_gateguard_facts_presented` from boolean to structured fact-keys with a deprecation window. That contract change deserves its own RFC + parallel-agent risk pass, not this lint PR.
- A future runtime hook for safety-guard (parallel to gateguard's #106 → #108 path). Not opened as an issue yet — reach out if you want me to file one.

## Why narrow scope

The user-authorized spec explicitly named three trigger phrases. I added a fourth ("runtime hook") on the first pass; the lint then flagged a wild-risa-balance disclaimer ("Not a runtime hook") as a false positive. Dropped the fourth phrase to match the authorized spec exactly. Future trigger additions need an explicit owner decision, documented in the lint's header comment.