### PR TITLE
feat(handoff): port mattpocock /handoff as native skill + cold-storage vendor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Project-local rules for AI coding agents. Global rules live in `~/.claude/CLAUDE
 
 ## third-party vendoring contract
 
-- The 4 vendored companions (`third-party/superpowers/`, `third-party/addy-agent-skills/`, `third-party/ruflo-swarm/`, `third-party/oh-my-claudecode/`) are **pinned-SHA snapshots**.
+- The 5 vendored companions (`third-party/superpowers/`, `third-party/addy-agent-skills/`, `third-party/ruflo-swarm/`, `third-party/oh-my-claudecode/`, `third-party/mattpocock-skills/`) are **pinned-SHA snapshots**.
 - Each snapshot must carry `MANIFEST.md` (SHA + version), `OUR_NOTES.md` (drift radar + integration scope), `CLAUDE.md` (read-only guard).
 - To refresh a snapshot: `node bin/refresh-third-party.mjs <name>` from a worktree off `origin/main`.
 - Never edit files inside `third-party/<name>/` directly — those are verbatim upstream copies. Cross-cutting integration code lives outside the snapshot.

--- a/commands/handoff.md
+++ b/commands/handoff.md
@@ -1,0 +1,42 @@
+---
+name: handoff
+description: "Compact the current conversation into a handoff document for another agent to pick up. Ported from mattpocock/skills under MIT."
+argument-hint: "What will the next session be used for?"
+---
+
+# /handoff
+
+Hand the current session off to a fresh agent by writing a brief, mktemp-backed markdown summary they can pick up cold.
+
+## Trigger phrases
+
+- `/handoff`
+- `/handoff <what the next session will focus on>`
+- "write a handoff doc"
+- "compact this into a handoff"
+
+## What happens
+
+1. Read the current conversation (and the user's argument, if given) to identify the goal, current state, decisions made, open questions, next concrete step, and skills to load.
+2. Generate a unique path with `mktemp -t handoff-XXXXXX.md` and read it (it will be empty).
+3. Write the handoff doc to that path. Reference PRDs, plans, ADRs, issues, commits, and diffs by path or URL — do not duplicate their content.
+4. Suggest the skills the next session should load.
+
+## What goes in the doc
+
+A one-screen brief, in this order:
+
+1. **Goal** — one sentence on the outcome the user is steering toward.
+2. **Current state** — what is actually true on disk / in the system right now.
+3. **Decisions made this session** — only what is not already captured in commits or other artifacts.
+4. **Open questions** — blocking choices the next agent needs the user to answer.
+5. **Next concrete step** — the single action the next agent should take first.
+6. **Skills to load** — names of the skills the next session should activate.
+
+## Skill file
+
+Full behavior is defined in [`skills/handoff.md`](../skills/handoff.md). The verbatim upstream cold-storage copy lives at [`third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md`](../third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md); SHA pin in [`third-party/MANIFEST.md`](../third-party/MANIFEST.md).
+
+## Attribution
+
+Ported from [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md) (MIT, © 2026 Matt Pocock).

--- a/plugins/continuous-improvement/commands/handoff.md
+++ b/plugins/continuous-improvement/commands/handoff.md
@@ -1,0 +1,42 @@
+---
+name: handoff
+description: "Compact the current conversation into a handoff document for another agent to pick up. Ported from mattpocock/skills under MIT."
+argument-hint: "What will the next session be used for?"
+---
+
+# /handoff
+
+Hand the current session off to a fresh agent by writing a brief, mktemp-backed markdown summary they can pick up cold.
+
+## Trigger phrases
+
+- `/handoff`
+- `/handoff <what the next session will focus on>`
+- "write a handoff doc"
+- "compact this into a handoff"
+
+## What happens
+
+1. Read the current conversation (and the user's argument, if given) to identify the goal, current state, decisions made, open questions, next concrete step, and skills to load.
+2. Generate a unique path with `mktemp -t handoff-XXXXXX.md` and read it (it will be empty).
+3. Write the handoff doc to that path. Reference PRDs, plans, ADRs, issues, commits, and diffs by path or URL — do not duplicate their content.
+4. Suggest the skills the next session should load.
+
+## What goes in the doc
+
+A one-screen brief, in this order:
+
+1. **Goal** — one sentence on the outcome the user is steering toward.
+2. **Current state** — what is actually true on disk / in the system right now.
+3. **Decisions made this session** — only what is not already captured in commits or other artifacts.
+4. **Open questions** — blocking choices the next agent needs the user to answer.
+5. **Next concrete step** — the single action the next agent should take first.
+6. **Skills to load** — names of the skills the next session should activate.
+
+## Skill file
+
+Full behavior is defined in [`skills/handoff.md`](../skills/handoff.md). The verbatim upstream cold-storage copy lives at [`third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md`](../third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md); SHA pin in [`third-party/MANIFEST.md`](../third-party/MANIFEST.md).
+
+## Attribution
+
+Ported from [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md) (MIT, © 2026 Matt Pocock).

--- a/plugins/continuous-improvement/skills/README.md
+++ b/plugins/continuous-improvement/skills/README.md
@@ -23,6 +23,7 @@ skill set on disk.
 - `verification-loop` — Enforces Law 4 (Verify Before Reporting) of the 7 Laws of AI Agent Discipline. A comprehensive verification system for agent coding sessions covering build, types, lint, tests, security, and diff with a PASS/FAIL report.
 
 ## Tier 2 — expert-mode add-ons
+- `handoff` — Enforces Law 5 (Reflect After Every Session) of the 7 Laws of AI Agent Discipline. Compact the current conversation into a handoff document for another agent to pick up. Ported from mattpocock/skills under MIT.
 - `recovery-classification` — Enforces Law 4 (Verify Before Reporting) of the 7 Laws of AI Agent Discipline. After any failure in the verification ladder or auto-loop, classify the failure class before retrying — provider, tool-schema, deterministic-policy, git, worktree, runtime — so retry-vs-pause-vs-self-heal-vs-stop is an intentional decision, not a generic 'try again'.
 - `safety-guard` — Enforces Law 3 (One Thing at a Time) of the 7 Laws of AI Agent Discipline by scoping edits to a directory and blocking destructive shell commands. Use this skill to prevent destructive operations when working on production systems or running agents autonomously.
 - `state-reconciliation` — Enforces Law 4 (Verify Before Reporting) of the 7 Laws of AI Agent Discipline. Pre-dispatch invariant: reconcile DB-vs-disk-vs-memory state before any unit runs, so a stale flag, missing artifact, or out-of-sync row never re-dispatches a unit that already completed or never started.

--- a/plugins/continuous-improvement/skills/handoff/SKILL.md
+++ b/plugins/continuous-improvement/skills/handoff/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: handoff
+tier: "2"
+description: Enforces Law 5 (Reflect After Every Session) of the 7 Laws of AI Agent Discipline. Compact the current conversation into a handoff document for another agent to pick up. Ported from mattpocock/skills under MIT.
+argument-hint: "What will the next session be used for?"
+origin: https://github.com/mattpocock/skills
+---
+
+# /handoff — Hand the session off to a fresh agent
+
+Ported verbatim in behavior from [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md) (MIT, © 2026 Matt Pocock). Cold-storage snapshot at [`third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md`](../third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md); SHA pin in [`third-party/MANIFEST.md`](../third-party/MANIFEST.md).
+
+## What this skill does
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.
+
+## When to fire it
+
+- End of a working session that did not finish the task — you want the next agent to pick up cold without re-reading the whole transcript.
+- Context budget approaching the ceiling and `/compact` would lose load-bearing state — write a handoff doc first, then compact.
+- Switching from one repo or branch to another mid-session — capture what was decided in the active context before the swap.
+- Before invoking a long-running autonomous loop (`/ralph`, `/loop`) that will run while you are away.
+
+## What goes in the doc
+
+The handoff is a brief, not a transcript. A useful one fits on one screen and answers, in order:
+
+1. **Goal** — the one-sentence outcome the user is steering toward.
+2. **Current state** — what is actually true on disk / in the system right now (branch, last commit, open files, last verified step).
+3. **Decisions made this session** — only what is not already in commits, PRDs, ADRs, or the plan doc.
+4. **Open questions** — blocking choices the next agent needs the user to answer before continuing.
+5. **Next concrete step** — the single action the next agent should take first.
+6. **Skills to load** — names of the skills the next session should activate (e.g. `verification-loop`, `superpowers:writing-plans`, `gateguard`).
+
+Anything that is already captured elsewhere gets a path or URL pointer, not a duplicate.
+
+## How it fits the 7 Laws
+
+| Law | Role of this skill |
+|---|---|
+| Law 5 (Reflect After Every Session) | The handoff is the reflection artifact — what changed, what was decided, what remains. |
+| Law 7 (Learn From Every Session) | Naming the skills the next session should activate is a learned-pattern signal. |
+| Law 2 (Plan Is Sacred) | The "next concrete step" preserves the existing plan across the session boundary instead of restarting from blank. |
+
+## Companion / alternative skills
+
+- [`strategic-compact`](./strategic-compact.md) — compact the current session at a phase boundary instead of writing a handoff doc. Use when the session continues with the same agent.
+- [`para-memory-files`](./para-memory-files.md) — durable cross-session memory under `~/.claude/memory/`. Use for classified facts (user, project, feedback, reference), not per-session handoff briefs.
+- `superpowers:writing-plans` — produce the plan doc the handoff can reference instead of duplicating.
+
+## Attribution
+
+This skill is a port of [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md). MIT-licensed upstream, MIT-licensed here. See [`third-party/mattpocock-skills/LICENSE`](../third-party/mattpocock-skills/LICENSE) for the verbatim license and [`third-party/mattpocock-skills/OUR_NOTES.md`](../third-party/mattpocock-skills/OUR_NOTES.md) for the vendoring rationale and drift radar.

--- a/skills/README.md
+++ b/skills/README.md
@@ -44,6 +44,7 @@ These ship in the same plugin bundle regardless of mode and are available the mo
 |-------|--------------|--------|
 | `ralph` | Autonomous loop that executes a PRD story-by-story with quality checks between iterations | [snarktank/ralph](https://github.com/snarktank/ralph) |
 | `superpowers` | **Law activator.** Routes tasks to the correct Law-aligned specialist (brainstorming → Law 2, writing-plans → Law 2, TDD → Law 3+4, verification-before-completion → Law 4, etc.) so the right discipline fires automatically. Not a peer skill — a dispatcher for the others. | [obra/superpowers](https://github.com/obra/superpowers) |
+| `handoff` | One-shot session compaction into an `mktemp`-backed markdown brief a fresh agent can pick up cold — goal, current state, decisions, open questions, next step, skills to load | [mattpocock/skills](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md) |
 | `workspace-surface-audit` | Audits the active repo, MCP servers, plugins, and env, then recommends high-value skills/workflows | continuous-improvement |
 
 ## How they get to your machine

--- a/skills/handoff.md
+++ b/skills/handoff.md
@@ -1,0 +1,59 @@
+---
+name: handoff
+tier: "2"
+description: Enforces Law 5 (Reflect After Every Session) of the 7 Laws of AI Agent Discipline. Compact the current conversation into a handoff document for another agent to pick up. Ported from mattpocock/skills under MIT.
+argument-hint: "What will the next session be used for?"
+origin: https://github.com/mattpocock/skills
+---
+
+# /handoff — Hand the session off to a fresh agent
+
+Ported verbatim in behavior from [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md) (MIT, © 2026 Matt Pocock). Cold-storage snapshot at [`third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md`](../third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md); SHA pin in [`third-party/MANIFEST.md`](../third-party/MANIFEST.md).
+
+## What this skill does
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.
+
+## When to fire it
+
+- End of a working session that did not finish the task — you want the next agent to pick up cold without re-reading the whole transcript.
+- Context budget approaching the ceiling and `/compact` would lose load-bearing state — write a handoff doc first, then compact.
+- Switching from one repo or branch to another mid-session — capture what was decided in the active context before the swap.
+- Before invoking a long-running autonomous loop (`/ralph`, `/loop`) that will run while you are away.
+
+## What goes in the doc
+
+The handoff is a brief, not a transcript. A useful one fits on one screen and answers, in order:
+
+1. **Goal** — the one-sentence outcome the user is steering toward.
+2. **Current state** — what is actually true on disk / in the system right now (branch, last commit, open files, last verified step).
+3. **Decisions made this session** — only what is not already in commits, PRDs, ADRs, or the plan doc.
+4. **Open questions** — blocking choices the next agent needs the user to answer before continuing.
+5. **Next concrete step** — the single action the next agent should take first.
+6. **Skills to load** — names of the skills the next session should activate (e.g. `verification-loop`, `superpowers:writing-plans`, `gateguard`).
+
+Anything that is already captured elsewhere gets a path or URL pointer, not a duplicate.
+
+## How it fits the 7 Laws
+
+| Law | Role of this skill |
+|---|---|
+| Law 5 (Reflect After Every Session) | The handoff is the reflection artifact — what changed, what was decided, what remains. |
+| Law 7 (Learn From Every Session) | Naming the skills the next session should activate is a learned-pattern signal. |
+| Law 2 (Plan Is Sacred) | The "next concrete step" preserves the existing plan across the session boundary instead of restarting from blank. |
+
+## Companion / alternative skills
+
+- [`strategic-compact`](./strategic-compact.md) — compact the current session at a phase boundary instead of writing a handoff doc. Use when the session continues with the same agent.
+- [`para-memory-files`](./para-memory-files.md) — durable cross-session memory under `~/.claude/memory/`. Use for classified facts (user, project, feedback, reference), not per-session handoff briefs.
+- `superpowers:writing-plans` — produce the plan doc the handoff can reference instead of duplicating.
+
+## Attribution
+
+This skill is a port of [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md). MIT-licensed upstream, MIT-licensed here. See [`third-party/mattpocock-skills/LICENSE`](../third-party/mattpocock-skills/LICENSE) for the verbatim license and [`third-party/mattpocock-skills/OUR_NOTES.md`](../third-party/mattpocock-skills/OUR_NOTES.md) for the vendoring rationale and drift radar.

--- a/third-party/MANIFEST.md
+++ b/third-party/MANIFEST.md
@@ -243,6 +243,59 @@ find third-party/ruflo-swarm -name CLAUDE.md -type f -delete
 
 > **Driver integration deferred.** Adding a `ruflo-swarm` SNAPSHOTS entry to `bin/refresh-third-party.mjs` is tracked as the same follow-up PR as `addy-agent-skills` — see `docs/plans/2026-05-07-ruflo-swarm-vendor.md` § "Deferred follow-ups". The recipe above is the source of truth in the meantime.
 
+### mattpocock/skills
+
+| Field | Value |
+|---|---|
+| Upstream | https://github.com/mattpocock/skills |
+| License | MIT |
+| Pinned SHA | `9fecab929abb904c68ce3366a1781df31ab22832` |
+| Snapshot date | 2026-05-11 |
+| Snapshot size | ~2 KB, 2 files |
+| Upstream version at SHA | unversioned (newsletter-tracked) |
+| Local path | `third-party/mattpocock-skills/` |
+
+Cherry-picked **single skill** (`handoff`) from a 25+ skill repository, addressing the per-session compaction-to-handoff-doc gap that `strategic-compact`, `para-memory-files`, and the global `wrap` skill do not cover. Cold-storage only — **not** loaded by `plugins/continuous-improvement/` and **not** registered in `.claude-plugin/marketplace.json`. The user-facing exposure is via `skills/handoff.md` + `commands/handoff.md`, which credit Matt Pocock and link back to this snapshot. The full vendoring rationale and drift radar live in `third-party/mattpocock-skills/OUR_NOTES.md`.
+
+**Selective scope (verbatim from upstream):**
+
+- `skills/in-progress/handoff/SKILL.md` — the 11-line skill body
+- `LICENSE` — copied from upstream **repo root** for MIT attribution
+
+**Excluded from snapshot (not vendored):**
+
+- The other 17+ skills across `engineering/`, `productivity/`, `misc/`, `personal/`, `in-progress/`, `deprecated/` — out of cherry-pick scope. Each is a separate decision and a separate port.
+- `README.md` (175 lines) — marketing piece for the upstream repo, not relevant to the cherry-picked skill.
+- `CLAUDE.md` — auto-load contamination risk; excluded for cross-contamination safety (consistent with how OMC, Obra, addy, ruflo are handled).
+- `CONTEXT.md`, `scripts/`, `docs/`, `.claude-plugin/`, `.out-of-scope/` — not vendor scope.
+
+**Refresh recipe:**
+
+```bash
+# 1. Pin the new SHA in this file under "Pinned SHA" above
+# 2. Shallow clone outside the repo
+git clone --depth 1 https://github.com/mattpocock/skills.git \
+  /tmp/mattpocock-skills-refresh
+git -C /tmp/mattpocock-skills-refresh rev-parse HEAD  # confirm matches Pinned SHA
+
+# 3. Wipe + re-copy the cherry-picked surface (skill body + repo-root LICENSE)
+rm -rf third-party/mattpocock-skills/skills
+rm -f  third-party/mattpocock-skills/LICENSE
+mkdir -p third-party/mattpocock-skills/skills/in-progress/handoff
+cp /tmp/mattpocock-skills-refresh/skills/in-progress/handoff/SKILL.md \
+  third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md
+cp /tmp/mattpocock-skills-refresh/LICENSE \
+  third-party/mattpocock-skills/LICENSE
+
+# Safety belt: nothing in this snapshot should be a CLAUDE.md
+find third-party/mattpocock-skills -name CLAUDE.md -type f -delete
+
+# 4. Single-concern commit:
+#    chore(third-party): refresh mattpocock/skills @ <new-sha>
+```
+
+> **Driver integration deferred.** Adding a `mattpocock-skills` SNAPSHOTS entry to `bin/refresh-third-party.mjs` is tracked as a follow-up alongside `addy-agent-skills` and `ruflo-swarm`. The recipe above is the source of truth in the meantime.
+
 <!--
   product-on-purpose/pm-skills was vendored here from 2026-05-07 to 2026-05-08
   (PR #91, SHA 8d23508cb7193435904e6d5f1e550051e0372b25, v2.13.1, Apache-2.0).

--- a/third-party/mattpocock-skills/LICENSE
+++ b/third-party/mattpocock-skills/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Matt Pocock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/third-party/mattpocock-skills/OUR_NOTES.md
+++ b/third-party/mattpocock-skills/OUR_NOTES.md
@@ -1,0 +1,81 @@
+# OUR_NOTES.md — mattpocock/skills
+
+Our annotations on the vendored snapshot. Authored by us, not copied from upstream.
+
+## Why we vendored this
+
+We are cherry-picking exactly **one skill** from `mattpocock/skills`: `skills/in-progress/handoff/SKILL.md`. It fills a gap none of our existing compaction skills cover cleanly:
+
+| Existing skill | What it does | Why it isn't a handoff |
+|---|---|---|
+| `strategic-compact` | PreToolUse hook that suggests `/compact` at logical phase boundaries | Triggers compaction in the same session, no doc artifact for the next agent |
+| `para-memory-files` | PARA-style cross-session memory under `~/.claude/memory/` | Stores classified facts, not a per-session handoff document |
+| `wrap` (global) | Wrap-up routine for the active session | Closes out, does not summarise for a successor |
+
+`handoff` is the missing piece: a one-shot, mktemp-backed markdown that compresses the current conversation into a brief a fresh agent can pick up cold, without duplicating what already lives in PRDs / plans / ADRs / issues / commits.
+
+## Selective scope (verbatim from upstream)
+
+Only the in-progress handoff skill, plus the repo-root `LICENSE` for MIT attribution. **Nothing else** from upstream is vendored — not the engineering skills, not the productivity skills, not the README, not the CLAUDE.md.
+
+- `skills/in-progress/handoff/SKILL.md` — the 11-line skill body
+- `LICENSE` — MIT, copied from the repo root for attribution
+
+That is the entire snapshot. If we ever decide to port a second skill (`grill-me`, `tdd`, `diagnose`, etc.), add it under the same `skills/<bucket>/<name>/SKILL.md` path and document the addition in the table above.
+
+## Status: cold-storage, not registered
+
+This snapshot is **cold-storage only** — same model as `obra/superpowers` and `ruvnet/ruflo`. It is:
+
+- **Not loaded** by `plugins/continuous-improvement/`.
+- **Not registered** in `.claude-plugin/marketplace.json` (no marketplace entry).
+- **Not added** to `bin/refresh-third-party.mjs`'s driver registry (cherry-pick of one in-progress file; refresh is manual).
+
+The user-facing exposure is via our own `skills/handoff.md` + `commands/handoff.md`, which credit Matt Pocock and link back to this snapshot.
+
+## What is intentionally NOT integrated (and why)
+
+1. **The other 17+ mattpocock skills** (`grill-me`, `grill-with-docs`, `tdd`, `diagnose`, `to-prd`, `to-issues`, `triage`, `zoom-out`, `improve-codebase-architecture`, `prototype`, `caveman`, `write-a-skill`, `setup-matt-pocock-skills`, `git-guardrails-claude-code`, `migrate-to-shoehorn`, `scaffold-exercises`, `setup-pre-commit`, plus the personal/in-progress/deprecated buckets). Out of scope for this PR. Each one is a separate decision and a separate port if/when we want it.
+2. **mattpocock's `CLAUDE.md`**. Auto-loads as Claude Code session context if read from this subtree and would leak upstream operating principles into the active 7 Laws session. Excluded for cross-contamination safety (consistent with how we handle Obra, OMC, addy, ruflo).
+3. **mattpocock's `README.md`** (175 lines). Marketing piece for the upstream repo, not relevant to the cherry-picked skill. Refer to upstream URL when needed.
+4. **`scripts/`, `docs/`, `.claude-plugin/`, `.out-of-scope/`**. Not vendor scope.
+5. **The `skills.sh` installer.** Out of scope; we ship our own marketplace.
+
+## Refresh recipe
+
+```bash
+# 1. Pin the new SHA in third-party/MANIFEST.md under "Pinned SHA"
+# 2. Shallow clone outside the repo
+git clone --depth 1 https://github.com/mattpocock/skills.git \
+  /tmp/mattpocock-skills-refresh
+git -C /tmp/mattpocock-skills-refresh rev-parse HEAD  # confirm matches Pinned SHA
+
+# 3. Wipe + re-copy the cherry-picked surface (skill body + repo-root LICENSE)
+rm -rf third-party/mattpocock-skills/skills
+rm -f  third-party/mattpocock-skills/LICENSE
+mkdir -p third-party/mattpocock-skills/skills/in-progress/handoff
+cp /tmp/mattpocock-skills-refresh/skills/in-progress/handoff/SKILL.md \
+  third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md
+cp /tmp/mattpocock-skills-refresh/LICENSE \
+  third-party/mattpocock-skills/LICENSE
+
+# Safety belt: nothing in this snapshot should be a CLAUDE.md
+find third-party/mattpocock-skills -name CLAUDE.md -type f -delete
+
+# 4. Diff the snapshot against our skills/handoff.md and decide whether
+#    the upstream change warrants a parallel update on the integration side.
+
+# 5. Single-concern commit:
+#    chore(third-party): refresh mattpocock/skills @ <new-sha>
+```
+
+## Drift radar
+
+The cherry-picked skill is in mattpocock's `in-progress/` bucket. By his own README convention, in-progress skills are **drafts not yet ready to ship** and may change shape without notice. On refresh, watch for:
+
+- The skill being **graduated** from `in-progress/` into `productivity/` or a new bucket (path will change).
+- The skill being **renamed** or **deprecated** (it would move to `deprecated/`).
+- Frontmatter changes — particularly `argument-hint`, which our integration mirrors verbatim.
+- Body changes that alter the contract (e.g. switching from `mktemp` to a fixed path, or removing the "do not duplicate other artifacts" rule).
+
+Any of the above warrants an aligned edit to `skills/handoff.md` and `commands/handoff.md` in the same refresh PR.

--- a/third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md
+++ b/third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md
@@ -1,0 +1,13 @@
+---
+name: handoff
+description: Compact the current conversation into a handoff document for another agent to pick up.
+argument-hint: "What will the next session be used for?"
+---
+
+Write a handoff document summarising the current conversation so a fresh agent can continue the work. Save it to a path produced by `mktemp -t handoff-XXXXXX.md` (read the file before you write to it).
+
+Suggest the skills to be used, if any, by the next session.
+
+Do not duplicate content already captured in other artifacts (PRDs, plans, ADRs, issues, commits, diffs). Reference them by path or URL instead.
+
+If the user passed arguments, treat them as a description of what the next session will focus on and tailor the doc accordingly.


### PR DESCRIPTION
## Summary

Adds **/handoff** — a one-shot session compaction into an `mktemp`-backed markdown brief a fresh agent can pick up cold. Ported verbatim in behavior from [mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md) (MIT, (c) 2026 Matt Pocock).

Fills the gap between existing compaction skills:

| Existing skill | What it does | Why it isn't a handoff |
|---|---|---|
| `strategic-compact` | PreToolUse hook suggesting `/compact` at phase boundaries | Same-session compaction, no doc artifact for the next agent |
| `para-memory-files` | PARA-style cross-session memory under `~/.claude/memory/` | Classified facts, not per-session handoff briefs |
| `wrap` (global) | Wrap-up routine for the active session | Closes out, doesn't summarise for a successor |

## Surfaces added

- `skills/handoff.md` — tier 2, Law 5 (Reflect After Every Session)
- `commands/handoff.md` — slash command entry, mirrors mattpocock's `argument-hint`
- `third-party/mattpocock-skills/` — cold-storage vendor snapshot:
  - `LICENSE` (verbatim MIT)
  - `OUR_NOTES.md` (drift radar + integration scope)
  - `skills/in-progress/handoff/SKILL.md` (verbatim upstream)
- `third-party/MANIFEST.md` — 5th snapshot entry + refresh recipe
- `CLAUDE.md` — vendor count 4 -> 5
- `skills/README.md` — `handoff` row in always-bundled companion table

Generated bundle mirrors (`npm run build`):
- `plugins/continuous-improvement/skills/handoff/SKILL.md`
- `plugins/continuous-improvement/commands/handoff.md`
- `plugins/continuous-improvement/skills/README.md`

## Vendor model

Cold-storage only — same pattern as `obra/superpowers`, `addyosmani/agent-skills`, `ruvnet/ruflo`, `oh-my-claudecode`:

- **Not loaded** by `plugins/continuous-improvement/`
- **Not registered** in `.claude-plugin/marketplace.json`
- **Not added** to `bin/refresh-third-party.mjs` driver registry (cherry-pick of one in-progress file; refresh recipe is manual)
- Pinned SHA `9fecab929abb904c68ce3366a1781df31ab22832`, snapshot date 2026-05-11
- Cherry-picked **single skill** out of 25+ upstream skills (none of the engineering/productivity/misc buckets vendored)

## Verification

All 7 `npm run verify:all` invariants green:

- skill-mirror: 18 source/bundle pairs match (was 17)
- skill-tiers: all 18 declare a recognized tier
- skill-law-tag: all 18 carry a Law tag (handoff = Law 5)
- docs-substrings: 144 assertions match
- everything-mirror: 36 mirrored files match
- routing-targets: 37 targets accounted for
- doc-runtime-claims: every runtime-claim anchored
- typecheck: 0 errors

## Test plan

- [ ] CI green
- [ ] Manual smoke: invoke `/handoff` in a fresh session, confirm it writes a brief to an `mktemp` path
- [ ] Manual smoke: invoke `/handoff focus on the auth refactor`, confirm the brief is tailored to the argument
- [ ] Confirm `third-party/mattpocock-skills/OUR_NOTES.md` refresh recipe executes cleanly on a worktree

## Attribution

[mattpocock/skills `in-progress/handoff`](https://github.com/mattpocock/skills/blob/main/skills/in-progress/handoff/SKILL.md), MIT (c) 2026 Matt Pocock. Verbatim copy in `third-party/mattpocock-skills/skills/in-progress/handoff/SKILL.md`; our integration in `skills/handoff.md` credits and links back.