### PR TITLE
fix(third-party): preserve upstream empty .claude/commands/ in addy-agent-skills snapshot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,11 @@ dist/
 # Recreated per session by the local harness; never source.
 .claude/
 
+# Exception: vendored snapshots may legitimately ship a .claude/ subtree
+# (e.g. addy-agent-skills/.claude/commands/ is referenced by upstream's plugin.json).
+!third-party/*/.claude/
+!third-party/*/.claude/**
+
 # Stray full-clone of upstream addy/agent-skills.
 # Vendored snapshot at third-party/addy-agent-skills/ (pinned via MANIFEST.md) is the source of truth.
 agent-skills/

--- a/third-party/MANIFEST.md
+++ b/third-party/MANIFEST.md
@@ -168,6 +168,13 @@ cp -r /tmp/addy-agent-skills-refresh/{skills,agents,hooks,references,docs,.claud
 cp /tmp/addy-agent-skills-refresh/{LICENSE,README.md,AGENTS.md,CONTRIBUTING.md} \
   third-party/addy-agent-skills/
 
+# Preserve upstream's empty .claude/commands/ directory (referenced by plugin.json's
+# "commands" key). Git does not track empty dirs, so add a .gitkeep sentinel.
+# Without this, /plugin install agent-skills@continuous-improvement fails with
+# "Path not found: ...\agent-skills\1.0.0\.claude\commands (commands)".
+mkdir -p third-party/addy-agent-skills/.claude/commands
+touch third-party/addy-agent-skills/.claude/commands/.gitkeep
+
 # Remove every CLAUDE.md inside the snapshot — they auto-load as session context.
 find third-party/addy-agent-skills -name CLAUDE.md -type f -delete
 


### PR DESCRIPTION
## Summary

- `/plugin install agent-skills@continuous-improvement` fails with `Path not found: ...\agent-skills\1.0.0\.claude\commands (commands)` because the vendored snapshot is missing a directory the upstream plugin manifest references.
- Root cause: upstream addy-agent-skills at pinned SHA `742dca5` ships an **empty** `.claude/commands/` directory whose path is declared in `.claude-plugin/plugin.json` (`"commands": "./.claude/commands"`). Git does not track empty directories, and the refresh recipe in `third-party/MANIFEST.md` only copies `.claude-plugin/` (not `.claude/`), so the directory got dropped from the snapshot.
- Fix: add a `.gitkeep` sentinel under `third-party/addy-agent-skills/.claude/commands/` to mirror upstream verbatim. No manifest patching — snapshot stays byte-aligned with upstream.

## Changes

| File | Change |
|---|---|
| `third-party/addy-agent-skills/.claude/commands/.gitkeep` | New empty sentinel — preserves upstream's empty directory in git |
| `.gitignore` | Whitelist `third-party/*/.claude/**` so vendored snapshots can ship a `.claude/` subtree without colliding with the host-runtime `.claude/` ignore rule |
| `third-party/MANIFEST.md` | Update addy refresh recipe to recreate the `.gitkeep` sentinel on future SHA bumps |

Three files. Single concern. No `.mts`/`.mjs` touched. No upstream-snapshot file content modified — only a sentinel added to preserve an empty upstream directory.

## Verification

- `npm run verify:all` — all 7 invariants green (skill-mirror, skill-tiers, skill-law-tag, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims)
- `npm run typecheck` — 0 errors
- `git check-ignore` confirms the new `.gitkeep` is tracked, not ignored
- Upstream verification: `gh api repos/addyosmani/agent-skills/contents/.claude?ref=742dca58ae557bc67afec9ea8e6de59c085f0534` confirms upstream has `.claude/commands/` (size 0) at the pinned SHA

## Test plan

- [ ] CI green
- [ ] On a host with the snapshot synced, `/plugin install agent-skills@continuous-improvement` succeeds without "Path not found" error
- [ ] `/plugin` lists `agent-skills@continuous-improvement` as healthy (no plugin error in `/doctor` diagnostics block)
- [ ] After restart, addy's 21 skills become loadable via prompt match (e.g. spec-driven-development)

## Notes

- This is the first edit inside `third-party/<name>/` that ships in a PR. It is **adding** a sentinel that mirrors upstream's empty directory, not modifying any verbatim upstream file content. The CLAUDE.md "never edit files inside `third-party/<name>/` directly" guard is intended for content drift; preserving an upstream empty directory is the opposite — it brings the snapshot closer to upstream-verbatim, not further from it.
- The empty `.claude/commands/` directory exists upstream because addy presumably plans to ship slash commands there in a future release. When that happens, the next SHA refresh will populate it and the `.gitkeep` becomes inert (stays alongside real files, no collision).