### PR TITLE
feat(hook): companion-preference telemetry JSONL with ci-first shadow rows

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -205,6 +205,20 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "hooks/companion-preference.mjs", source: "docs-substrings-manifest:superpowers-runtime-enforcement" },
     { file: "skills/superpowers.md", pattern: "fails open", source: "docs-substrings-manifest:superpowers-runtime-enforcement" },
     { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "fails open", source: "docs-substrings-manifest:superpowers-runtime-enforcement" },
+    // superpowers Telemetry subsection — locked 2026-05-14 (PR 4 of dispatcher-bias train).
+    // The hook gained a JSONL telemetry writer at ~/.claude/instincts/<hash>/companion-preference.jsonl
+    // that fires under every mode including ci-first (which writes `observation` shadow rows). The
+    // "### Telemetry" subsection documents the JSONL path and the four-value action enum. Each
+    // assertion catches a specific class of regression:
+    //   - "### Telemetry"                     → removing the whole subsection
+    //   - "companion-preference.jsonl"        → renaming the JSONL file
+    //   - "observation"                       → losing the ci-first shadow row that makes default-flip decisions evidence-driven
+    { file: "skills/superpowers.md", pattern: "### Telemetry", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+    { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "### Telemetry", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+    { file: "skills/superpowers.md", pattern: "companion-preference.jsonl", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+    { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "companion-preference.jsonl", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+    { file: "skills/superpowers.md", pattern: "`observation`", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+    { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "`observation`", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
     // verification-loop per-project ladder — locked 2026-05-07 (PR C of second-release train).
     // Phase 0 (Ladder Resolution) was added so Phases 1–6 read the project's actual build/typecheck/
     // lint/test/security/deploy_receipt invocations from .claude/verify-ladder.json (or sniff /

--- a/docs/plans/2026-05-14-companion-preference-telemetry-jsonl.md
+++ b/docs/plans/2026-05-14-companion-preference-telemetry-jsonl.md
@@ -1,0 +1,77 @@
+# Companion-Preference Telemetry JSONL
+
+**Date:** 2026-05-14
+**Slug:** `companion-preference-telemetry-jsonl`
+**Operator:** Naim
+**Reason:** PR #136 shipped runtime enforcement for the `companion_preference` flag but emits no persistent record of what it does. The closing recommendation of the 2026-05-13 dispatcher-bias train was: "ship the telemetry JSONL WILD next — every other follow-up is independent and can land in any order, but only telemetry produces the evidence that earns a clean default-flip decision later." This PR delivers exactly that — one JSONL line per hook decision, written to `~/.claude/instincts/<hash>/companion-preference.jsonl`. Critically, telemetry fires even under `ci-first` mode as `observation` rows so the data set captures the shadow path (what `companions-first` would have done) without changing default behavior.
+
+## Single-concern scope
+
+| PR | Title | Scope (files) | Test strategy | Merge order |
+|---|---|---|---|---|
+| 4 | `feat(hook): companion-preference telemetry JSONL with ci-first shadow rows` | `src/hooks/companion-preference.mts` (+ telemetry writer), `src/test/companion-preference-hook.test.mts` (+ 5–6 new tests), `skills/superpowers.md` (+ telemetry paragraph), `src/bin/check-docs-substrings.mts` (+ 2 assertions) + the generated `.mjs` / plugin mirrors | TDD RED-then-GREEN for the new tests; `npm test` total stays passing; `npm run verify:all` green | Independent (follows #133–#136) |
+
+## Event shape
+
+One JSONL line per hook invocation that touches a mapped CI skill, regardless of mode:
+
+```json
+{
+  "ts": "2026-05-14T10:30:00.000Z",
+  "hook": "companion-preference",
+  "mode": "ci-first" | "companions-first" | "strict-companions",
+  "action": "observation" | "advisory" | "block" | "block-not-installed",
+  "ci_skill": "tdd-workflow",
+  "companion": "superpowers:test-driven-development",
+  "plugin": "superpowers",
+  "companion_installed": true | false
+}
+```
+
+- `observation` — mode is `ci-first`; would have fired advisory under `companions-first`. This is the shadow data the default-flip decision needs.
+- `advisory` — mode is `companions-first`; stderr advisory was emitted.
+- `block` — mode is `strict-companions`; companion plugin installed; tool call blocked.
+- `block-not-installed` — mode is `strict-companions`; companion plugin missing; blocked with install hint.
+
+Non-mapped skills and non-`Skill` tool calls write nothing — they were no-op before PR 4 and remain no-op.
+
+## File path resolution
+
+Telemetry file: `<sessionDir>/companion-preference.jsonl`, where `sessionDir` is the same `~/.claude/instincts/<project-hash>/` directory `gateguard-state.mts` resolves via `resolveSessionDir()`. Reusing that helper keeps the per-project hash scheme single-sourced.
+
+## TDD plan
+
+RED — new tests added before any production code change. Existing 8 tests stay green; 5 new tests fail until the implementation lands:
+
+1. `ci-first` + mapped skill → no decision change, but a JSONL line with `action: "observation"` lands at `<sessionDir>/companion-preference.jsonl`.
+2. `companions-first` + mapped skill → JSONL line has `action: "advisory"` and `mode: "companions-first"`.
+3. `strict-companions` + mapped skill + companion installed → JSONL line has `action: "block"` and `companion_installed: true`.
+4. `strict-companions` + mapped skill + companion missing → JSONL line has `action: "block-not-installed"` and `companion_installed: false`.
+5. Multiple invocations append (not overwrite) — two calls produce two lines.
+6. Telemetry write failure (unwritable session dir) does not change the hook decision — fail-open invariant preserved.
+
+GREEN — extend `src/hooks/companion-preference.mts` with a `writeTelemetry()` function called from each of the four branches (observation in `ci-first`, advisory in `companions-first`, block × 2 in `strict-companions`). The writer wraps `appendFileSync` in try/catch; any error is swallowed and the decision proceeds.
+
+## Out of scope
+
+- Telemetry for non-mapped skills (would balloon volume; the override only affects mapped rows so only those need shadow data).
+- Telemetry for non-`Skill` tool calls (gateguard already covers Bash; this hook is `Skill`-scoped).
+- Reading or analyzing the JSONL (separate skill / command, follow-up).
+- Log rotation. JSONL grows append-only; if size becomes a concern after the 7-day shadow, a follow-up adds rotation or a TTL.
+- Task / Agent tool-call coverage (the other WILD; tracked separately).
+
+## Verification ladder
+
+- `npm test` — 13 hook tests total (8 existing + 5 new) plus the full suite (~547 tests).
+- `npm run verify:all` — 8 invariants. New docs-substring assertions lock the telemetry paragraph in `skills/superpowers.md` and its plugin mirror.
+- Manual: spawn the hook with a synthetic payload under each mode, confirm a JSONL line lands at the expected path and parses as JSON.
+
+## End-state behavior
+
+After PR 4 merges:
+
+- Every mapped CI skill invocation writes one line to `~/.claude/instincts/<hash>/companion-preference.jsonl`.
+- Under `ci-first` (default) the file accumulates `observation` rows — the shadow data.
+- Under `companions-first` it accumulates `advisory` rows.
+- Under `strict-companions` it accumulates `block` / `block-not-installed` rows.
+- After 7 days of accumulated data the operator can grep / aggregate the JSONL to see exactly which routing rows the override fires on, how often, and which companions are installed in the wild. That dataset is what makes a future default-flip evidence-driven instead of preference-driven.

--- a/hooks/companion-preference.mjs
+++ b/hooks/companion-preference.mjs
@@ -23,7 +23,9 @@
  * § "Which rows the override affects" — drift will surface when the test
  * suite or a follow-up audit walks the table against this map.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 const OVERRIDES = {
@@ -87,6 +89,47 @@ function normalizeSkill(skill) {
 function resolveHome() {
     return process.env.HOME ?? process.env.USERPROFILE ?? homedir();
 }
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+function telemetryPath(home) {
+    const hash = createHash("sha256")
+        .update(resolveProjectRoot())
+        .digest("hex")
+        .slice(0, 12);
+    return join(home, ".claude", "instincts", hash, "companion-preference.jsonl");
+}
+/**
+ * Append one JSONL line per hook decision. Wrapped to fail open: any write
+ * error (read-only dir, disk full, race on mkdir) is swallowed and the hook
+ * decision proceeds. Telemetry must never block tool calls.
+ */
+function writeTelemetry(home, event) {
+    try {
+        const path = telemetryPath(home);
+        const dir = join(path, "..");
+        if (!existsSync(dir))
+            mkdirSync(dir, { recursive: true });
+        appendFileSync(path, `${JSON.stringify(event)}\n`);
+    }
+    catch {
+        // fail-open — telemetry failure never changes the decision
+    }
+}
 function main() {
     const raw = readStdin();
     let payload;
@@ -110,21 +153,35 @@ function main() {
     }
     const home = resolveHome();
     const mode = readMode(home);
+    const installed = isCompanionInstalled(home, override.plugin);
+    const baseEvent = {
+        ts: new Date().toISOString(),
+        hook: "companion-preference",
+        ci_skill: normalized,
+        companion: override.companion,
+        plugin: override.plugin,
+        companion_installed: installed,
+    };
     if (mode === "ci-first") {
+        // Shadow row: what companions-first would have done. This is the data
+        // set that earns a future default-flip decision.
+        writeTelemetry(home, { ...baseEvent, mode, action: "observation" });
         emitAndExit({ decision: "allow" });
     }
     if (mode === "companions-first") {
         process.stderr.write(`[continuous-improvement] companion_preference=companions-first → prefer \`${override.companion}\` over \`ci:${normalized}\`.\n`);
+        writeTelemetry(home, { ...baseEvent, mode, action: "advisory" });
         emitAndExit({ decision: "allow" });
     }
     // strict-companions: always block; reason depends on install state.
-    const installed = isCompanionInstalled(home, override.plugin);
     if (installed) {
+        writeTelemetry(home, { ...baseEvent, mode, action: "block" });
         emitAndExit({
             decision: "block",
             reason: `companion_preference=strict-companions: route to \`${override.companion}\` instead of \`ci:${normalized}\`. The CI fallback is suppressed by your setting.`,
         });
     }
+    writeTelemetry(home, { ...baseEvent, mode, action: "block-not-installed" });
     emitAndExit({
         decision: "block",
         reason: `companion_preference=strict-companions: companion plugin \`${override.plugin}\` is not installed. Install with \`/plugin install ${override.plugin}@continuous-improvement\` or relax the setting to \`companions-first\` or \`ci-first\` in ~/.claude/settings.json.`,

--- a/plugins/continuous-improvement/hooks/companion-preference.mjs
+++ b/plugins/continuous-improvement/hooks/companion-preference.mjs
@@ -23,7 +23,9 @@
  * § "Which rows the override affects" — drift will surface when the test
  * suite or a follow-up audit walks the table against this map.
  */
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 const OVERRIDES = {
@@ -87,6 +89,47 @@ function normalizeSkill(skill) {
 function resolveHome() {
     return process.env.HOME ?? process.env.USERPROFILE ?? homedir();
 }
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+function telemetryPath(home) {
+    const hash = createHash("sha256")
+        .update(resolveProjectRoot())
+        .digest("hex")
+        .slice(0, 12);
+    return join(home, ".claude", "instincts", hash, "companion-preference.jsonl");
+}
+/**
+ * Append one JSONL line per hook decision. Wrapped to fail open: any write
+ * error (read-only dir, disk full, race on mkdir) is swallowed and the hook
+ * decision proceeds. Telemetry must never block tool calls.
+ */
+function writeTelemetry(home, event) {
+    try {
+        const path = telemetryPath(home);
+        const dir = join(path, "..");
+        if (!existsSync(dir))
+            mkdirSync(dir, { recursive: true });
+        appendFileSync(path, `${JSON.stringify(event)}\n`);
+    }
+    catch {
+        // fail-open — telemetry failure never changes the decision
+    }
+}
 function main() {
     const raw = readStdin();
     let payload;
@@ -110,21 +153,35 @@ function main() {
     }
     const home = resolveHome();
     const mode = readMode(home);
+    const installed = isCompanionInstalled(home, override.plugin);
+    const baseEvent = {
+        ts: new Date().toISOString(),
+        hook: "companion-preference",
+        ci_skill: normalized,
+        companion: override.companion,
+        plugin: override.plugin,
+        companion_installed: installed,
+    };
     if (mode === "ci-first") {
+        // Shadow row: what companions-first would have done. This is the data
+        // set that earns a future default-flip decision.
+        writeTelemetry(home, { ...baseEvent, mode, action: "observation" });
         emitAndExit({ decision: "allow" });
     }
     if (mode === "companions-first") {
         process.stderr.write(`[continuous-improvement] companion_preference=companions-first → prefer \`${override.companion}\` over \`ci:${normalized}\`.\n`);
+        writeTelemetry(home, { ...baseEvent, mode, action: "advisory" });
         emitAndExit({ decision: "allow" });
     }
     // strict-companions: always block; reason depends on install state.
-    const installed = isCompanionInstalled(home, override.plugin);
     if (installed) {
+        writeTelemetry(home, { ...baseEvent, mode, action: "block" });
         emitAndExit({
             decision: "block",
             reason: `companion_preference=strict-companions: route to \`${override.companion}\` instead of \`ci:${normalized}\`. The CI fallback is suppressed by your setting.`,
         });
     }
+    writeTelemetry(home, { ...baseEvent, mode, action: "block-not-installed" });
     emitAndExit({
         decision: "block",
         reason: `companion_preference=strict-companions: companion plugin \`${override.plugin}\` is not installed. Install with \`/plugin install ${override.plugin}@continuous-improvement\` or relax the setting to \`companions-first\` or \`ci-first\` in ~/.claude/settings.json.`,

--- a/plugins/continuous-improvement/skills/superpowers/SKILL.md
+++ b/plugins/continuous-improvement/skills/superpowers/SKILL.md
@@ -157,6 +157,17 @@ The override map inside `hooks/companion-preference.mjs` stays row-aligned with 
 
 The hook fails open. If `~/.claude/settings.json` is missing, malformed, or unreadable, the hook emits `{ "decision": "allow" }` and exits 0. Bugs in the hook never block tool calls — they only fail to enforce.
 
+### Telemetry
+
+Every hook invocation that touches a mapped CI skill appends one JSONL line to `~/.claude/instincts/<project-hash>/companion-preference.jsonl`. The line carries `ts`, `mode`, `action`, `ci_skill`, `companion`, `plugin`, and `companion_installed`. The action enum is:
+
+- `observation` — mode is `ci-first`; this is the shadow row showing what `companions-first` would have done.
+- `advisory` — mode is `companions-first`; stderr advisory was emitted.
+- `block` — mode is `strict-companions`; companion installed; tool call blocked.
+- `block-not-installed` — mode is `strict-companions`; companion missing; blocked with install hint.
+
+Non-mapped skills and non-`Skill` tool calls write nothing. The writer wraps `appendFileSync` in try/catch — telemetry failure never changes the hook decision, preserving the fail-open invariant. The JSONL file is the evidence base for a future default-flip decision: after a 7-day window, the operator can grep / aggregate the file to see which routing rows the override fires on, how often, and whether the companion was installed at the time.
+
 ## Stacked-PR Plan Precondition (≥3 files)
 
 Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan as a precondition to the first edit landing. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.

--- a/skills/superpowers.md
+++ b/skills/superpowers.md
@@ -157,6 +157,17 @@ The override map inside `hooks/companion-preference.mjs` stays row-aligned with 
 
 The hook fails open. If `~/.claude/settings.json` is missing, malformed, or unreadable, the hook emits `{ "decision": "allow" }` and exits 0. Bugs in the hook never block tool calls — they only fail to enforce.
 
+### Telemetry
+
+Every hook invocation that touches a mapped CI skill appends one JSONL line to `~/.claude/instincts/<project-hash>/companion-preference.jsonl`. The line carries `ts`, `mode`, `action`, `ci_skill`, `companion`, `plugin`, and `companion_installed`. The action enum is:
+
+- `observation` — mode is `ci-first`; this is the shadow row showing what `companions-first` would have done.
+- `advisory` — mode is `companions-first`; stderr advisory was emitted.
+- `block` — mode is `strict-companions`; companion installed; tool call blocked.
+- `block-not-installed` — mode is `strict-companions`; companion missing; blocked with install hint.
+
+Non-mapped skills and non-`Skill` tool calls write nothing. The writer wraps `appendFileSync` in try/catch — telemetry failure never changes the hook decision, preserving the fail-open invariant. The JSONL file is the evidence base for a future default-flip decision: after a 7-day window, the operator can grep / aggregate the file to see which routing rows the override fires on, how often, and whether the companion was installed at the time.
+
 ## Stacked-PR Plan Precondition (≥3 files)
 
 Any change touching three or more files — across `skills/`, `src/`, `bin/`, `commands/`, or any combination — must produce a stacked-PR plan as a precondition to the first edit landing. The 28-day usage report shows a clean correlation: sessions that opened with a stacked-PR plan landed at `fully_achieved`; sessions that began as a single big-bang multi-file edit landed at `partially_achieved` (landing-page dark theme, market-data-hub wiring, RAG misrouting). Single-concern PRs are the lever that closes that gap.

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -236,6 +236,21 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "skills/superpowers.md", pattern: "fails open", source: "docs-substrings-manifest:superpowers-runtime-enforcement" },
   { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "fails open", source: "docs-substrings-manifest:superpowers-runtime-enforcement" },
 
+  // superpowers Telemetry subsection — locked 2026-05-14 (PR 4 of dispatcher-bias train).
+  // The hook gained a JSONL telemetry writer at ~/.claude/instincts/<hash>/companion-preference.jsonl
+  // that fires under every mode including ci-first (which writes `observation` shadow rows). The
+  // "### Telemetry" subsection documents the JSONL path and the four-value action enum. Each
+  // assertion catches a specific class of regression:
+  //   - "### Telemetry"                     → removing the whole subsection
+  //   - "companion-preference.jsonl"        → renaming the JSONL file
+  //   - "observation"                       → losing the ci-first shadow row that makes default-flip decisions evidence-driven
+  { file: "skills/superpowers.md", pattern: "### Telemetry", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+  { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "### Telemetry", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+  { file: "skills/superpowers.md", pattern: "companion-preference.jsonl", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+  { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "companion-preference.jsonl", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+  { file: "skills/superpowers.md", pattern: "`observation`", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+  { file: "plugins/continuous-improvement/skills/superpowers/SKILL.md", pattern: "`observation`", source: "docs-substrings-manifest:superpowers-telemetry-jsonl" },
+
   // verification-loop per-project ladder — locked 2026-05-07 (PR C of second-release train).
   // Phase 0 (Ladder Resolution) was added so Phases 1–6 read the project's actual build/typecheck/
   // lint/test/security/deploy_receipt invocations from .claude/verify-ladder.json (or sniff /

--- a/src/hooks/companion-preference.mts
+++ b/src/hooks/companion-preference.mts
@@ -24,7 +24,9 @@
  * suite or a follow-up audit walks the table against this map.
  */
 
-import { existsSync, readFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
@@ -115,6 +117,62 @@ function resolveHome(): string {
   return process.env.HOME ?? process.env.USERPROFILE ?? homedir();
 }
 
+function resolveProjectRoot(): string {
+  const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+  if (fromEnv) return fromEnv;
+  try {
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (root) return root;
+  } catch {
+    // not in a git repo
+  }
+  return "global";
+}
+
+function telemetryPath(home: string): string {
+  const hash = createHash("sha256")
+    .update(resolveProjectRoot())
+    .digest("hex")
+    .slice(0, 12);
+  return join(home, ".claude", "instincts", hash, "companion-preference.jsonl");
+}
+
+type TelemetryAction =
+  | "observation"
+  | "advisory"
+  | "block"
+  | "block-not-installed";
+
+interface TelemetryEvent {
+  ts: string;
+  hook: "companion-preference";
+  mode: Mode;
+  action: TelemetryAction;
+  ci_skill: string;
+  companion: string;
+  plugin: string;
+  companion_installed: boolean;
+}
+
+/**
+ * Append one JSONL line per hook decision. Wrapped to fail open: any write
+ * error (read-only dir, disk full, race on mkdir) is swallowed and the hook
+ * decision proceeds. Telemetry must never block tool calls.
+ */
+function writeTelemetry(home: string, event: TelemetryEvent): void {
+  try {
+    const path = telemetryPath(home);
+    const dir = join(path, "..");
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    appendFileSync(path, `${JSON.stringify(event)}\n`);
+  } catch {
+    // fail-open — telemetry failure never changes the decision
+  }
+}
+
 function main(): void {
   const raw = readStdin();
   let payload: Payload;
@@ -137,23 +195,37 @@ function main(): void {
   }
   const home = resolveHome();
   const mode = readMode(home);
+  const installed = isCompanionInstalled(home, override!.plugin);
+  const baseEvent = {
+    ts: new Date().toISOString(),
+    hook: "companion-preference" as const,
+    ci_skill: normalized,
+    companion: override!.companion,
+    plugin: override!.plugin,
+    companion_installed: installed,
+  };
   if (mode === "ci-first") {
+    // Shadow row: what companions-first would have done. This is the data
+    // set that earns a future default-flip decision.
+    writeTelemetry(home, { ...baseEvent, mode, action: "observation" });
     emitAndExit({ decision: "allow" });
   }
   if (mode === "companions-first") {
     process.stderr.write(
       `[continuous-improvement] companion_preference=companions-first → prefer \`${override!.companion}\` over \`ci:${normalized}\`.\n`,
     );
+    writeTelemetry(home, { ...baseEvent, mode, action: "advisory" });
     emitAndExit({ decision: "allow" });
   }
   // strict-companions: always block; reason depends on install state.
-  const installed = isCompanionInstalled(home, override!.plugin);
   if (installed) {
+    writeTelemetry(home, { ...baseEvent, mode, action: "block" });
     emitAndExit({
       decision: "block",
       reason: `companion_preference=strict-companions: route to \`${override!.companion}\` instead of \`ci:${normalized}\`. The CI fallback is suppressed by your setting.`,
     });
   }
+  writeTelemetry(home, { ...baseEvent, mode, action: "block-not-installed" });
   emitAndExit({
     decision: "block",
     reason: `companion_preference=strict-companions: companion plugin \`${override!.plugin}\` is not installed. Install with \`/plugin install ${override!.plugin}@continuous-improvement\` or relax the setting to \`companions-first\` or \`ci-first\` in ~/.claude/settings.json.`,

--- a/src/test/companion-preference-hook.test.mts
+++ b/src/test/companion-preference-hook.test.mts
@@ -1,7 +1,16 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -173,5 +182,239 @@ describe("companion-preference hook", () => {
     const r = runHook("{not valid json", home);
     assert.equal(r.status, 0);
     assert.equal(decision(r).decision, "allow");
+  });
+});
+
+// Telemetry suite — each test gets its own fresh HOME + CLAUDE_PROJECT_DIR
+// so the JSONL file is hermetic and line counts are deterministic.
+
+interface TelemetryLine {
+  ts: string;
+  hook: string;
+  mode: "ci-first" | "companions-first" | "strict-companions";
+  action: "observation" | "advisory" | "block" | "block-not-installed";
+  ci_skill: string;
+  companion: string;
+  plugin: string;
+  companion_installed: boolean;
+}
+
+function projectHash(projectRoot: string): string {
+  return createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+}
+
+function telemetryPath(home: string, projectRoot: string): string {
+  return join(
+    home,
+    ".claude",
+    "instincts",
+    projectHash(projectRoot),
+    "companion-preference.jsonl",
+  );
+}
+
+function runHookWithProject(
+  payload: unknown,
+  home: string,
+  projectRoot: string,
+): HookResult {
+  const input = typeof payload === "string" ? payload : JSON.stringify(payload);
+  const env = buildIsolatedEnv(home);
+  env.CLAUDE_PROJECT_DIR = projectRoot;
+  const result = spawnSync(process.execPath, [HOOK_PATH], {
+    input,
+    env,
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function readTelemetry(home: string, projectRoot: string): TelemetryLine[] {
+  const path = telemetryPath(home, projectRoot);
+  if (!existsSync(path)) return [];
+  return readFileSync(path, "utf8")
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => JSON.parse(line) as TelemetryLine);
+}
+
+describe("companion-preference hook telemetry", () => {
+  let home: string;
+  let projectRoot: string;
+
+  before(() => {
+    home = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-"));
+    // Use a stable synthetic project root so the hash is deterministic
+    // independent of where the test is invoked from.
+    projectRoot = "/test/companion-preference-telemetry";
+  });
+
+  after(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("ci-first writes an `observation` row for a mapped CI skill (shadow data)", () => {
+    setSettings(home, {
+      continuous_improvement: { companion_preference: "ci-first" },
+    });
+    const r = runHookWithProject(
+      { tool_name: "Skill", tool_input: { skill: "tdd-workflow" } },
+      home,
+      projectRoot,
+    );
+    assert.equal(decision(r).decision, "allow");
+    assert.equal(r.stderr, "");
+    const lines = readTelemetry(home, projectRoot);
+    assert.equal(lines.length, 1);
+    assert.equal(lines[0]!.action, "observation");
+    assert.equal(lines[0]!.mode, "ci-first");
+    assert.equal(lines[0]!.ci_skill, "tdd-workflow");
+    assert.equal(lines[0]!.companion, "superpowers:test-driven-development");
+    assert.equal(lines[0]!.plugin, "superpowers");
+    assert.equal(lines[0]!.hook, "companion-preference");
+    assert.match(
+      lines[0]!.ts,
+      /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/,
+      "ts is ISO 8601",
+    );
+  });
+
+  it("ci-first does NOT write telemetry for a non-mapped skill", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-nonmapped-"));
+    try {
+      const isolatedProject = "/test/non-mapped";
+      setSettings(isolated, {
+        continuous_improvement: { companion_preference: "ci-first" },
+      });
+      runHookWithProject(
+        { tool_name: "Skill", tool_input: { skill: "gateguard" } },
+        isolated,
+        isolatedProject,
+      );
+      assert.equal(readTelemetry(isolated, isolatedProject).length, 0);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("companions-first writes an `advisory` row with companion_installed flag", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-adv-"));
+    try {
+      const isolatedProject = "/test/companions-first";
+      setSettings(isolated, {
+        continuous_improvement: { companion_preference: "companions-first" },
+      });
+      installCompanion(isolated, "superpowers");
+      runHookWithProject(
+        { tool_name: "Skill", tool_input: { skill: "verification-loop" } },
+        isolated,
+        isolatedProject,
+      );
+      const lines = readTelemetry(isolated, isolatedProject);
+      assert.equal(lines.length, 1);
+      assert.equal(lines[0]!.action, "advisory");
+      assert.equal(lines[0]!.mode, "companions-first");
+      assert.equal(lines[0]!.ci_skill, "verification-loop");
+      assert.equal(lines[0]!.companion_installed, true);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("strict-companions writes `block` when companion installed, `block-not-installed` when missing", () => {
+    const installed = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-blk-yes-"));
+    const missing = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-blk-no-"));
+    try {
+      setSettings(installed, {
+        continuous_improvement: { companion_preference: "strict-companions" },
+      });
+      installCompanion(installed, "superpowers");
+      runHookWithProject(
+        { tool_name: "Skill", tool_input: { skill: "tdd-workflow" } },
+        installed,
+        "/test/strict-installed",
+      );
+      const installedLines = readTelemetry(installed, "/test/strict-installed");
+      assert.equal(installedLines.length, 1);
+      assert.equal(installedLines[0]!.action, "block");
+      assert.equal(installedLines[0]!.companion_installed, true);
+
+      setSettings(missing, {
+        continuous_improvement: { companion_preference: "strict-companions" },
+      });
+      runHookWithProject(
+        { tool_name: "Skill", tool_input: { skill: "tdd-workflow" } },
+        missing,
+        "/test/strict-missing",
+      );
+      const missingLines = readTelemetry(missing, "/test/strict-missing");
+      assert.equal(missingLines.length, 1);
+      assert.equal(missingLines[0]!.action, "block-not-installed");
+      assert.equal(missingLines[0]!.companion_installed, false);
+    } finally {
+      rmSync(installed, { recursive: true, force: true });
+      rmSync(missing, { recursive: true, force: true });
+    }
+  });
+
+  it("multiple invocations append (not overwrite)", () => {
+    const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-append-"));
+    try {
+      const isolatedProject = "/test/append";
+      setSettings(isolated, {
+        continuous_improvement: { companion_preference: "companions-first" },
+      });
+      for (let i = 0; i < 3; i += 1) {
+        runHookWithProject(
+          { tool_name: "Skill", tool_input: { skill: "tdd-workflow" } },
+          isolated,
+          isolatedProject,
+        );
+      }
+      const lines = readTelemetry(isolated, isolatedProject);
+      assert.equal(lines.length, 3);
+      assert.ok(lines.every((l) => l.action === "advisory"));
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
+  });
+
+  it("telemetry write failure does not change the decision (fail-open preserved)", () => {
+    // Skip POSIX-permission test on Windows where chmod is a no-op for read-only.
+    if (platform() === "win32") return;
+    const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-rdonly-"));
+    try {
+      const isolatedProject = "/test/readonly";
+      setSettings(isolated, {
+        continuous_improvement: { companion_preference: "strict-companions" },
+      });
+      // Pre-create the session dir as read-only so appendFileSync inside the
+      // hook fails. The decision must still succeed.
+      const sessionDir = join(
+        isolated,
+        ".claude",
+        "instincts",
+        projectHash(isolatedProject),
+      );
+      mkdirSync(sessionDir, { recursive: true });
+      chmodSync(sessionDir, 0o500);
+      const r = runHookWithProject(
+        { tool_name: "Skill", tool_input: { skill: "tdd-workflow" } },
+        isolated,
+        isolatedProject,
+      );
+      assert.equal(r.status, 0);
+      // Block decision still emitted from stdout regardless of telemetry failure.
+      assert.equal(decision(r).decision, "block");
+      chmodSync(sessionDir, 0o700);
+    } finally {
+      rmSync(isolated, { recursive: true, force: true });
+    }
   });
 });

--- a/test/companion-preference-hook.test.mjs
+++ b/test/companion-preference-hook.test.mjs
@@ -1,7 +1,8 @@
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { createHash } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync, } from "node:fs";
+import { platform, tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 import { fileURLToPath } from "node:url";
@@ -130,5 +131,172 @@ describe("companion-preference hook", () => {
         const r = runHook("{not valid json", home);
         assert.equal(r.status, 0);
         assert.equal(decision(r).decision, "allow");
+    });
+});
+function projectHash(projectRoot) {
+    return createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+}
+function telemetryPath(home, projectRoot) {
+    return join(home, ".claude", "instincts", projectHash(projectRoot), "companion-preference.jsonl");
+}
+function runHookWithProject(payload, home, projectRoot) {
+    const input = typeof payload === "string" ? payload : JSON.stringify(payload);
+    const env = buildIsolatedEnv(home);
+    env.CLAUDE_PROJECT_DIR = projectRoot;
+    const result = spawnSync(process.execPath, [HOOK_PATH], {
+        input,
+        env,
+        encoding: "utf8",
+        timeout: 5000,
+    });
+    if (result.error)
+        throw result.error;
+    return {
+        status: result.status,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+function readTelemetry(home, projectRoot) {
+    const path = telemetryPath(home, projectRoot);
+    if (!existsSync(path))
+        return [];
+    return readFileSync(path, "utf8")
+        .split(/\r?\n/)
+        .filter((line) => line.trim().length > 0)
+        .map((line) => JSON.parse(line));
+}
+describe("companion-preference hook telemetry", () => {
+    let home;
+    let projectRoot;
+    before(() => {
+        home = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-"));
+        // Use a stable synthetic project root so the hash is deterministic
+        // independent of where the test is invoked from.
+        projectRoot = "/test/companion-preference-telemetry";
+    });
+    after(() => {
+        rmSync(home, { recursive: true, force: true });
+    });
+    it("ci-first writes an `observation` row for a mapped CI skill (shadow data)", () => {
+        setSettings(home, {
+            continuous_improvement: { companion_preference: "ci-first" },
+        });
+        const r = runHookWithProject({ tool_name: "Skill", tool_input: { skill: "tdd-workflow" } }, home, projectRoot);
+        assert.equal(decision(r).decision, "allow");
+        assert.equal(r.stderr, "");
+        const lines = readTelemetry(home, projectRoot);
+        assert.equal(lines.length, 1);
+        assert.equal(lines[0].action, "observation");
+        assert.equal(lines[0].mode, "ci-first");
+        assert.equal(lines[0].ci_skill, "tdd-workflow");
+        assert.equal(lines[0].companion, "superpowers:test-driven-development");
+        assert.equal(lines[0].plugin, "superpowers");
+        assert.equal(lines[0].hook, "companion-preference");
+        assert.match(lines[0].ts, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/, "ts is ISO 8601");
+    });
+    it("ci-first does NOT write telemetry for a non-mapped skill", () => {
+        const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-nonmapped-"));
+        try {
+            const isolatedProject = "/test/non-mapped";
+            setSettings(isolated, {
+                continuous_improvement: { companion_preference: "ci-first" },
+            });
+            runHookWithProject({ tool_name: "Skill", tool_input: { skill: "gateguard" } }, isolated, isolatedProject);
+            assert.equal(readTelemetry(isolated, isolatedProject).length, 0);
+        }
+        finally {
+            rmSync(isolated, { recursive: true, force: true });
+        }
+    });
+    it("companions-first writes an `advisory` row with companion_installed flag", () => {
+        const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-adv-"));
+        try {
+            const isolatedProject = "/test/companions-first";
+            setSettings(isolated, {
+                continuous_improvement: { companion_preference: "companions-first" },
+            });
+            installCompanion(isolated, "superpowers");
+            runHookWithProject({ tool_name: "Skill", tool_input: { skill: "verification-loop" } }, isolated, isolatedProject);
+            const lines = readTelemetry(isolated, isolatedProject);
+            assert.equal(lines.length, 1);
+            assert.equal(lines[0].action, "advisory");
+            assert.equal(lines[0].mode, "companions-first");
+            assert.equal(lines[0].ci_skill, "verification-loop");
+            assert.equal(lines[0].companion_installed, true);
+        }
+        finally {
+            rmSync(isolated, { recursive: true, force: true });
+        }
+    });
+    it("strict-companions writes `block` when companion installed, `block-not-installed` when missing", () => {
+        const installed = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-blk-yes-"));
+        const missing = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-blk-no-"));
+        try {
+            setSettings(installed, {
+                continuous_improvement: { companion_preference: "strict-companions" },
+            });
+            installCompanion(installed, "superpowers");
+            runHookWithProject({ tool_name: "Skill", tool_input: { skill: "tdd-workflow" } }, installed, "/test/strict-installed");
+            const installedLines = readTelemetry(installed, "/test/strict-installed");
+            assert.equal(installedLines.length, 1);
+            assert.equal(installedLines[0].action, "block");
+            assert.equal(installedLines[0].companion_installed, true);
+            setSettings(missing, {
+                continuous_improvement: { companion_preference: "strict-companions" },
+            });
+            runHookWithProject({ tool_name: "Skill", tool_input: { skill: "tdd-workflow" } }, missing, "/test/strict-missing");
+            const missingLines = readTelemetry(missing, "/test/strict-missing");
+            assert.equal(missingLines.length, 1);
+            assert.equal(missingLines[0].action, "block-not-installed");
+            assert.equal(missingLines[0].companion_installed, false);
+        }
+        finally {
+            rmSync(installed, { recursive: true, force: true });
+            rmSync(missing, { recursive: true, force: true });
+        }
+    });
+    it("multiple invocations append (not overwrite)", () => {
+        const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-append-"));
+        try {
+            const isolatedProject = "/test/append";
+            setSettings(isolated, {
+                continuous_improvement: { companion_preference: "companions-first" },
+            });
+            for (let i = 0; i < 3; i += 1) {
+                runHookWithProject({ tool_name: "Skill", tool_input: { skill: "tdd-workflow" } }, isolated, isolatedProject);
+            }
+            const lines = readTelemetry(isolated, isolatedProject);
+            assert.equal(lines.length, 3);
+            assert.ok(lines.every((l) => l.action === "advisory"));
+        }
+        finally {
+            rmSync(isolated, { recursive: true, force: true });
+        }
+    });
+    it("telemetry write failure does not change the decision (fail-open preserved)", () => {
+        // Skip POSIX-permission test on Windows where chmod is a no-op for read-only.
+        if (platform() === "win32")
+            return;
+        const isolated = mkdtempSync(join(tmpdir(), "ci-comp-pref-tel-rdonly-"));
+        try {
+            const isolatedProject = "/test/readonly";
+            setSettings(isolated, {
+                continuous_improvement: { companion_preference: "strict-companions" },
+            });
+            // Pre-create the session dir as read-only so appendFileSync inside the
+            // hook fails. The decision must still succeed.
+            const sessionDir = join(isolated, ".claude", "instincts", projectHash(isolatedProject));
+            mkdirSync(sessionDir, { recursive: true });
+            chmodSync(sessionDir, 0o500);
+            const r = runHookWithProject({ tool_name: "Skill", tool_input: { skill: "tdd-workflow" } }, isolated, isolatedProject);
+            assert.equal(r.status, 0);
+            // Block decision still emitted from stdout regardless of telemetry failure.
+            assert.equal(decision(r).decision, "block");
+            chmodSync(sessionDir, 0o700);
+        }
+        finally {
+            rmSync(isolated, { recursive: true, force: true });
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Extends `hooks/companion-preference.mjs` (PR #136) with a JSONL telemetry writer at `~/.claude/instincts/<project-hash>/companion-preference.jsonl`.
- One line per invocation that touches a mapped CI skill. Action enum: `observation` (ci-first shadow), `advisory` (companions-first), `block` (strict-companions + installed), `block-not-installed` (strict-companions + missing).
- Critically, telemetry fires under `ci-first` too — those `observation` rows are the shadow data that lets a future default-flip be evidence-driven instead of preference-driven.
- Writer wraps `appendFileSync` in try/catch; telemetry failure never changes the hook decision (fail-open invariant preserved).

## Motivation
The closing recommendation of the 2026-05-13 dispatcher-bias train was: "ship the telemetry JSONL WILD next as a single-concern PR — every other follow-up is independent and can land in any order, but only telemetry produces the evidence that earns a clean default-flip decision later." This PR delivers exactly that. The dispatcher-bias surface is now shipped (#133), enforced (#136), and measured (#137 if this lands).

## Event shape
```json
{
  "ts": "2026-05-14T10:30:00.000Z",
  "hook": "companion-preference",
  "mode": "ci-first" | "companions-first" | "strict-companions",
  "action": "observation" | "advisory" | "block" | "block-not-installed",
  "ci_skill": "tdd-workflow",
  "companion": "superpowers:test-driven-development",
  "plugin": "superpowers",
  "companion_installed": true
}
```

## Scope (single concern, 10 files)
- `src/hooks/companion-preference.mts` — new `writeTelemetry()` + `telemetryPath()` + `resolveProjectRoot()`; integrated into all four decision branches.
- `src/test/companion-preference-hook.test.mts` — 6 new RED-then-GREEN tests in a separate `describe` block with hermetic per-test tmpdirs.
- `skills/superpowers.md` — new `### Telemetry` subsection under Runtime enforcement.
- `src/bin/check-docs-substrings.mts` — 6 assertions across source + plugin mirror locking the section heading, JSONL filename, and the `observation` action enum literal.
- All generated `.mjs` / plugin mirrors rebuild from the `.mts` sources via `npm run build`.

## Test plan
- [x] **RED**: 6 telemetry tests added before implementation; 4 of them failed against the unmodified hook (the 2 that passed asserted no-write conditions — non-mapped silence and fail-open on read-only dir).
- [x] **GREEN**: `npm test` — 548/548 pass (was 542 before; +6 new telemetry tests).
- [x] **VERIFY**: `npm run verify:all` — 8 invariants green. `docs-substrings` grew from 156 to 162.
- [x] **Hermetic tests**: each telemetry test uses its own fresh tmpdir + synthetic `CLAUDE_PROJECT_DIR` so line counts are deterministic. Read-only-dir fail-open test is POSIX-only (skipped on Windows).

## Out of scope
- Reading or aggregating the JSONL — separate skill / command, follow-up.
- Log rotation or TTL — JSONL is append-only; size mitigation lands later if needed.
- Telemetry for non-mapped skills or non-`Skill` tool calls — would balloon volume; only mapped rows benefit from shadow data.
- Task / Agent tool-call coverage for the hook itself — the other dispatcher-bias WILD; tracked separately.

## Past Mistake Acknowledgment Gate
- **PR #66 wiped by tsc** — active (touches `.mts` source). All edits in `.mts`; `.mjs` regenerated by `npm run build`.
- **PR #136 generator-source mistake** — active (this PR also touches the hook). Confirmed: this change lives only in `src/hooks/companion-preference.mts`; `hooks.json` is not touched.
- **Direct push to main** — using feature branch + PR flow.
- **PR #26 local-main bundling** — branched from `origin/main` (`4de5780`), not local main.

**Will NOT repeat:** assuming any JSON config under `plugins/continuous-improvement/` is editable — every JSON file there is generated by `getPluginHooksConfig()` or `bin/generate-plugin-manifests.mjs`. Sources are `.mts` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)