### PR TITLE
ci(release): tag-triggered npm publish + RELEASING.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,59 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build generated artifacts
+        run: npm run build
+
+      - name: Verify generated artifacts are committed
+        run: git diff --exit-code -- .claude-plugin bin test lib plugins
+
+      - name: Run verify:all
+        run: npm run verify:all
+
+      - name: Run tests
+        run: node --test test/*.test.mjs
+
+      - name: Verify tag matches package.json version
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION="${GITHUB_REF#refs/tags/v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "ERROR: tag v$TAG_VERSION does not match package.json version $PKG_VERSION"
+            echo "Bump package.json on a release PR before tagging."
+            exit 1
+          fi
+          echo "✓ tag v$TAG_VERSION matches package.json $PKG_VERSION"
+
+      - name: Publish to npm
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create "$GITHUB_REF_NAME" --generate-notes --verify-tag

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,85 @@
+# Releasing continuous-improvement
+
+The release pipeline is **tag-triggered**. Pushing a `v*` tag publishes the npm package and cuts a GitHub Release. Plugin marketplace consumers get new content the moment changes land on `main` — no extra release step required for them.
+
+## What ships, and how
+
+| Surface | Trigger | Mechanism |
+|---|---|---|
+| **Plugin marketplace** (`/plugin install`) | Merge to `main` | Claude Code clients fetch `.claude-plugin/marketplace.json` from `main` on demand. Consumers refresh with `/plugin update continuous-improvement`. |
+| **npm package** (`npm install -g continuous-improvement`) | Tag push (`v*`) | `.github/workflows/release.yml` runs `npm publish` and creates a GitHub Release. |
+
+## Cutting a release
+
+### 1. Bump version on a release PR
+
+The PR contains the version bump and nothing else.
+
+```bash
+git switch main
+git pull --ff-only origin main
+git switch -c chore/release-vX.Y.Z
+npm version X.Y.Z --no-git-tag-version
+git add package.json package-lock.json
+git commit -m "chore(release): cut vX.Y.Z"
+git push -u origin chore/release-vX.Y.Z
+gh pr create --title "chore(release): cut vX.Y.Z" --body "Release bump for X.Y.Z."
+```
+
+### 2. Merge the PR
+
+Squash-merge once CI is green. `main` now has the bumped `package.json`.
+
+### 3. Tag the merge commit
+
+```bash
+git switch main
+git pull --ff-only origin main
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### 4. The workflow does the rest
+
+`release.yml` runs on the tag push:
+
+1. `npm ci` + `npm run build`
+2. `git diff --exit-code` to ensure generated artifacts are committed
+3. `npm run verify:all` (7 invariants + typecheck)
+4. `node --test test/*.test.mjs`
+5. Asserts `package.json` version equals the tag
+6. `npm publish --access public`
+7. `gh release create --generate-notes`
+
+If any step fails the publish does not happen and the tag remains unpublished. Fix forward with a new patch tag.
+
+## Required GitHub secrets
+
+| Secret | Source | Purpose |
+|---|---|---|
+| `NPM_TOKEN` | npmjs.com → Access Tokens → Granular automation token with publish access to `continuous-improvement` | Authenticates `npm publish` |
+
+Set under **Settings → Secrets and variables → Actions → New repository secret**.
+
+## Verifying a release shipped
+
+```bash
+npm view continuous-improvement version    # matches the tag
+gh run list --workflow=release.yml -L 1    # shows the latest run as success
+gh release view vX.Y.Z                     # shows generated notes
+```
+
+## Rollback
+
+npm has a 72-hour unpublish window, but **deprecate instead** — unpublishing breaks dependents.
+
+```bash
+npm deprecate continuous-improvement@X.Y.Z "Use X.Y.W instead — see <issue link>"
+```
+
+Then cut a new patch release that supersedes the bad version.
+
+## Optional upgrades
+
+- **npm provenance** — once npm trusted publisher is configured for this repo, change the publish step to `npm publish --provenance --access public`. The workflow already sets `id-token: write`.
+- **Tag protection** — under Settings → Tags → New rule, require admin role to create `v*` tags. Stops accidental tag pushes from triggering a publish.


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release.yml` — runs on `v*` tag push, gates publish behind `verify:all`, build-diff check, full test suite, and a tag-equals-`package.json` assertion, then runs `npm publish --access public` and `gh release create --generate-notes`.
- Adds `docs/RELEASING.md` — bump-on-PR → tag-on-merge → workflow-publishes flow, required `NPM_TOKEN` secret, deprecate-don't-unpublish rollback path, optional provenance + tag-protection upgrades.

Closes the npm-publish gap that left repo at 3.9.0 while npm latest stayed at 3.8.0. After this lands, "update every project" is one command per maintainer (`git tag vX.Y.Z && git push origin vX.Y.Z`) and one command per consumer (`npm install -g continuous-improvement@latest` or `/plugin update`).

Plugin marketplace surface is untouched — it already updates on merge to `main` via `.claude-plugin/marketplace.json` being live-fetched.

## Test plan
- [x] `npm run verify:all` green in worktree (7 invariants + typecheck)
- [x] `npm test` green in worktree (534/534)
- [x] `git status` shows only the 2 new files (no generated-artifact drift)
- [ ] Add `NPM_TOKEN` repo secret before tagging the next release (one-time setup)
- [ ] First real exercise: cut `v3.9.1` (or whatever version follows merge) to validate end-to-end publish

## Notes
- Provenance (`--provenance`) deliberately omitted from v1 to avoid surprise failures if npm trusted publisher isn't configured. `id-token: write` permission is set so it can be enabled later by changing one flag — see `docs/RELEASING.md` "Optional upgrades".
- Workflow uses `--verify-tag` on `gh release create` to refuse untagged commits.