### PR TITLE
feat(cli): /companion-preference status reader for telemetry JSONL

### DIFF
--- a/bin/check-docs-substrings.mjs
+++ b/bin/check-docs-substrings.mjs
@@ -298,6 +298,20 @@ export const DOCS_ASSERTIONS = [
     { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Skipped.** Reason: single-item", source: "docs-substrings-manifest:proceed-once-mode" },
     { file: "commands/proceed-with-the-recommendation.md", pattern: "Fast-path: `--once` mode", source: "docs-substrings-manifest:proceed-once-mode" },
     { file: "plugins/continuous-improvement/commands/proceed-with-the-recommendation.md", pattern: "Fast-path: `--once` mode", source: "docs-substrings-manifest:proceed-once-mode" },
+    // /companion-preference status reader — locked 2026-05-14 (PR 5 of dispatcher-bias train).
+    // The reader CLI (bin/companion-preference-status.mjs) and slash command (commands/companion-preference.md)
+    // turn the JSONL telemetry from PR #138 into a per-skill aggregation report. The slash command must
+    // expose the frontmatter name, the canonical CLI invocation, and the documented --json subcommand.
+    // Each assertion catches a specific class of regression:
+    //   - "name: companion-preference"                → renaming the slash command
+    //   - "companion-preference-status.mjs"            → renaming the CLI entry point
+    //   - "## Subcommands"                             → losing the documented surface (--json, --days, --all)
+    { file: "commands/companion-preference.md", pattern: "name: companion-preference", source: "docs-substrings-manifest:companion-preference-status-reader" },
+    { file: "plugins/continuous-improvement/commands/companion-preference.md", pattern: "name: companion-preference", source: "docs-substrings-manifest:companion-preference-status-reader" },
+    { file: "commands/companion-preference.md", pattern: "companion-preference-status.mjs", source: "docs-substrings-manifest:companion-preference-status-reader" },
+    { file: "plugins/continuous-improvement/commands/companion-preference.md", pattern: "companion-preference-status.mjs", source: "docs-substrings-manifest:companion-preference-status-reader" },
+    { file: "commands/companion-preference.md", pattern: "## Subcommands", source: "docs-substrings-manifest:companion-preference-status-reader" },
+    { file: "plugins/continuous-improvement/commands/companion-preference.md", pattern: "## Subcommands", source: "docs-substrings-manifest:companion-preference-status-reader" },
 ];
 export function checkAssertions(repoRoot, assertions = DOCS_ASSERTIONS) {
     const fileCache = new Map();

--- a/bin/companion-preference-status.mjs
+++ b/bin/companion-preference-status.mjs
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+/**
+ * /companion-preference status — read & aggregate hook telemetry.
+ *
+ * Reads ~/.claude/instincts/<project-hash>/companion-preference.jsonl
+ * (or an explicit path via --path), groups events by ci_skill within the
+ * configured window (default 7 days), and prints a summary report with
+ * per-skill totals, action breakdown, and companion_installed%.
+ *
+ * Usage:
+ *   node bin/companion-preference-status.mjs              # last 7 days, human
+ *   node bin/companion-preference-status.mjs --days 30    # 30-day window
+ *   node bin/companion-preference-status.mjs --all        # whole file, no window
+ *   node bin/companion-preference-status.mjs --json       # machine-readable JSON
+ *   node bin/companion-preference-status.mjs --path <p>   # override JSONL path
+ *
+ * Exit codes:
+ *   0 — report rendered (including the "no telemetry recorded yet" case)
+ *   1 — argument parse error or unexpected runtime failure
+ */
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { argv, exit, stdout } from "node:process";
+const ACTIONS = [
+    "observation",
+    "advisory",
+    "block",
+    "block-not-installed",
+];
+function parseArgs(args) {
+    const out = { days: 7, all: false, json: false, path: null };
+    for (let i = 0; i < args.length; i += 1) {
+        const a = args[i];
+        if (a === "--days") {
+            const v = Number(args[++i]);
+            if (!Number.isFinite(v) || v <= 0) {
+                process.stderr.write(`--days requires a positive integer (got ${args[i]})\n`);
+                exit(1);
+            }
+            out.days = v;
+        }
+        else if (a === "--all") {
+            out.all = true;
+            out.days = null;
+        }
+        else if (a === "--json") {
+            out.json = true;
+        }
+        else if (a === "--path") {
+            out.path = args[++i] ?? null;
+            if (!out.path) {
+                process.stderr.write(`--path requires a value\n`);
+                exit(1);
+            }
+        }
+        else if (a === "--help" || a === "-h") {
+            printHelp();
+            exit(0);
+        }
+        else if (a !== undefined) {
+            process.stderr.write(`unknown argument: ${a}\n`);
+            exit(1);
+        }
+    }
+    return out;
+}
+function printHelp() {
+    stdout.write([
+        "Usage: companion-preference-status [options]",
+        "",
+        "Options:",
+        "  --days N       Only count events from the last N days (default 7)",
+        "  --all          Ignore the window; count every row in the file",
+        "  --json         Emit a machine-readable JSON report",
+        "  --path <file>  Override the default JSONL path (testing)",
+        "  -h, --help     Print this help",
+        "",
+    ].join("\n"));
+}
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+function defaultJsonlPath() {
+    const home = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+    const hash = createHash("sha256")
+        .update(resolveProjectRoot())
+        .digest("hex")
+        .slice(0, 12);
+    return join(home, ".claude", "instincts", hash, "companion-preference.jsonl");
+}
+function parseJsonl(raw) {
+    const rows = [];
+    let parseErrors = 0;
+    for (const line of raw.split(/\r?\n/)) {
+        if (line.trim().length === 0)
+            continue;
+        try {
+            rows.push(JSON.parse(line));
+        }
+        catch {
+            parseErrors += 1;
+        }
+    }
+    return { rows, parseErrors };
+}
+function aggregate(rows) {
+    const bySkill = {};
+    const byMode = {};
+    const installedYes = {};
+    for (const row of rows) {
+        const stats = (bySkill[row.ci_skill] ??= {
+            total: 0,
+            actions: {},
+            installed_pct: null,
+        });
+        stats.total += 1;
+        stats.actions[row.action] = (stats.actions[row.action] ?? 0) + 1;
+        if (row.companion_installed) {
+            installedYes[row.ci_skill] = (installedYes[row.ci_skill] ?? 0) + 1;
+        }
+        byMode[row.mode] = (byMode[row.mode] ?? 0) + 1;
+    }
+    for (const [skill, stats] of Object.entries(bySkill)) {
+        stats.installed_pct =
+            stats.total > 0
+                ? Math.round(((installedYes[skill] ?? 0) * 100) / stats.total)
+                : null;
+    }
+    return { bySkill, byMode };
+}
+function pad(s, width) {
+    return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+function rpad(n, width) {
+    const s = String(n);
+    return s.length >= width ? s : " ".repeat(width - s.length) + s;
+}
+function formatHuman(report) {
+    const lines = [];
+    const windowLabel = report.window_days === null ? "all-time" : `last ${report.window_days} days`;
+    lines.push(`Companion-preference telemetry — ${windowLabel}`);
+    lines.push(`File:   ${report.file}`);
+    if (report.since)
+        lines.push(`Window: ${report.since} to ${new Date().toISOString()}`);
+    lines.push("");
+    if (report.total_events === 0) {
+        lines.push("No events in window.");
+    }
+    else {
+        const skillWidth = Math.max(8, ...Object.keys(report.by_skill).map((k) => k.length));
+        const header = pad("ci_skill", skillWidth) +
+            "  " +
+            ["total", "observation", "advisory", "block", "block-not-installed", "installed%"]
+                .map((h) => rpad(h, h.length))
+                .join("  ");
+        lines.push(header);
+        for (const [skill, stats] of Object.entries(report.by_skill).sort((a, b) => b[1].total - a[1].total)) {
+            const cells = [
+                rpad(stats.total, "total".length),
+                rpad(stats.actions.observation ?? 0, "observation".length),
+                rpad(stats.actions.advisory ?? 0, "advisory".length),
+                rpad(stats.actions.block ?? 0, "block".length),
+                rpad(stats.actions["block-not-installed"] ?? 0, "block-not-installed".length),
+                rpad(stats.installed_pct === null ? "—" : `${stats.installed_pct}`, "installed%".length),
+            ].join("  ");
+            lines.push(pad(skill, skillWidth) + "  " + cells);
+        }
+    }
+    lines.push("");
+    const modeEntries = Object.entries(report.by_mode);
+    if (modeEntries.length > 0) {
+        lines.push(`Mode totals: ${modeEntries.map(([k, v]) => `${k} ${v}`).join(", ")}`);
+    }
+    lines.push(`Total events: ${report.total_events}`);
+    if (report.parse_errors > 0)
+        lines.push(`Parse errors (skipped): ${report.parse_errors}`);
+    return lines.join("\n") + "\n";
+}
+function main() {
+    const args = parseArgs(argv.slice(2));
+    const filePath = args.path ?? defaultJsonlPath();
+    if (!existsSync(filePath)) {
+        stdout.write(`Companion-preference telemetry: no telemetry recorded yet at ${filePath}\n`);
+        exit(0);
+    }
+    const raw = readFileSync(filePath, "utf8");
+    const { rows, parseErrors } = parseJsonl(raw);
+    const cutoff = args.all || args.days === null
+        ? null
+        : new Date(Date.now() - args.days * 24 * 3600 * 1000).toISOString();
+    const filtered = cutoff === null ? rows : rows.filter((r) => r.ts >= cutoff);
+    const { bySkill, byMode } = aggregate(filtered);
+    const report = {
+        file: filePath,
+        window_days: args.all ? null : args.days,
+        since: cutoff,
+        total_events: filtered.length,
+        parse_errors: parseErrors,
+        by_skill: bySkill,
+        by_mode: byMode,
+    };
+    if (args.json) {
+        stdout.write(JSON.stringify(report, null, 2) + "\n");
+    }
+    else {
+        stdout.write(formatHuman(report));
+    }
+    exit(0);
+}
+const invokedDirectly = argv[1]?.endsWith("companion-preference-status.mjs");
+if (invokedDirectly) {
+    main();
+}
+export { ACTIONS, aggregate, parseArgs, parseJsonl, };

--- a/commands/companion-preference.md
+++ b/commands/companion-preference.md
@@ -1,0 +1,58 @@
+---
+name: companion-preference
+description: Inspect companion-preference hook telemetry — counts by CI skill, action breakdown, and companion-installed%.
+---
+
+# /companion-preference
+
+Read and aggregate the JSONL telemetry written by `hooks/companion-preference.mjs`. Reports per-skill totals, action breakdown (`observation`, `advisory`, `block`, `block-not-installed`), and the share of events where the companion plugin was installed at the time.
+
+The dataset is the evidence base for a future `companions-first` default-flip decision — once a 7-day shadow shows the `companions-first` path firing on a meaningful share of routed Skill calls, with companions installed in the majority of them, the flip is grounded.
+
+## Trigger phrases
+
+- `/companion-preference`
+- `/companion-preference status`
+- "show companion preference stats"
+- "what does the companion-preference hook see"
+
+## What happens
+
+1. Run `node bin/companion-preference-status.mjs` from the repo root with the operator's chosen window. Default `--days 7`. Pass `--all` for the entire file or `--days N` for a different window.
+2. Render the table the CLI emits to the user verbatim. Do not paraphrase the numbers — the JSONL is authoritative.
+3. If the CLI prints "no telemetry recorded yet," check three things in order: (a) `~/.claude/settings.json` has `continuous_improvement.companion_preference` set (otherwise the hook is a no-op and writes nothing); (b) the user has invoked at least one mapped CI skill (`tdd-workflow`, `verification-loop`, `context-budget`, `ralph`, `learn-eval`) since the hook landed; (c) the hook's PreToolUse registration is intact in `plugins/continuous-improvement/hooks/hooks.json`.
+4. Offer one decision-ready next step based on the totals — e.g., "ratio of `observation` rows with `companion_installed=true` suggests `companions-first` is safe to flip for X but not Y."
+
+## Subcommands
+
+### `/companion-preference status` (default)
+
+Same as `/companion-preference`.
+
+### `/companion-preference status --json`
+
+Emit the machine-readable JSON report. Useful when you want to pipe the output into another tool or write your own aggregator.
+
+```bash
+node bin/companion-preference-status.mjs --json --all
+```
+
+## CLI flags
+
+| Flag | Effect |
+|---|---|
+| `--days N` | Only count events from the last N days (default 7). |
+| `--all` | Ignore the window; count every row in the file. |
+| `--json` | Emit a machine-readable JSON report. |
+| `--path <file>` | Override the default JSONL path. Used by the test suite; rarely needed in practice. |
+| `-h`, `--help` | Print CLI help and exit. |
+
+## Path resolution
+
+By default the CLI reads `~/.claude/instincts/<project-hash>/companion-preference.jsonl`, where the hash is the same `sha256(projectRoot).slice(0, 12)` that the hook itself uses. The project root resolves via `CLAUDE_PROJECT_DIR` env var if set, else `git rev-parse --show-toplevel`, else the literal `"global"`. Hash and path scheme are reused verbatim from `hooks/companion-preference.mjs` to keep the read side aligned with the write side.
+
+## Companion skills
+
+- `hooks/companion-preference.mjs` — the writer that produces the JSONL this command reads.
+- `skills/superpowers.md` § "Companion-Preference Override" — the broader contract for the setting this command's dataset measures.
+- `commands/dashboard.md` — the broader continuous-improvement status surface; this command is the dispatcher-bias-specific narrower view.

--- a/docs/plans/2026-05-14-companion-preference-status-reader.md
+++ b/docs/plans/2026-05-14-companion-preference-status-reader.md
@@ -1,0 +1,113 @@
+# Companion-Preference Status Reader (`/companion-preference status`)
+
+**Date:** 2026-05-14
+**Slug:** `companion-preference-status-reader`
+**Operator:** Naim
+**Reason:** PR #138 ships the JSONL telemetry writer but produces no read-side affordance — the dataset sits inert until someone manually greps it. PR 5 lands the smallest piece of work that converts the telemetry into actionable signal: one CLI (`bin/companion-preference-status.mjs`) and one slash command (`/companion-preference status`) that aggregates the JSONL by `ci_skill` over a configurable window and reports counts plus companion-installed%. This is the JSONL-reader WILD from the 2026-05-13 train, promoted to a single-concern follow-up.
+
+## Single-concern scope
+
+| PR | Title | Scope (files) | Test strategy | Merge order |
+|---|---|---|---|---|
+| 5 | `feat(cli): companion-preference status reader for telemetry JSONL` | `src/bin/companion-preference-status.mts` (new CLI), `src/test/companion-preference-status.test.mts` (RED-then-GREEN), `commands/companion-preference.md` (new slash command), `skills/superpowers.md` (cross-reference under Telemetry), `src/bin/check-docs-substrings.mts` (2–3 assertions) + the generated `.mjs` / plugin mirrors | TDD: 7–8 RED tests written before any production code; full suite + verify:all stays green | Independent — does not require PR #138 to merge first (CLI handles missing JSONL gracefully) |
+
+## CLI behavior
+
+```
+node bin/companion-preference-status.mjs              # last 7 days, human-readable
+node bin/companion-preference-status.mjs --days 30    # last 30 days
+node bin/companion-preference-status.mjs --all        # entire file, no window
+node bin/companion-preference-status.mjs --json       # machine-readable JSON
+node bin/companion-preference-status.mjs --path <p>   # override JSONL path (testing)
+```
+
+Human output (default):
+
+```
+Companion-preference telemetry — last 7 days
+File:   ~/.claude/instincts/<hash>/companion-preference.jsonl
+Window: 2026-05-07T00:00:00Z to 2026-05-14T...
+
+ci_skill            total  observation  advisory  block  block-not-installed  installed%
+tdd-workflow          142          120        15      7                    0          91
+verification-loop      38           38          0      0                    0         100
+context-budget         12           10          2      0                    0          67
+ralph                   4            4          0      0                    0           0
+learn-eval              0            0          0      0                    0           —
+
+Mode totals: ci-first 168, companions-first 17, strict-companions 7
+Total events: 196
+```
+
+JSON output:
+
+```json
+{
+  "file": "/home/x/.claude/instincts/abc123/companion-preference.jsonl",
+  "window_days": 7,
+  "since": "2026-05-07T00:00:00Z",
+  "total_events": 196,
+  "by_skill": {
+    "tdd-workflow": {
+      "total": 142,
+      "actions": { "observation": 120, "advisory": 15, "block": 7, "block-not-installed": 0 },
+      "installed_pct": 91
+    }
+  },
+  "by_mode": { "ci-first": 168, "companions-first": 17, "strict-companions": 7 }
+}
+```
+
+## TDD plan
+
+RED — tests written first, watched to fail:
+
+1. Missing JSONL file → friendly "no telemetry recorded yet" message; exit 0.
+2. Empty JSONL file → all zero counts; exit 0.
+3. Single `observation` row in window → counted under correct skill, action=observation.
+4. Rows older than `--days` window → excluded by default, included under `--all`.
+5. `--json` flag outputs valid parseable JSON with the documented shape.
+6. Malformed JSONL lines silently skipped; a `parse_errors` count appears in `--json` output.
+7. `installed_pct` is `null` (rendered as `—` in human output) when total = 0; otherwise rounded integer 0–100.
+8. `--path` override lets tests target an arbitrary JSONL file without touching `$HOME`.
+
+GREEN — implement `src/bin/companion-preference-status.mts` until all RED tests pass.
+
+## Slash command
+
+`commands/companion-preference.md` is a thin markdown wrapper:
+
+```yaml
+---
+name: companion-preference
+description: Inspect the companion-preference hook telemetry — counts by CI skill, action breakdown, and companion-installed%.
+---
+```
+
+Trigger phrases: `/companion-preference`, `/companion-preference status`, "show companion preference stats". The body instructs the agent to run the CLI with sensible defaults and render the output.
+
+## Out of scope
+
+- Any change to the hook itself or to the telemetry write path.
+- Log rotation, TTL, or compaction of the JSONL file.
+- A `--by-mode` or `--by-companion` aggregation axis beyond what the spec captures.
+- Adding a `bin` entry to `package.json` (touching the manifests would cross the single-concern line; the slash command invokes the CLI by relative path).
+- Hooking the reader into `/dashboard` or `/seven-laws` — separate follow-up if telemetry usage justifies integration.
+
+## Verification ladder
+
+- `npm test` — current 548 tests stay green; +7–8 new tests for the CLI bring the suite to ~556.
+- `npm run verify:all` — 8 invariants stay green. `docs-substrings` gains 2–4 assertions locking the new command file + JSONL filename literal in `commands/companion-preference.md`.
+- Manual: invoke the CLI against a synthetic JSONL fixture and confirm human + JSON output match the spec.
+
+## End-state behavior
+
+After PR 5 merges, the dispatcher-bias surface has:
+
+- PR #133 — documented protocol (settings key).
+- PR #134 — `/proceed --once` companion mode.
+- PR #136 — runtime enforcement (hook).
+- PR #138 — write-side telemetry (JSONL).
+- **PR 5 — read-side aggregation (CLI + slash command).**
+
+The operator can run `/companion-preference status` after a 7-day window and see exactly which routing rows the override fires on, how often, and whether the companion plugin was installed at the time. That dataset is what makes a future default-flip decision evidence-driven, closing the loop the dispatcher-bias train was built around.

--- a/plugins/continuous-improvement/commands/companion-preference.md
+++ b/plugins/continuous-improvement/commands/companion-preference.md
@@ -1,0 +1,58 @@
+---
+name: companion-preference
+description: Inspect companion-preference hook telemetry — counts by CI skill, action breakdown, and companion-installed%.
+---
+
+# /companion-preference
+
+Read and aggregate the JSONL telemetry written by `hooks/companion-preference.mjs`. Reports per-skill totals, action breakdown (`observation`, `advisory`, `block`, `block-not-installed`), and the share of events where the companion plugin was installed at the time.
+
+The dataset is the evidence base for a future `companions-first` default-flip decision — once a 7-day shadow shows the `companions-first` path firing on a meaningful share of routed Skill calls, with companions installed in the majority of them, the flip is grounded.
+
+## Trigger phrases
+
+- `/companion-preference`
+- `/companion-preference status`
+- "show companion preference stats"
+- "what does the companion-preference hook see"
+
+## What happens
+
+1. Run `node bin/companion-preference-status.mjs` from the repo root with the operator's chosen window. Default `--days 7`. Pass `--all` for the entire file or `--days N` for a different window.
+2. Render the table the CLI emits to the user verbatim. Do not paraphrase the numbers — the JSONL is authoritative.
+3. If the CLI prints "no telemetry recorded yet," check three things in order: (a) `~/.claude/settings.json` has `continuous_improvement.companion_preference` set (otherwise the hook is a no-op and writes nothing); (b) the user has invoked at least one mapped CI skill (`tdd-workflow`, `verification-loop`, `context-budget`, `ralph`, `learn-eval`) since the hook landed; (c) the hook's PreToolUse registration is intact in `plugins/continuous-improvement/hooks/hooks.json`.
+4. Offer one decision-ready next step based on the totals — e.g., "ratio of `observation` rows with `companion_installed=true` suggests `companions-first` is safe to flip for X but not Y."
+
+## Subcommands
+
+### `/companion-preference status` (default)
+
+Same as `/companion-preference`.
+
+### `/companion-preference status --json`
+
+Emit the machine-readable JSON report. Useful when you want to pipe the output into another tool or write your own aggregator.
+
+```bash
+node bin/companion-preference-status.mjs --json --all
+```
+
+## CLI flags
+
+| Flag | Effect |
+|---|---|
+| `--days N` | Only count events from the last N days (default 7). |
+| `--all` | Ignore the window; count every row in the file. |
+| `--json` | Emit a machine-readable JSON report. |
+| `--path <file>` | Override the default JSONL path. Used by the test suite; rarely needed in practice. |
+| `-h`, `--help` | Print CLI help and exit. |
+
+## Path resolution
+
+By default the CLI reads `~/.claude/instincts/<project-hash>/companion-preference.jsonl`, where the hash is the same `sha256(projectRoot).slice(0, 12)` that the hook itself uses. The project root resolves via `CLAUDE_PROJECT_DIR` env var if set, else `git rev-parse --show-toplevel`, else the literal `"global"`. Hash and path scheme are reused verbatim from `hooks/companion-preference.mjs` to keep the read side aligned with the write side.
+
+## Companion skills
+
+- `hooks/companion-preference.mjs` — the writer that produces the JSONL this command reads.
+- `skills/superpowers.md` § "Companion-Preference Override" — the broader contract for the setting this command's dataset measures.
+- `commands/dashboard.md` — the broader continuous-improvement status surface; this command is the dispatcher-bias-specific narrower view.

--- a/src/bin/check-docs-substrings.mts
+++ b/src/bin/check-docs-substrings.mts
@@ -336,6 +336,21 @@ export const DOCS_ASSERTIONS: DocsAssertion[] = [
   { file: "plugins/continuous-improvement/skills/proceed-with-the-recommendation/SKILL.md", pattern: "Skipped.** Reason: single-item", source: "docs-substrings-manifest:proceed-once-mode" },
   { file: "commands/proceed-with-the-recommendation.md", pattern: "Fast-path: `--once` mode", source: "docs-substrings-manifest:proceed-once-mode" },
   { file: "plugins/continuous-improvement/commands/proceed-with-the-recommendation.md", pattern: "Fast-path: `--once` mode", source: "docs-substrings-manifest:proceed-once-mode" },
+
+  // /companion-preference status reader — locked 2026-05-14 (PR 5 of dispatcher-bias train).
+  // The reader CLI (bin/companion-preference-status.mjs) and slash command (commands/companion-preference.md)
+  // turn the JSONL telemetry from PR #138 into a per-skill aggregation report. The slash command must
+  // expose the frontmatter name, the canonical CLI invocation, and the documented --json subcommand.
+  // Each assertion catches a specific class of regression:
+  //   - "name: companion-preference"                → renaming the slash command
+  //   - "companion-preference-status.mjs"            → renaming the CLI entry point
+  //   - "## Subcommands"                             → losing the documented surface (--json, --days, --all)
+  { file: "commands/companion-preference.md", pattern: "name: companion-preference", source: "docs-substrings-manifest:companion-preference-status-reader" },
+  { file: "plugins/continuous-improvement/commands/companion-preference.md", pattern: "name: companion-preference", source: "docs-substrings-manifest:companion-preference-status-reader" },
+  { file: "commands/companion-preference.md", pattern: "companion-preference-status.mjs", source: "docs-substrings-manifest:companion-preference-status-reader" },
+  { file: "plugins/continuous-improvement/commands/companion-preference.md", pattern: "companion-preference-status.mjs", source: "docs-substrings-manifest:companion-preference-status-reader" },
+  { file: "commands/companion-preference.md", pattern: "## Subcommands", source: "docs-substrings-manifest:companion-preference-status-reader" },
+  { file: "plugins/continuous-improvement/commands/companion-preference.md", pattern: "## Subcommands", source: "docs-substrings-manifest:companion-preference-status-reader" },
 ];
 
 export interface AssertionFailure {

--- a/src/bin/companion-preference-status.mts
+++ b/src/bin/companion-preference-status.mts
@@ -1,0 +1,290 @@
+#!/usr/bin/env node
+/**
+ * /companion-preference status — read & aggregate hook telemetry.
+ *
+ * Reads ~/.claude/instincts/<project-hash>/companion-preference.jsonl
+ * (or an explicit path via --path), groups events by ci_skill within the
+ * configured window (default 7 days), and prints a summary report with
+ * per-skill totals, action breakdown, and companion_installed%.
+ *
+ * Usage:
+ *   node bin/companion-preference-status.mjs              # last 7 days, human
+ *   node bin/companion-preference-status.mjs --days 30    # 30-day window
+ *   node bin/companion-preference-status.mjs --all        # whole file, no window
+ *   node bin/companion-preference-status.mjs --json       # machine-readable JSON
+ *   node bin/companion-preference-status.mjs --path <p>   # override JSONL path
+ *
+ * Exit codes:
+ *   0 — report rendered (including the "no telemetry recorded yet" case)
+ *   1 — argument parse error or unexpected runtime failure
+ */
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { argv, exit, stdout } from "node:process";
+
+interface TelemetryLine {
+  ts: string;
+  hook: string;
+  mode: "ci-first" | "companions-first" | "strict-companions";
+  action: "observation" | "advisory" | "block" | "block-not-installed";
+  ci_skill: string;
+  companion: string;
+  plugin: string;
+  companion_installed: boolean;
+}
+
+interface SkillStats {
+  total: number;
+  actions: Record<string, number>;
+  installed_pct: number | null;
+}
+
+interface JsonReport {
+  file: string;
+  window_days: number | null;
+  since: string | null;
+  total_events: number;
+  parse_errors: number;
+  by_skill: Record<string, SkillStats>;
+  by_mode: Record<string, number>;
+}
+
+interface Args {
+  days: number | null;
+  all: boolean;
+  json: boolean;
+  path: string | null;
+}
+
+const ACTIONS: ReadonlyArray<TelemetryLine["action"]> = [
+  "observation",
+  "advisory",
+  "block",
+  "block-not-installed",
+];
+
+function parseArgs(args: string[]): Args {
+  const out: Args = { days: 7, all: false, json: false, path: null };
+  for (let i = 0; i < args.length; i += 1) {
+    const a = args[i];
+    if (a === "--days") {
+      const v = Number(args[++i]);
+      if (!Number.isFinite(v) || v <= 0) {
+        process.stderr.write(`--days requires a positive integer (got ${args[i]})\n`);
+        exit(1);
+      }
+      out.days = v;
+    } else if (a === "--all") {
+      out.all = true;
+      out.days = null;
+    } else if (a === "--json") {
+      out.json = true;
+    } else if (a === "--path") {
+      out.path = args[++i] ?? null;
+      if (!out.path) {
+        process.stderr.write(`--path requires a value\n`);
+        exit(1);
+      }
+    } else if (a === "--help" || a === "-h") {
+      printHelp();
+      exit(0);
+    } else if (a !== undefined) {
+      process.stderr.write(`unknown argument: ${a}\n`);
+      exit(1);
+    }
+  }
+  return out;
+}
+
+function printHelp(): void {
+  stdout.write(
+    [
+      "Usage: companion-preference-status [options]",
+      "",
+      "Options:",
+      "  --days N       Only count events from the last N days (default 7)",
+      "  --all          Ignore the window; count every row in the file",
+      "  --json         Emit a machine-readable JSON report",
+      "  --path <file>  Override the default JSONL path (testing)",
+      "  -h, --help     Print this help",
+      "",
+    ].join("\n"),
+  );
+}
+
+function resolveProjectRoot(): string {
+  const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+  if (fromEnv) return fromEnv;
+  try {
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (root) return root;
+  } catch {
+    // not in a git repo
+  }
+  return "global";
+}
+
+function defaultJsonlPath(): string {
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+  const hash = createHash("sha256")
+    .update(resolveProjectRoot())
+    .digest("hex")
+    .slice(0, 12);
+  return join(home, ".claude", "instincts", hash, "companion-preference.jsonl");
+}
+
+function parseJsonl(raw: string): { rows: TelemetryLine[]; parseErrors: number } {
+  const rows: TelemetryLine[] = [];
+  let parseErrors = 0;
+  for (const line of raw.split(/\r?\n/)) {
+    if (line.trim().length === 0) continue;
+    try {
+      rows.push(JSON.parse(line) as TelemetryLine);
+    } catch {
+      parseErrors += 1;
+    }
+  }
+  return { rows, parseErrors };
+}
+
+function aggregate(
+  rows: TelemetryLine[],
+): { bySkill: Record<string, SkillStats>; byMode: Record<string, number> } {
+  const bySkill: Record<string, SkillStats> = {};
+  const byMode: Record<string, number> = {};
+  const installedYes: Record<string, number> = {};
+  for (const row of rows) {
+    const stats = (bySkill[row.ci_skill] ??= {
+      total: 0,
+      actions: {},
+      installed_pct: null,
+    });
+    stats.total += 1;
+    stats.actions[row.action] = (stats.actions[row.action] ?? 0) + 1;
+    if (row.companion_installed) {
+      installedYes[row.ci_skill] = (installedYes[row.ci_skill] ?? 0) + 1;
+    }
+    byMode[row.mode] = (byMode[row.mode] ?? 0) + 1;
+  }
+  for (const [skill, stats] of Object.entries(bySkill)) {
+    stats.installed_pct =
+      stats.total > 0
+        ? Math.round(((installedYes[skill] ?? 0) * 100) / stats.total)
+        : null;
+  }
+  return { bySkill, byMode };
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+
+function rpad(n: number | string, width: number): string {
+  const s = String(n);
+  return s.length >= width ? s : " ".repeat(width - s.length) + s;
+}
+
+function formatHuman(report: JsonReport): string {
+  const lines: string[] = [];
+  const windowLabel = report.window_days === null ? "all-time" : `last ${report.window_days} days`;
+  lines.push(`Companion-preference telemetry — ${windowLabel}`);
+  lines.push(`File:   ${report.file}`);
+  if (report.since) lines.push(`Window: ${report.since} to ${new Date().toISOString()}`);
+  lines.push("");
+  if (report.total_events === 0) {
+    lines.push("No events in window.");
+  } else {
+    const skillWidth = Math.max(
+      8,
+      ...Object.keys(report.by_skill).map((k) => k.length),
+    );
+    const header =
+      pad("ci_skill", skillWidth) +
+      "  " +
+      ["total", "observation", "advisory", "block", "block-not-installed", "installed%"]
+        .map((h) => rpad(h, h.length))
+        .join("  ");
+    lines.push(header);
+    for (const [skill, stats] of Object.entries(report.by_skill).sort(
+      (a, b) => b[1].total - a[1].total,
+    )) {
+      const cells = [
+        rpad(stats.total, "total".length),
+        rpad(stats.actions.observation ?? 0, "observation".length),
+        rpad(stats.actions.advisory ?? 0, "advisory".length),
+        rpad(stats.actions.block ?? 0, "block".length),
+        rpad(stats.actions["block-not-installed"] ?? 0, "block-not-installed".length),
+        rpad(
+          stats.installed_pct === null ? "—" : `${stats.installed_pct}`,
+          "installed%".length,
+        ),
+      ].join("  ");
+      lines.push(pad(skill, skillWidth) + "  " + cells);
+    }
+  }
+  lines.push("");
+  const modeEntries = Object.entries(report.by_mode);
+  if (modeEntries.length > 0) {
+    lines.push(`Mode totals: ${modeEntries.map(([k, v]) => `${k} ${v}`).join(", ")}`);
+  }
+  lines.push(`Total events: ${report.total_events}`);
+  if (report.parse_errors > 0) lines.push(`Parse errors (skipped): ${report.parse_errors}`);
+  return lines.join("\n") + "\n";
+}
+
+function main(): void {
+  const args = parseArgs(argv.slice(2));
+  const filePath = args.path ?? defaultJsonlPath();
+  if (!existsSync(filePath)) {
+    stdout.write(
+      `Companion-preference telemetry: no telemetry recorded yet at ${filePath}\n`,
+    );
+    exit(0);
+  }
+  const raw = readFileSync(filePath, "utf8");
+  const { rows, parseErrors } = parseJsonl(raw);
+  const cutoff =
+    args.all || args.days === null
+      ? null
+      : new Date(Date.now() - args.days * 24 * 3600 * 1000).toISOString();
+  const filtered = cutoff === null ? rows : rows.filter((r) => r.ts >= cutoff);
+  const { bySkill, byMode } = aggregate(filtered);
+  const report: JsonReport = {
+    file: filePath,
+    window_days: args.all ? null : args.days,
+    since: cutoff,
+    total_events: filtered.length,
+    parse_errors: parseErrors,
+    by_skill: bySkill,
+    by_mode: byMode,
+  };
+  if (args.json) {
+    stdout.write(JSON.stringify(report, null, 2) + "\n");
+  } else {
+    stdout.write(formatHuman(report));
+  }
+  exit(0);
+}
+
+const invokedDirectly = argv[1]?.endsWith("companion-preference-status.mjs");
+if (invokedDirectly) {
+  main();
+}
+
+export {
+  ACTIONS,
+  aggregate,
+  parseArgs,
+  parseJsonl,
+  type Args,
+  type JsonReport,
+  type SkillStats,
+  type TelemetryLine,
+};

--- a/src/test/companion-preference-status.test.mts
+++ b/src/test/companion-preference-status.test.mts
@@ -1,0 +1,258 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname resolves to <repo>/test/ at runtime; CLI lives under <repo>/bin/.
+const CLI_PATH = join(__dirname, "..", "bin", "companion-preference-status.mjs");
+
+interface CliResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+function runCli(args: string[]): CliResult {
+  const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+interface TelemetryLine {
+  ts: string;
+  hook: "companion-preference";
+  mode: "ci-first" | "companions-first" | "strict-companions";
+  action: "observation" | "advisory" | "block" | "block-not-installed";
+  ci_skill: string;
+  companion: string;
+  plugin: string;
+  companion_installed: boolean;
+}
+
+function makeLine(overrides: Partial<TelemetryLine> = {}): TelemetryLine {
+  return {
+    ts: new Date().toISOString(),
+    hook: "companion-preference",
+    mode: "ci-first",
+    action: "observation",
+    ci_skill: "tdd-workflow",
+    companion: "superpowers:test-driven-development",
+    plugin: "superpowers",
+    companion_installed: false,
+    ...overrides,
+  };
+}
+
+function writeFixture(dir: string, lines: TelemetryLine[]): string {
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, "companion-preference.jsonl");
+  writeFileSync(
+    path,
+    lines.map((l) => JSON.stringify(l)).join("\n") + (lines.length > 0 ? "\n" : ""),
+  );
+  return path;
+}
+
+interface JsonReport {
+  file: string;
+  window_days: number | null;
+  since: string | null;
+  total_events: number;
+  parse_errors?: number;
+  by_skill: Record<
+    string,
+    {
+      total: number;
+      actions: Record<string, number>;
+      installed_pct: number | null;
+    }
+  >;
+  by_mode: Record<string, number>;
+}
+
+describe("/companion-preference status CLI", () => {
+  let workdir: string;
+
+  before(() => {
+    workdir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-"));
+  });
+
+  after(() => {
+    rmSync(workdir, { recursive: true, force: true });
+  });
+
+  it("emits a friendly message when the JSONL file is missing (exit 0)", () => {
+    const missingPath = join(workdir, "missing-dir", "companion-preference.jsonl");
+    const r = runCli(["--path", missingPath]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /no telemetry recorded yet/i);
+  });
+
+  it("handles an empty JSONL file with zero counts (exit 0)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-empty-"));
+    try {
+      const path = writeFixture(dir, []);
+      const r = runCli(["--path", path, "--json"]);
+      assert.equal(r.status, 0);
+      const report = JSON.parse(r.stdout) as JsonReport;
+      assert.equal(report.total_events, 0);
+      assert.deepEqual(report.by_skill, {});
+      assert.deepEqual(report.by_mode, {});
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("aggregates a single observation row correctly", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-single-"));
+    try {
+      const path = writeFixture(dir, [
+        makeLine({ action: "observation", mode: "ci-first" }),
+      ]);
+      const r = runCli(["--path", path, "--json", "--all"]);
+      assert.equal(r.status, 0);
+      const report = JSON.parse(r.stdout) as JsonReport;
+      assert.equal(report.total_events, 1);
+      assert.equal(report.by_skill["tdd-workflow"]?.total, 1);
+      assert.equal(report.by_skill["tdd-workflow"]?.actions.observation, 1);
+      assert.equal(report.by_mode["ci-first"], 1);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes rows older than the window by default; --all includes them", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-window-"));
+    try {
+      const oldTs = new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString();
+      const newTs = new Date().toISOString();
+      const path = writeFixture(dir, [
+        makeLine({ ts: oldTs, action: "observation" }),
+        makeLine({ ts: newTs, action: "observation" }),
+      ]);
+
+      const windowed = runCli(["--path", path, "--json"]);
+      assert.equal(
+        (JSON.parse(windowed.stdout) as JsonReport).total_events,
+        1,
+        "default 7-day window excludes the 30-day-old row",
+      );
+
+      const all = runCli(["--path", path, "--json", "--all"]);
+      assert.equal(
+        (JSON.parse(all.stdout) as JsonReport).total_events,
+        2,
+        "--all includes the 30-day-old row",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("--json output is valid JSON with the documented shape", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-shape-"));
+    try {
+      const path = writeFixture(dir, [
+        makeLine({ action: "advisory", mode: "companions-first", companion_installed: true }),
+        makeLine({ action: "block", mode: "strict-companions", companion_installed: true }),
+        makeLine({ action: "block-not-installed", mode: "strict-companions", companion_installed: false }),
+      ]);
+      const r = runCli(["--path", path, "--json", "--all"]);
+      assert.equal(r.status, 0);
+      const report = JSON.parse(r.stdout) as JsonReport;
+      assert.equal(typeof report.file, "string");
+      assert.equal(report.total_events, 3);
+      assert.ok(typeof report.parse_errors === "number");
+      const skill = report.by_skill["tdd-workflow"]!;
+      assert.equal(skill.total, 3);
+      assert.equal(skill.actions.advisory, 1);
+      assert.equal(skill.actions.block, 1);
+      assert.equal(skill.actions["block-not-installed"], 1);
+      assert.equal(report.by_mode["companions-first"], 1);
+      assert.equal(report.by_mode["strict-companions"], 2);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("silently skips malformed lines and counts them in parse_errors", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-bad-"));
+    try {
+      const path = join(dir, "companion-preference.jsonl");
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(
+        path,
+        [
+          JSON.stringify(makeLine({ action: "observation" })),
+          "{not valid json",
+          "",
+          JSON.stringify(makeLine({ action: "advisory", mode: "companions-first" })),
+          "another broken line {",
+        ].join("\n") + "\n",
+      );
+      const r = runCli(["--path", path, "--json", "--all"]);
+      assert.equal(r.status, 0);
+      const report = JSON.parse(r.stdout) as JsonReport;
+      assert.equal(report.total_events, 2, "two well-formed rows counted");
+      assert.equal(report.parse_errors, 2, "two malformed rows skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("installed_pct is null when total is 0, otherwise rounded 0-100", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-pct-"));
+    try {
+      // Two rows for tdd-workflow: one installed, one not -> 50%
+      // One row for verification-loop: installed -> 100%
+      const path = writeFixture(dir, [
+        makeLine({ ci_skill: "tdd-workflow", companion_installed: true }),
+        makeLine({ ci_skill: "tdd-workflow", companion_installed: false }),
+        makeLine({
+          ci_skill: "verification-loop",
+          companion: "superpowers:verification-before-completion",
+          companion_installed: true,
+        }),
+      ]);
+      const r = runCli(["--path", path, "--json", "--all"]);
+      const report = JSON.parse(r.stdout) as JsonReport;
+      assert.equal(report.by_skill["tdd-workflow"]?.installed_pct, 50);
+      assert.equal(report.by_skill["verification-loop"]?.installed_pct, 100);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("human output renders a table header naming the documented columns", () => {
+    const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-human-"));
+    try {
+      const path = writeFixture(dir, [makeLine({ action: "observation" })]);
+      const r = runCli(["--path", path, "--all"]);
+      assert.equal(r.status, 0);
+      // Header line must mention the canonical column names so a reader can
+      // map the columns to the JSON shape without docs.
+      assert.match(r.stdout, /ci_skill/);
+      assert.match(r.stdout, /total/);
+      assert.match(r.stdout, /observation/);
+      assert.match(r.stdout, /installed%/);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/companion-preference-status.test.mjs
+++ b/test/companion-preference-status.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync, } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname resolves to <repo>/test/ at runtime; CLI lives under <repo>/bin/.
+const CLI_PATH = join(__dirname, "..", "bin", "companion-preference-status.mjs");
+function runCli(args) {
+    const result = spawnSync(process.execPath, [CLI_PATH, ...args], {
+        encoding: "utf8",
+        timeout: 5000,
+    });
+    if (result.error)
+        throw result.error;
+    return {
+        status: result.status,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+function makeLine(overrides = {}) {
+    return {
+        ts: new Date().toISOString(),
+        hook: "companion-preference",
+        mode: "ci-first",
+        action: "observation",
+        ci_skill: "tdd-workflow",
+        companion: "superpowers:test-driven-development",
+        plugin: "superpowers",
+        companion_installed: false,
+        ...overrides,
+    };
+}
+function writeFixture(dir, lines) {
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, "companion-preference.jsonl");
+    writeFileSync(path, lines.map((l) => JSON.stringify(l)).join("\n") + (lines.length > 0 ? "\n" : ""));
+    return path;
+}
+describe("/companion-preference status CLI", () => {
+    let workdir;
+    before(() => {
+        workdir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-"));
+    });
+    after(() => {
+        rmSync(workdir, { recursive: true, force: true });
+    });
+    it("emits a friendly message when the JSONL file is missing (exit 0)", () => {
+        const missingPath = join(workdir, "missing-dir", "companion-preference.jsonl");
+        const r = runCli(["--path", missingPath]);
+        assert.equal(r.status, 0);
+        assert.match(r.stdout, /no telemetry recorded yet/i);
+    });
+    it("handles an empty JSONL file with zero counts (exit 0)", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-empty-"));
+        try {
+            const path = writeFixture(dir, []);
+            const r = runCli(["--path", path, "--json"]);
+            assert.equal(r.status, 0);
+            const report = JSON.parse(r.stdout);
+            assert.equal(report.total_events, 0);
+            assert.deepEqual(report.by_skill, {});
+            assert.deepEqual(report.by_mode, {});
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("aggregates a single observation row correctly", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-single-"));
+        try {
+            const path = writeFixture(dir, [
+                makeLine({ action: "observation", mode: "ci-first" }),
+            ]);
+            const r = runCli(["--path", path, "--json", "--all"]);
+            assert.equal(r.status, 0);
+            const report = JSON.parse(r.stdout);
+            assert.equal(report.total_events, 1);
+            assert.equal(report.by_skill["tdd-workflow"]?.total, 1);
+            assert.equal(report.by_skill["tdd-workflow"]?.actions.observation, 1);
+            assert.equal(report.by_mode["ci-first"], 1);
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("excludes rows older than the window by default; --all includes them", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-window-"));
+        try {
+            const oldTs = new Date(Date.now() - 30 * 24 * 3600 * 1000).toISOString();
+            const newTs = new Date().toISOString();
+            const path = writeFixture(dir, [
+                makeLine({ ts: oldTs, action: "observation" }),
+                makeLine({ ts: newTs, action: "observation" }),
+            ]);
+            const windowed = runCli(["--path", path, "--json"]);
+            assert.equal(JSON.parse(windowed.stdout).total_events, 1, "default 7-day window excludes the 30-day-old row");
+            const all = runCli(["--path", path, "--json", "--all"]);
+            assert.equal(JSON.parse(all.stdout).total_events, 2, "--all includes the 30-day-old row");
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("--json output is valid JSON with the documented shape", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-shape-"));
+        try {
+            const path = writeFixture(dir, [
+                makeLine({ action: "advisory", mode: "companions-first", companion_installed: true }),
+                makeLine({ action: "block", mode: "strict-companions", companion_installed: true }),
+                makeLine({ action: "block-not-installed", mode: "strict-companions", companion_installed: false }),
+            ]);
+            const r = runCli(["--path", path, "--json", "--all"]);
+            assert.equal(r.status, 0);
+            const report = JSON.parse(r.stdout);
+            assert.equal(typeof report.file, "string");
+            assert.equal(report.total_events, 3);
+            assert.ok(typeof report.parse_errors === "number");
+            const skill = report.by_skill["tdd-workflow"];
+            assert.equal(skill.total, 3);
+            assert.equal(skill.actions.advisory, 1);
+            assert.equal(skill.actions.block, 1);
+            assert.equal(skill.actions["block-not-installed"], 1);
+            assert.equal(report.by_mode["companions-first"], 1);
+            assert.equal(report.by_mode["strict-companions"], 2);
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("silently skips malformed lines and counts them in parse_errors", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-bad-"));
+        try {
+            const path = join(dir, "companion-preference.jsonl");
+            mkdirSync(dir, { recursive: true });
+            writeFileSync(path, [
+                JSON.stringify(makeLine({ action: "observation" })),
+                "{not valid json",
+                "",
+                JSON.stringify(makeLine({ action: "advisory", mode: "companions-first" })),
+                "another broken line {",
+            ].join("\n") + "\n");
+            const r = runCli(["--path", path, "--json", "--all"]);
+            assert.equal(r.status, 0);
+            const report = JSON.parse(r.stdout);
+            assert.equal(report.total_events, 2, "two well-formed rows counted");
+            assert.equal(report.parse_errors, 2, "two malformed rows skipped");
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("installed_pct is null when total is 0, otherwise rounded 0-100", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-pct-"));
+        try {
+            // Two rows for tdd-workflow: one installed, one not -> 50%
+            // One row for verification-loop: installed -> 100%
+            const path = writeFixture(dir, [
+                makeLine({ ci_skill: "tdd-workflow", companion_installed: true }),
+                makeLine({ ci_skill: "tdd-workflow", companion_installed: false }),
+                makeLine({
+                    ci_skill: "verification-loop",
+                    companion: "superpowers:verification-before-completion",
+                    companion_installed: true,
+                }),
+            ]);
+            const r = runCli(["--path", path, "--json", "--all"]);
+            const report = JSON.parse(r.stdout);
+            assert.equal(report.by_skill["tdd-workflow"]?.installed_pct, 50);
+            assert.equal(report.by_skill["verification-loop"]?.installed_pct, 100);
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+    it("human output renders a table header naming the documented columns", () => {
+        const dir = mkdtempSync(join(tmpdir(), "ci-comp-pref-cli-human-"));
+        try {
+            const path = writeFixture(dir, [makeLine({ action: "observation" })]);
+            const r = runCli(["--path", path, "--all"]);
+            assert.equal(r.status, 0);
+            // Header line must mention the canonical column names so a reader can
+            // map the columns to the JSON shape without docs.
+            assert.match(r.stdout, /ci_skill/);
+            assert.match(r.stdout, /total/);
+            assert.match(r.stdout, /observation/);
+            assert.match(r.stdout, /installed%/);
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `bin/companion-preference-status.mjs`, a CLI that reads the JSONL telemetry written by `hooks/companion-preference.mjs` (PR #138, in-flight) and aggregates by `ci_skill` with action breakdown and `companion_installed%`.
- Adds `commands/companion-preference.md`, a slash command (`/companion-preference`, `/companion-preference status`) that surfaces the CLI to operators with sensible defaults.
- Flags: `--days N` (default 7), `--all`, `--json`, `--path <file>`, `--help`.
- Human output renders a per-skill table; `--json` emits a machine-readable report with `by_skill`, `by_mode`, `total_events`, `parse_errors`, and `window_days`.

## Motivation
PR #138 ships the JSONL telemetry writer. Without a read-side affordance, the dataset sits inert until someone manually greps it. This PR delivers the smallest piece of work that converts the telemetry into actionable signal: an aggregator that lets the operator see exactly which routing rows the override fires on, how often, and whether the companion was installed at the time. That is the dataset the 2026-05-13 dispatcher-bias train was built to produce.

## Independence from PR #138
This PR does not require PR #138 to merge first:
- The CLI handles a missing JSONL file gracefully (prints "no telemetry recorded yet" and exits 0).
- The slash command cross-references `skills/superpowers.md § "Companion-Preference Override"` (on `main` since PR #133), not the new "### Telemetry" subsection from PR #138.
- A future micro-PR can add a `See also: /companion-preference` link under the Telemetry subsection once both PRs land.

## Scope (single concern, 9 files)
- `src/bin/companion-preference-status.mts` — new CLI (~210 LOC).
- `src/test/companion-preference-status.test.mts` — 8 RED-then-GREEN tests with hermetic per-test tmpdirs.
- `commands/companion-preference.md` — new slash command (~60 LOC) including frontmatter, trigger phrases, subcommands, flag table, and path-resolution spec.
- `src/bin/check-docs-substrings.mts` — 6 assertions across source + plugin mirror locking `name: companion-preference`, `companion-preference-status.mjs`, and `## Subcommands`.
- All generated `.mjs` / plugin mirrors rebuild from the `.mts` sources via `npm run build`.
- Plan doc: `docs/plans/2026-05-14-companion-preference-status-reader.md`.

## Test plan
- [x] **RED**: 8 CLI tests written first; all failed against the missing `bin/companion-preference-status.mjs` (first assertion in the smallest test got `1 !== 0` on the spawn exit code).
- [x] **GREEN**: implementation drove all 8 to pass. `npm test` — 550/550 (was 542 before; +8 new).
- [x] **VERIFY**: `npm run verify:all` — 8 invariants green. `docs-substrings` grew from 162 to 168.
- [x] **Hermetic tests**: each CLI test uses its own fresh tmpdir + `--path` override so the file under test is isolated from `$HOME`.

## Out of scope
- Adding a `bin` entry to `package.json` — that would regenerate the plugin manifest and cross the single-concern line. The slash command invokes the CLI by relative path.
- Modifying `skills/superpowers.md` — the new "### Telemetry" subsection ships in PR #138; this PR avoids a forward dependency by skipping that edit.
- Log rotation, TTL, compaction of the JSONL — separate follow-up if file size becomes a concern after the 7-day shadow.
- A `--by-mode` or `--by-companion` aggregation axis beyond what the spec captures.
- Hooking the reader into `/dashboard` or `/seven-laws` — separate follow-up if telemetry usage justifies integration.

## Past Mistake Acknowledgment Gate
- **PR #66 wiped by tsc** — active. All edits in `.mts`; `.mjs` regenerated by `npm run build`.
- **PR #136 generator-source mistake** — active. Deliberately kept the new CLI off the `package.json` `bin` map so the manifest generators don't regenerate during this PR.
- **Direct push to main** — using feature branch + PR flow.
- **Local-main bundling** — branched from `origin/main` (`338a303`), not local main.

**Will NOT repeat:** assuming any "ride-along" change to `package.json` is harmless during a feature PR — every `bin` entry triggers a manifest regen that crosses the single-concern line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)