### PR TITLE
chore(third-party): strip broken mcpServers pointer from OMC plugin.json

### DIFF
--- a/bin/refresh-third-party.mjs
+++ b/bin/refresh-third-party.mjs
@@ -37,7 +37,7 @@
  *   2 — bad CLI usage / unknown snapshot name
  */
 import { spawnSync } from "node:child_process";
-import { cp, mkdir, readFile, rm, stat } from "node:fs/promises";
+import { cp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join, relative, resolve } from "node:path";
 import { argv, cwd, exit, stderr, stdout } from "node:process";
@@ -82,6 +82,14 @@ const SNAPSHOTS = [
     // OMC's hooks/hooks.json calls $CLAUDE_PLUGIN_ROOT/scripts/run.cjs,
     // which lives under src/scripts/ — neither is vendored.
     excludePostCopy: ["hooks", "src/scripts"],
+    // Packaging patches applied after the selective copy. For each entry,
+    // load the JSON file, delete the listed top-level keys, write it back
+    // pretty-printed. Use case: upstream's plugin.json points at runtime
+    // files we exclude from vendoring (e.g. .mcp.json), so the pointers
+    // resolve to missing files at install time. See OUR_NOTES.md item 3.
+    postCopyJsonKeyDeletes: [
+      { file: ".claude-plugin/plugin.json", keys: ["mcpServers"] },
+    ],
   },
   {
     name: "superpowers",
@@ -327,6 +335,34 @@ async function refreshOne(snapshot, { force }) {
       }
     }
 
