### PR TITLE
fix(observe): canonicalize MSYS-mounted paths in bash fallback

### DIFF
--- a/hooks/observe.sh
+++ b/hooks/observe.sh
@@ -101,6 +101,20 @@ fi
 # ---------------------------------------------------------------------------
 # Compute project hash and name
 # ---------------------------------------------------------------------------
+# Canonicalize MSYS-mounted Windows paths (/d/Path) to native form (D:/Path)
+# so the bash fallback hashes to the same project bucket as the Node observer.
+# Without this, Git Bash on Windows produces /d/Ai/repo from `git rev-parse`
+# while Node's child_process produces D:/Ai/repo for the same physical path,
+# splitting telemetry between two SHA-256 buckets per project.
+# Pattern matches /<single-letter>/... only — Linux/macOS paths like /usr,
+# /home, /Users are unaffected.
+case "$PROJECT_ROOT" in
+  /[a-zA-Z]/*)
+    drive_letter="$(printf '%s' "$PROJECT_ROOT" | cut -c2 | tr '[:lower:]' '[:upper:]')"
+    PROJECT_ROOT="${drive_letter}:$(printf '%s' "$PROJECT_ROOT" | cut -c3-)"
+    ;;
+esac
+
 PROJECT_HASH="$(printf '%s' "$PROJECT_ROOT" | sha256sum | cut -c1-12)"
 PROJECT_NAME="$(basename "${PROJECT_ROOT%.git}")"
 

--- a/plugins/continuous-improvement/hooks/observe.sh
+++ b/plugins/continuous-improvement/hooks/observe.sh
@@ -101,6 +101,20 @@ fi
 # ---------------------------------------------------------------------------
 # Compute project hash and name
 # ---------------------------------------------------------------------------
+# Canonicalize MSYS-mounted Windows paths (/d/Path) to native form (D:/Path)
+# so the bash fallback hashes to the same project bucket as the Node observer.
+# Without this, Git Bash on Windows produces /d/Ai/repo from `git rev-parse`
+# while Node's child_process produces D:/Ai/repo for the same physical path,
+# splitting telemetry between two SHA-256 buckets per project.
+# Pattern matches /<single-letter>/... only — Linux/macOS paths like /usr,
+# /home, /Users are unaffected.
+case "$PROJECT_ROOT" in
+  /[a-zA-Z]/*)
+    drive_letter="$(printf '%s' "$PROJECT_ROOT" | cut -c2 | tr '[:lower:]' '[:upper:]')"
+    PROJECT_ROOT="${drive_letter}:$(printf '%s' "$PROJECT_ROOT" | cut -c3-)"
+    ;;
+esac
+
 PROJECT_HASH="$(printf '%s' "$PROJECT_ROOT" | sha256sum | cut -c1-12)"
 PROJECT_NAME="$(basename "${PROJECT_ROOT%.git}")"
 


### PR DESCRIPTION
## Summary
- `hooks/observe.sh` (bash fallback) and `bin/observe.mjs` (Node observer) hashed the same physical project to two different SHA-256 buckets on Windows because Git Bash returns `/d/Ai/repo` from `git rev-parse --show-toplevel` while Node's `child_process` returns `D:/Ai/repo` for the same path.
- Telemetry, instincts, and `ci_dashboard` reporting were silently split across two `~/.claude/instincts/<hash>/` directories per repo whenever an operator used both Git Bash and a Windows-native shell during a project's lifetime.
- This patch canonicalizes the leading MSYS mounted-drive segment in the bash fallback before hashing, so `/d/Path` and `D:/Path` collapse to one bucket. The Node observer is unchanged because it already produces the canonical form.

## Evidence
On the reporting host, 9 of 22 project hashes were duplicates of the same repo, accounting for ~40% of indexed telemetry being unfindable from the canonical bucket. Affected projects observed in the wild: continuous-improvement, MiniTelegramApp, Mobile, Roboforex, STOX, tradeclaw, tg-trading-apps, Personal, and one secondary continuous-improvement bifurcation that recreated mid-session.

## Behavior
- Pattern: `case /[a-zA-Z]/*` matches MSYS mounted-drive paths only (`/d/...`, `/c/...`). Linux/macOS paths like `/usr`, `/home`, `/Users` are unaffected because the second segment after the leading slash is more than one letter before the next `/`.
- Round-trip self-test confirms `/d/Ai/continuous-improvement` and `D:/Ai/continuous-improvement` now hash to the same 12-char prefix.
- Mirror invariant satisfied: same patch applied to `hooks/observe.sh` and `plugins/continuous-improvement/hooks/observe.sh`.

## Test plan
- [x] `npm run verify:all` — all 7 invariants green (skill-mirror, skill-tiers, skill-law-tag, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims, typecheck)
- [x] `bash -n hooks/observe.sh` — syntax OK
- [x] Manual canonicalization round-trip: both `/d/...` and `D:/...` hash to `38c17ae973a4` for `Ai/continuous-improvement`
- [ ] Reviewer to sanity-check the case-glob portability against zsh-as-bash hosts