### PR TITLE
chore(release): cut v3.9.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",


### PR DESCRIPTION
## Summary
- First-exercise patch bump (3.9.0 → 3.9.1) to smoke-test the tag-triggered publish pipeline added in #119.
- Deliberately tiny: only `package.json` + `package-lock.json` move. Keeps the "test the workflow" concern separate from any feature release.

## Test plan
- [x] `npm run verify:all` clean in worktree
- [x] `npm test` 534/534 in worktree
- [ ] After squash-merge: tag `v3.9.1` on main + push → release.yml runs → `npm view continuous-improvement version` returns 3.9.1 → GitHub Release v3.9.1 page exists with generated notes.