+    // Packaging patches: drop named top-level keys from JSON files.
+    // For pointers to runtime files we exclude from vendoring (e.g.
+    // plugin.json's "mcpServers" → ".mcp.json"), leaving the key in
+    // would let Claude Code's loader resolve a missing file on every
+    // install. One-key minimal mutation; all other fields stay verbatim.
+    let patchedKeys = 0;
+    for (const patch of snapshot.postCopyJsonKeyDeletes ?? []) {
+      const target = join(localAbs, patch.file);
+      if (!(await pathExists(target))) {
+        throw new Error(
+          `[${snapshot.name}] postCopyJsonKeyDeletes: file "${patch.file}" missing after copy`,
+        );
+      }
+      const text = await readFile(target, "utf8");
+      const obj = JSON.parse(text);
+      let changed = false;
+      for (const key of patch.keys) {
+        if (Object.prototype.hasOwnProperty.call(obj, key)) {
+          delete obj[key];
+          changed = true;
+          patchedKeys++;
+        }
+      }
+      if (changed) {
+        await writeFile(target, JSON.stringify(obj, null, 2) + "\n", "utf8");
+      }
+    }
+
     // Print git diff stat scoped to the snapshot path.
     const diffStat = runGit(
       ["diff", "--stat", "--", snapshot.localPath],
@@ -337,7 +373,7 @@ async function refreshOne(snapshot, { force }) {
     log(`  pinned SHA   : ${pinned}`);
     log(`  upstream HEAD: ${headSha}`);
     log(
-      `  status       : updated (${copiedDirs} dirs, ${copiedFiles} files, ${stripped} CLAUDE.md stripped, ${excluded} excluded paths removed)`,
+      `  status       : updated (${copiedDirs} dirs, ${copiedFiles} files, ${stripped} CLAUDE.md stripped, ${excluded} excluded paths removed, ${patchedKeys} json keys patched)`,
     );
     if (diffStat.stdout.trim()) {
       log("  diff --stat  :");

--- a/third-party/MANIFEST.md
+++ b/third-party/MANIFEST.md
@@ -34,9 +34,10 @@ Pinned snapshots. Read-only. Refresh by bumping the SHA and re-running the docum
 - `bridge/` (~6 MB — runtime adapters)
 - `tests/`, `scripts/`, `benchmark/`, `benchmarks/`, `seminar/`, `shellmark/`, `research/`
 - `hooks/hooks.json` — every entry calls `$CLAUDE_PLUGIN_ROOT/scripts/run.cjs`, which lives in the excluded `src/` tree. With the runtime not vendored, registering these hooks would throw `MODULE_NOT_FOUND` on every PreToolUse/PostToolUse/SessionStart/Stop/PreCompact fire. See `third-party/oh-my-claudecode/OUR_NOTES.md` item 2 in "What is intentionally NOT integrated".
+- `.mcp.json` — MCP server registration is a per-install user opt-in surface and should not be pre-wired by a cold-storage snapshot. Because `.claude-plugin/plugin.json` (which IS vendored) declares `"mcpServers": "./.mcp.json"`, the vendored `plugin.json` is **packaging-patched** to drop that key (see refresh recipe step 3.5 below). All other `plugin.json` fields are verbatim upstream. See `third-party/oh-my-claudecode/OUR_NOTES.md` item 3.
 - `package.json`, `package-lock.json`, `tsconfig.json`, `eslint.config.js`, `vitest.config.ts`, `typos.toml`
 - All non-English `README.*.md` files
-- `.github/`, `.git/`, `.gitignore`, `.gitattributes`, `.npmignore`, `.codex`, `.clawhip/`, `.mcp.json`
+- `.github/`, `.git/`, `.gitignore`, `.gitattributes`, `.npmignore`, `.codex`, `.clawhip/`
 - `CLAUDE.md` (root) and `docs/CLAUDE.md` — both auto-load as Claude Code session context if read from this subtree, leaking OMC's operating principles into the active 7 Laws session. Excluded for cross-contamination safety. The root `CLAUDE.md` was empirically observed to leak; `docs/CLAUDE.md` is excluded preemptively without empirical confirmation. Upstream still ships both; refer to upstream URL when needed.
 
 **Refresh recipe:**
@@ -60,6 +61,14 @@ cp /tmp/omc-refresh/{LICENSE,README.md,AGENTS.md,CHANGELOG.md,SECURITY.md} \
 # (root CLAUDE.md is not copied above; docs/CLAUDE.md gets copied by the dir cp,
 # so it must be deleted post-copy.)
 find third-party/oh-my-claudecode -name CLAUDE.md -type f -delete
+
+# 3.5. Packaging-patch plugin.json: drop the mcpServers key that points at
+#      .mcp.json (excluded from vendoring above). One-key minimal mutation;
+#      all other fields stay verbatim upstream. See OUR_NOTES.md item 3.
+node -e "const f='third-party/oh-my-claudecode/.claude-plugin/plugin.json'; \
+  const j=JSON.parse(require('fs').readFileSync(f,'utf8')); \
+  delete j.mcpServers; \
+  require('fs').writeFileSync(f, JSON.stringify(j, null, 2) + '\n');"
 
 # 4. Single-concern commit:
 #    chore(third-party): refresh oh-my-claudecode @ <new-sha>

--- a/third-party/oh-my-claudecode/.claude-plugin/plugin.json
+++ b/third-party/oh-my-claudecode/.claude-plugin/plugin.json
@@ -15,6 +15,5 @@
     "orchestration",
     "automation"
   ],
-  "skills": "./skills/",
-  "mcpServers": "./.mcp.json"
+  "skills": "./skills/"
 }

--- a/third-party/oh-my-claudecode/OUR_NOTES.md
+++ b/third-party/oh-my-claudecode/OUR_NOTES.md
@@ -37,8 +37,8 @@ Activating the plugin installs OMC's agents and skills only — `hooks/` is inte
 
 1. **OMC's `ralph` skill.** Our `ralph` is already a Tier-1 skill under the 7 Laws and is shaped around the Mulahazah learning loop. Adopting OMC's would fork the contract. Stay on ours.
 2. **OMC's hooks (removed from snapshot).** `hooks/hooks.json` was stripped from this snapshot — not just disabled. Reasons: (a) every entry calls `$CLAUDE_PLUGIN_ROOT/scripts/run.cjs`, which lives in upstream's `src/` and is explicitly excluded from vendoring per item 4 below, so the hooks throw `MODULE_NOT_FOUND` on every fire when the plugin is installed; (b) our `hooks/three-section-close.mjs` enforces a project-specific output contract and mixing OMC's hooks would create ordering surprises. The selective-scope and refresh recipe in `third-party/MANIFEST.md` reflect the strip.
-3. **OMC's plugin manifest** (`.claude-plugin/plugin.json`). Read-only reference only. Do not register `omc` in our `.claude-plugin/marketplace.json`.
-4. **OMC's `src/` and `dist/`.** Not vendored. We have no intent to fork the runtime. If we ever want OMC behavior, install from upstream.
+3. **OMC's plugin manifest** (`.claude-plugin/plugin.json`). Vendored but **packaging-patched**: the `mcpServers: "./.mcp.json"` key was stripped because `.mcp.json` is excluded from vendoring per item 4 below (see `third-party/MANIFEST.md` exclusions), so leaving the pointer in would have Claude Code's plugin loader resolve a missing file on every install. The patch is one-key minimal; all other fields are verbatim upstream. Same precedent as the hooks/ strip in item 2 — a packaging correction for a pointer to an excluded-from-vendoring runtime, not a fork of upstream content.
+4. **OMC's `src/` and `dist/` (and `.mcp.json`).** Not vendored. We have no intent to fork the runtime, and the `.mcp.json` MCP server registration is a per-install user opt-in surface that should not be pre-wired by a cold-storage snapshot. If we ever want OMC behavior, install from upstream.
 
 ## Ported from OMC into the 7 Laws
 


### PR DESCRIPTION
## Summary

Follow-up to PR #135. Same class of bug, same shape of fix.

`third-party/oh-my-claudecode/.claude-plugin/plugin.json` declared `"mcpServers": "./.mcp.json"`, but `.mcp.json` is excluded from vendoring per `third-party/MANIFEST.md`. Like the hooks/hooks.json strip in PR #135, this is a plugin-manifest pointer to a runtime file we intentionally do not ship — so Claude Code's plugin loader resolves a missing file every time a user installs `oh-my-claudecode@continuous-improvement` from this marketplace.

## Changes

**Commit 1 — `chore(third-party): strip broken mcpServers pointer from OMC plugin.json`**
- Delete the `mcpServers` key from `third-party/oh-my-claudecode/.claude-plugin/plugin.json`. One-key minimal mutation; all other fields remain verbatim upstream.
- `OUR_NOTES.md`: rewrite item 3 to document the packaging patch and cite the PR #135 hooks/-strip precedent; extend item 4 to explain why `.mcp.json` is excluded (per-install user opt-in surface, not cold-storage).
- `MANIFEST.md`: pull `.mcp.json` out of the catch-all repo-metadata exclusion line and give it its own bullet with the consequence for `plugin.json`; add a "3.5" packaging-patch step to the refresh recipe using a small `node -e` script so future manual re-vendors don't reintroduce the broken pointer.

**Commit 2 — `chore(third-party): post-copy JSON-key patches in refresh driver`**
- Add optional `postCopyJsonKeyDeletes` field per snapshot to `bin/refresh-third-party.mjs`. After the selective copy and `excludePostCopy` strip complete, the driver loads each named JSON file, deletes the listed top-level keys, and writes it back pretty-printed.
- Wired only for `oh-my-claudecode`: `[{ file: ".claude-plugin/plugin.json", keys: ["mcpServers"] }]`.
- Throws if the named JSON file is missing after copy (loud failure beats silent regression).
- Field is optional; snapshots without it (e.g. superpowers) behave exactly as before. Status line reports the count of patched keys alongside copied dirs/files, CLAUDE.md strips, and excluded paths.

## Verification

`npm run verify:all` green — all 8 invariants pass:

- ✅ skill-mirror (20 pairs)
- ✅ skill-tiers (20)
- ✅ skill-law-tag (20)
- ✅ docs-substrings (164 assertions)
- ✅ everything-mirror (39 files)
- ✅ routing-targets (37 targets)
- ✅ doc-runtime-claims (21 scanned)
- ✅ typecheck

Smoke test: `node bin/refresh-third-party.mjs --list` still parses MANIFEST.md and reports both snapshots correctly after the edit.

## Relationship to PR #135

PR #135 stripped `hooks/hooks.json` (entire 212-line file pointing at `$CLAUDE_PLUGIN_ROOT/scripts/run.cjs` which lives in the excluded `src/`). This PR strips one key from `plugin.json` (`mcpServers` → `./.mcp.json` which is also excluded). The two PRs together exhaust the known broken-pointer-to-excluded-runtime instances in the OMC snapshot.

The defense-in-depth pattern is now also symmetric: `excludePostCopy` covers directories, `postCopyJsonKeyDeletes` covers JSON keys. Future snapshots can opt into either.

## Test plan

- [ ] User reinstalls `oh-my-claudecode@continuous-improvement` after merge and confirms no "missing `.mcp.json`" warnings or MCP server registration errors on install.
- [ ] Optional: dry-run `node bin/refresh-third-party.mjs oh-my-claudecode --check` to confirm the driver still parses MANIFEST.md after the new field landed.