### PR TITLE
fix(plugin-metadata): derive VERSION from package.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -1,5 +1,9 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.9.0";
+const PKG_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+export const VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -1,5 +1,9 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.9.0";
+const PKG_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+export const VERSION = JSON.parse(readFileSync(PKG_PATH, "utf8")).version;
 export const PLUGIN_MODES = ["beginner", "expert"];
 const REPOSITORY_URL = "https://github.com/naimkatiman/continuous-improvement";
 const HOMEPAGE_URL = `${REPOSITORY_URL}#readme`;

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
   "tools": [

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -1,5 +1,11 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
 export const PACKAGE_NAME = "continuous-improvement";
-export const VERSION = "3.9.0";
+
+const PKG_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "package.json");
+export const VERSION: string = (JSON.parse(readFileSync(PKG_PATH, "utf8")) as { version: string }).version;
 
 export const PLUGIN_MODES = ["beginner", "expert"] as const;
 


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `export const VERSION = "3.9.0"` in `src/lib/plugin-metadata.mts` with a runtime read of `package.json`.
- Regenerates the 7 downstream artifacts so all surfaces (npm, marketplace listing, plugin manifest) now report the same number.

## Why
After v3.9.1 published to npm (#120 / commit f1bdfed), plugin-marketplace consumers running `/plugin update continuous-improvement` were still seeing **3.9.0** in `.claude-plugin/marketplace.json` and `plugins/continuous-improvement/.claude-plugin/plugin.json` because the version was hardcoded in the .mts source. CI's `git diff --exit-code` couldn't catch it — the generator faithfully reproduced a stale constant.

After this PR, future release-bump PRs only touch `package.json` + `package-lock.json`. `npm run build` propagates the new version to:
- `lib/plugin-metadata.mjs` (+ mirror under `plugins/continuous-improvement/lib/`)
- `.claude-plugin/marketplace.json` (+ mirror)
- `plugins/continuous-improvement/.claude-plugin/plugin.json`
- `plugins/{beginner,expert}.json`

CI's existing `verify:generated` invariant catches any drift for free.

## Test plan
- [x] `src/lib/plugin-metadata.mts` reads via `import.meta.url` → `..` → `package.json` (no CWD dependency, works at runtime regardless of where Node is invoked from)
- [x] `npm run build` → all 4 generators report regeneration; manifest version fields equal package.json (3.9.1) in worktree
- [x] `npm run verify:all` green (7 invariants + typecheck)
- [x] `npm test` 534/534 in worktree
- [x] `node -e "import('./lib/plugin-metadata.mjs').then(m => console.log(m.VERSION))"` prints `3.9.1`
- [ ] After merge: cut v3.9.2 release to confirm marketplace listing finally updates (separate PR)

## Notes
- Type assertion `as { version: string }` keeps strict TS happy without adding a separate type module.
- Path math: `src/` → `./` per tsconfig (`rootDir: "src"`, `outDir: "."`), so the compiled `.mjs` lives at repo-root/`lib/`. One `..` from `import.meta.url`'s dirname reaches the repo root.
- Single-concern PR; no other behavior changes.