### PR TITLE
docs(releasing): add npm run build step before staging release bump

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -13,18 +13,26 @@ The release pipeline is **tag-triggered**. Pushing a `v*` tag publishes the npm 
 
 ### 1. Bump version on a release PR
 
-The PR contains the version bump and nothing else.
+The PR contains the version bump and the regenerated plugin manifests — nothing else. `src/lib/plugin-metadata.mts` derives `VERSION` from `package.json` at runtime, so `npm run build` propagates the bump to all 5 generated manifests automatically. You never edit a constant.
 
 ```bash
 git switch main
 git pull --ff-only origin main
 git switch -c chore/release-vX.Y.Z
 npm version X.Y.Z --no-git-tag-version
-git add package.json package-lock.json
+npm run build
+git add package.json package-lock.json \
+  .claude-plugin/marketplace.json \
+  plugins/continuous-improvement/.claude-plugin/marketplace.json \
+  plugins/continuous-improvement/.claude-plugin/plugin.json \
+  plugins/beginner.json \
+  plugins/expert.json
 git commit -m "chore(release): cut vX.Y.Z"
 git push -u origin chore/release-vX.Y.Z
 gh pr create --title "chore(release): cut vX.Y.Z" --body "Release bump for X.Y.Z."
 ```
+
+If you forget `npm run build`, CI fails at `git diff --exit-code -- .claude-plugin bin test lib plugins`. Loud failure, not silent — just rebuild, restage the regenerated files, and push a new commit.
 
 ### 2. Merge the PR
 


### PR DESCRIPTION
## Summary
After #122 made VERSION auto-derived from `package.json`, the release-PR recipe in `docs/RELEASING.md` step 1 was incomplete: it stops at `git add package.json package-lock.json` without first rebuilding. That leaves the 5 generated manifests (`.claude-plugin/marketplace.json`, the mirrored copy, `plugin.json`, `plugins/{beginner,expert}.json`) stale, and CI's `git diff --exit-code -- .claude-plugin bin test lib plugins` fails on the release PR.

This PR:
- Inserts `npm run build` between `npm version` and `git add`
- Expands the `git add` line to enumerate the 5 regenerated manifest paths explicitly (matching the no-`git add .` discipline already in CLAUDE.md)
- Adds a one-line note explaining the loud-failure mode so the next maintainer who forgets recovers fast instead of debugging CI

## Test plan
- [x] `npm run verify:all` clean in worktree (`docs-substrings` invariant intact — no broken cross-references)
- [x] No code change; doc-only edit
- [ ] Validate by following the recipe verbatim on next real release (any version after 3.9.2)

## Why now
`v3.9.2` shipped via this exact corrected sequence (manual fix-up); doc lagged. Closing the gap before the next maintainer hits CI red on a release PR they followed the doc to write.