### PR TITLE
chore(release): cut v3.9.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
-      "version": "3.9.1",
+      "version": "3.9.2",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.9.1",
+  "version": "3.9.2",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## Summary
- First release using the auto-derived VERSION flow from #122.
- Touches `package.json` + `package-lock.json` + the 5 generated manifests; **no source-code constant change** — just `npm version 3.9.2 --no-git-tag-version && npm run build`.

## Why now
Validates end-to-end that #122's auto-derive works: bumping `package.json` propagates to `marketplace.json`, `plugin.json`, `beginner.json`, `expert.json`, and the mirrored marketplace under `plugins/continuous-improvement/`. CI's `git diff --exit-code` proves it; this PR is the receipt.

## Test plan
- [x] `npm version 3.9.2 --no-git-tag-version`
- [x] `npm run build` regenerates 4 generators; all manifest `version` fields = `3.9.2`
- [x] `npm run verify:all` clean in worktree
- [ ] After squash-merge: tag `v3.9.2` on main, push tag, release.yml runs, `npm view continuous-improvement version` returns 3.9.2, `gh release view v3.9.2` shows generated notes