### PR TITLE
feat(hooks): observe→PostToolUse only, doc-drift test, prompt router

### DIFF
--- a/hooks/route-prompt.mjs
+++ b/hooks/route-prompt.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Runtime UserPromptSubmit prompt-router hook.
+ *
+ * Reads the user prompt, matches it against patterns in
+ * hooks/route-table.json, and emits a single `<system-reminder>` recommending
+ * the matched skill. When no row matches, the hook emits nothing — the prompt
+ * passes through untouched.
+ *
+ * Stdin  : JSON { prompt, session_id?, transcript_path?, cwd? }
+ * Stdout : JSON { hookSpecificOutput: { hookEventName: "UserPromptSubmit",
+ *                                       additionalContext: string } }
+ *          OR empty when there is no match.
+ * Exit   : 0 always — routing decisions live in stdout, never in exit code.
+ *
+ * Fail-open: any unexpected error reading stdin / parsing the route table /
+ * compiling a pattern → emit nothing and exit 0. The hook never blocks a
+ * prompt on its own bugs.
+ *
+ * Telemetry: each match appends one JSONL line to
+ * ~/.claude/instincts/<project-hash>/route-prompt.jsonl with the row index,
+ * skill, and pattern. Telemetry failures never change the decision.
+ *
+ * Route table schema (hooks/route-table.json):
+ *   {
+ *     "rows": [
+ *       { "pattern": "regex source", "flags": "i", "skill": "skill-name",
+ *         "reason": "one-line description" }
+ *     ]
+ *   }
+ * Rows are evaluated in order; first match wins.
+ */
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+function readStdin() {
+    try {
+        return readFileSync(0, "utf8");
+    }
+    catch {
+        return "";
+    }
+}
+function resolveHome() {
+    return process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+}
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+function telemetryPath(home) {
+    const hash = createHash("sha256")
+        .update(resolveProjectRoot())
+        .digest("hex")
+        .slice(0, 12);
+    return join(home, ".claude", "instincts", hash, "route-prompt.jsonl");
+}
+function writeTelemetry(home, event) {
+    try {
+        const path = telemetryPath(home);
+        const dir = dirname(path);
+        if (!existsSync(dir))
+            mkdirSync(dir, { recursive: true });
+        appendFileSync(path, `${JSON.stringify(event)}\n`);
+    }
+    catch {
+        // fail-open
+    }
+}
+function loadRouteTable() {
+    // Hook lives at <plugin-root>/hooks/route-prompt.mjs at runtime; the table
+    // sits next to it. import.meta.url gives the file:// URL of the compiled
+    // .mjs.
+    try {
+        const here = fileURLToPath(new URL(".", import.meta.url));
+        const tablePath = join(here, "route-table.json");
+        const raw = readFileSync(tablePath, "utf8");
+        const parsed = JSON.parse(raw);
+        if (!parsed || !Array.isArray(parsed.rows))
+            return null;
+        return parsed;
+    }
+    catch {
+        return null;
+    }
+}
+function findMatch(prompt, table) {
+    for (let i = 0; i < table.rows.length; i++) {
+        const row = table.rows[i];
+        if (!row || typeof row.pattern !== "string" || typeof row.skill !== "string") {
+            continue;
+        }
+        let rx;
+        try {
+            rx = new RegExp(row.pattern, row.flags ?? "");
+        }
+        catch {
+            continue;
+        }
+        if (rx.test(prompt)) {
+            return { row, index: i };
+        }
+    }
+    return null;
+}
+function buildContext(row) {
+    const reason = row.reason
+        ? `${row.reason}\nConsider invoking \`/${row.skill}\` now.`
+        : `Consider invoking \`/${row.skill}\` now.`;
+    return `<system-reminder>\nPrompt-router suggestion: ${reason}\n</system-reminder>`;
+}
+function emit(output) {
+    if (output !== null) {
+        process.stdout.write(`${JSON.stringify(output)}\n`);
+    }
+    process.exit(0);
+}
+function main() {
+    const raw = readStdin();
+    let payload;
+    try {
+        payload = JSON.parse(raw);
+    }
+    catch {
+        emit(null);
+        return;
+    }
+    const prompt = payload.prompt;
+    if (typeof prompt !== "string" || prompt.length === 0) {
+        emit(null);
+        return;
+    }
+    const table = loadRouteTable();
+    if (!table) {
+        emit(null);
+        return;
+    }
+    const match = findMatch(prompt, table);
+    const home = resolveHome();
+    if (!match) {
+        writeTelemetry(home, {
+            ts: new Date().toISOString(),
+            hook: "route-prompt",
+            matched: false,
+        });
+        emit(null);
+        return;
+    }
+    writeTelemetry(home, {
+        ts: new Date().toISOString(),
+        hook: "route-prompt",
+        matched: true,
+        row_index: match.index,
+        skill: match.row.skill,
+        pattern: match.row.pattern,
+    });
+    emit({
+        hookSpecificOutput: {
+            hookEventName: "UserPromptSubmit",
+            additionalContext: buildContext(match.row),
+        },
+    });
+}
+main();

--- a/hooks/route-table.json
+++ b/hooks/route-table.json
@@ -1,0 +1,35 @@
+{
+  "description": "Declarative prompt-router for the continuous-improvement UserPromptSubmit hook. Each row maps a regex (prompt-side trigger) to a skill the agent should consider invoking. First match wins; rows are evaluated in order. Edit this file to grow the routing table — no code change required.",
+  "rows": [
+    {
+      "pattern": "\\b(write|add|new)\\s+(a\\s+)?(failing\\s+)?test\\b|\\btdd\\b|\\bred[- ]green[- ]refactor\\b",
+      "flags": "i",
+      "skill": "tdd-workflow",
+      "reason": "Prompt mentions writing tests, TDD, or RED-GREEN-REFACTOR."
+    },
+    {
+      "pattern": "\\b(verify|verification|prove\\s+it\\s+works|smallest\\s+check|check\\s+it\\s+passes)\\b",
+      "flags": "i",
+      "skill": "verification-loop",
+      "reason": "Prompt asks for verification before declaring done."
+    },
+    {
+      "pattern": "\\b(plan|blueprint|design\\s+(the\\s+)?approach|step[- ]by[- ]step\\s+plan|roadmap)\\b",
+      "flags": "i",
+      "skill": "planning-with-files",
+      "reason": "Prompt asks for a plan, blueprint, or design before implementation."
+    },
+    {
+      "pattern": "\\b(security\\s+review|threat\\s+model|owasp|vulnerab|auth(entication|orization)\\s+check)\\b",
+      "flags": "i",
+      "skill": "security-review",
+      "reason": "Prompt touches security review, threat modeling, or auth surface."
+    },
+    {
+      "pattern": "\\b(code\\s+review|review\\s+(my|the|this)\\s+(code|pr|diff|patch)|critique\\s+(the|this)\\s+code)\\b",
+      "flags": "i",
+      "skill": "code-review",
+      "reason": "Prompt asks for a code review on existing changes."
+    }
+  ]
+}

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -286,13 +286,13 @@ const EXPERT_TOOL_ENTRIES = [
 const MODE_METADATA = {
     beginner: {
         description: "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
-        hooks: ["PreToolUse", "PostToolUse"],
-        hookDescription: "Silently captures every tool call as observations. Lightweight and non-blocking.",
+        hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit"],
+        hookDescription: "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking.",
     },
     expert: {
         description: "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
-        hooks: ["PreToolUse", "PostToolUse", "SessionStart", "SessionEnd"],
-        hookDescription: "Full hook suite: observation capture + session-level instinct loading and auto-reflection.",
+        hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd"],
+        hookDescription: "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection.",
     },
 };
 function getToolCatalog(mode) {
@@ -381,19 +381,28 @@ export function getPluginHooksConfig() {
         command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/three-section-close.mjs\"",
         timeout: 5,
     };
+    const routePromptCommand = {
+        type: "command",
+        command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/route-prompt.mjs\"",
+        timeout: 5,
+    };
     return {
-        description: "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+        description: "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, 3-section-close discipline, and UserPromptSubmit lazy-routing hooks for continuous-improvement.",
         hooks: {
-            // gateguard runs FIRST so its block decision short-circuits before
-            // companion-preference and observe.sh see the call. companion-preference
-            // runs second on Skill tool calls; it is a no-op under ci-first (the
-            // default) and never blocks under companions-first. observe.sh stays in
-            // PreToolUse for the observation feed; the Claude Code host runs all
-            // three regardless of gateguard's decision.
+            // gateguard runs FIRST on PreToolUse so its block decision short-circuits
+            // before companion-preference sees the call. companion-preference runs
+            // second on Skill tool calls; it is a no-op under ci-first (the default)
+            // and never blocks under companions-first. observe.sh only runs on
+            // PostToolUse: gateguard-blocked calls are intentionally not observed so
+            // PreToolUse stays at two subprocesses on the hot path. route-prompt
+            // fires on UserPromptSubmit and emits a system-reminder when a prompt
+            // pattern in hooks/route-table.json matches; non-matching prompts pass
+            // through with no output.
             PreToolUse: [
-                { hooks: [gateguardCommand, companionPreferenceCommand, observeCommand] },
+                { hooks: [gateguardCommand, companionPreferenceCommand] },
             ],
             PostToolUse: [{ hooks: [observeCommand] }],
+            UserPromptSubmit: [{ hooks: [routePromptCommand] }],
             SessionStart: [{ hooks: [sessionCommand] }],
             SessionEnd: [{ hooks: [sessionCommand] }],
             Stop: [{ hooks: [threeSectionCloseCommand] }],

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -46,8 +46,9 @@
   "hooks": {
     "included": [
       "PreToolUse",
-      "PostToolUse"
+      "PostToolUse",
+      "UserPromptSubmit"
     ],
-    "description": "Silently captures every tool call as observations. Lightweight and non-blocking."
+    "description": "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking."
   }
 }

--- a/plugins/continuous-improvement/hooks/hooks.json
+++ b/plugins/continuous-improvement/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+  "description": "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, 3-section-close discipline, and UserPromptSubmit lazy-routing hooks for continuous-improvement.",
   "hooks": {
     "PreToolUse": [
       {
@@ -13,11 +13,6 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/companion-preference.mjs\"",
             "timeout": 5
-          },
-          {
-            "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/observe.sh\"",
-            "timeout": 5
           }
         ]
       }
@@ -28,6 +23,17 @@
           {
             "type": "command",
             "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/observe.sh\"",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/route-prompt.mjs\"",
             "timeout": 5
           }
         ]

--- a/plugins/continuous-improvement/hooks/route-prompt.mjs
+++ b/plugins/continuous-improvement/hooks/route-prompt.mjs
@@ -1,0 +1,180 @@
+#!/usr/bin/env node
+/**
+ * Runtime UserPromptSubmit prompt-router hook.
+ *
+ * Reads the user prompt, matches it against patterns in
+ * hooks/route-table.json, and emits a single `<system-reminder>` recommending
+ * the matched skill. When no row matches, the hook emits nothing — the prompt
+ * passes through untouched.
+ *
+ * Stdin  : JSON { prompt, session_id?, transcript_path?, cwd? }
+ * Stdout : JSON { hookSpecificOutput: { hookEventName: "UserPromptSubmit",
+ *                                       additionalContext: string } }
+ *          OR empty when there is no match.
+ * Exit   : 0 always — routing decisions live in stdout, never in exit code.
+ *
+ * Fail-open: any unexpected error reading stdin / parsing the route table /
+ * compiling a pattern → emit nothing and exit 0. The hook never blocks a
+ * prompt on its own bugs.
+ *
+ * Telemetry: each match appends one JSONL line to
+ * ~/.claude/instincts/<project-hash>/route-prompt.jsonl with the row index,
+ * skill, and pattern. Telemetry failures never change the decision.
+ *
+ * Route table schema (hooks/route-table.json):
+ *   {
+ *     "rows": [
+ *       { "pattern": "regex source", "flags": "i", "skill": "skill-name",
+ *         "reason": "one-line description" }
+ *     ]
+ *   }
+ * Rows are evaluated in order; first match wins.
+ */
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+function readStdin() {
+    try {
+        return readFileSync(0, "utf8");
+    }
+    catch {
+        return "";
+    }
+}
+function resolveHome() {
+    return process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+}
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+function telemetryPath(home) {
+    const hash = createHash("sha256")
+        .update(resolveProjectRoot())
+        .digest("hex")
+        .slice(0, 12);
+    return join(home, ".claude", "instincts", hash, "route-prompt.jsonl");
+}
+function writeTelemetry(home, event) {
+    try {
+        const path = telemetryPath(home);
+        const dir = dirname(path);
+        if (!existsSync(dir))
+            mkdirSync(dir, { recursive: true });
+        appendFileSync(path, `${JSON.stringify(event)}\n`);
+    }
+    catch {
+        // fail-open
+    }
+}
+function loadRouteTable() {
+    // Hook lives at <plugin-root>/hooks/route-prompt.mjs at runtime; the table
+    // sits next to it. import.meta.url gives the file:// URL of the compiled
+    // .mjs.
+    try {
+        const here = fileURLToPath(new URL(".", import.meta.url));
+        const tablePath = join(here, "route-table.json");
+        const raw = readFileSync(tablePath, "utf8");
+        const parsed = JSON.parse(raw);
+        if (!parsed || !Array.isArray(parsed.rows))
+            return null;
+        return parsed;
+    }
+    catch {
+        return null;
+    }
+}
+function findMatch(prompt, table) {
+    for (let i = 0; i < table.rows.length; i++) {
+        const row = table.rows[i];
+        if (!row || typeof row.pattern !== "string" || typeof row.skill !== "string") {
+            continue;
+        }
+        let rx;
+        try {
+            rx = new RegExp(row.pattern, row.flags ?? "");
+        }
+        catch {
+            continue;
+        }
+        if (rx.test(prompt)) {
+            return { row, index: i };
+        }
+    }
+    return null;
+}
+function buildContext(row) {
+    const reason = row.reason
+        ? `${row.reason}\nConsider invoking \`/${row.skill}\` now.`
+        : `Consider invoking \`/${row.skill}\` now.`;
+    return `<system-reminder>\nPrompt-router suggestion: ${reason}\n</system-reminder>`;
+}
+function emit(output) {
+    if (output !== null) {
+        process.stdout.write(`${JSON.stringify(output)}\n`);
+    }
+    process.exit(0);
+}
+function main() {
+    const raw = readStdin();
+    let payload;
+    try {
+        payload = JSON.parse(raw);
+    }
+    catch {
+        emit(null);
+        return;
+    }
+    const prompt = payload.prompt;
+    if (typeof prompt !== "string" || prompt.length === 0) {
+        emit(null);
+        return;
+    }
+    const table = loadRouteTable();
+    if (!table) {
+        emit(null);
+        return;
+    }
+    const match = findMatch(prompt, table);
+    const home = resolveHome();
+    if (!match) {
+        writeTelemetry(home, {
+            ts: new Date().toISOString(),
+            hook: "route-prompt",
+            matched: false,
+        });
+        emit(null);
+        return;
+    }
+    writeTelemetry(home, {
+        ts: new Date().toISOString(),
+        hook: "route-prompt",
+        matched: true,
+        row_index: match.index,
+        skill: match.row.skill,
+        pattern: match.row.pattern,
+    });
+    emit({
+        hookSpecificOutput: {
+            hookEventName: "UserPromptSubmit",
+            additionalContext: buildContext(match.row),
+        },
+    });
+}
+main();

--- a/plugins/continuous-improvement/hooks/route-table.json
+++ b/plugins/continuous-improvement/hooks/route-table.json
@@ -1,0 +1,35 @@
+{
+  "description": "Declarative prompt-router for the continuous-improvement UserPromptSubmit hook. Each row maps a regex (prompt-side trigger) to a skill the agent should consider invoking. First match wins; rows are evaluated in order. Edit this file to grow the routing table — no code change required.",
+  "rows": [
+    {
+      "pattern": "\\b(write|add|new)\\s+(a\\s+)?(failing\\s+)?test\\b|\\btdd\\b|\\bred[- ]green[- ]refactor\\b",
+      "flags": "i",
+      "skill": "tdd-workflow",
+      "reason": "Prompt mentions writing tests, TDD, or RED-GREEN-REFACTOR."
+    },
+    {
+      "pattern": "\\b(verify|verification|prove\\s+it\\s+works|smallest\\s+check|check\\s+it\\s+passes)\\b",
+      "flags": "i",
+      "skill": "verification-loop",
+      "reason": "Prompt asks for verification before declaring done."
+    },
+    {
+      "pattern": "\\b(plan|blueprint|design\\s+(the\\s+)?approach|step[- ]by[- ]step\\s+plan|roadmap)\\b",
+      "flags": "i",
+      "skill": "planning-with-files",
+      "reason": "Prompt asks for a plan, blueprint, or design before implementation."
+    },
+    {
+      "pattern": "\\b(security\\s+review|threat\\s+model|owasp|vulnerab|auth(entication|orization)\\s+check)\\b",
+      "flags": "i",
+      "skill": "security-review",
+      "reason": "Prompt touches security review, threat modeling, or auth surface."
+    },
+    {
+      "pattern": "\\b(code\\s+review|review\\s+(my|the|this)\\s+(code|pr|diff|patch)|critique\\s+(the|this)\\s+code)\\b",
+      "flags": "i",
+      "skill": "code-review",
+      "reason": "Prompt asks for a code review on existing changes."
+    }
+  ]
+}

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -286,13 +286,13 @@ const EXPERT_TOOL_ENTRIES = [
 const MODE_METADATA = {
     beginner: {
         description: "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
-        hooks: ["PreToolUse", "PostToolUse"],
-        hookDescription: "Silently captures every tool call as observations. Lightweight and non-blocking.",
+        hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit"],
+        hookDescription: "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking.",
     },
     expert: {
         description: "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
-        hooks: ["PreToolUse", "PostToolUse", "SessionStart", "SessionEnd"],
-        hookDescription: "Full hook suite: observation capture + session-level instinct loading and auto-reflection.",
+        hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd"],
+        hookDescription: "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection.",
     },
 };
 function getToolCatalog(mode) {
@@ -381,19 +381,28 @@ export function getPluginHooksConfig() {
         command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/three-section-close.mjs\"",
         timeout: 5,
     };
+    const routePromptCommand = {
+        type: "command",
+        command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/route-prompt.mjs\"",
+        timeout: 5,
+    };
     return {
-        description: "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+        description: "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, 3-section-close discipline, and UserPromptSubmit lazy-routing hooks for continuous-improvement.",
         hooks: {
-            // gateguard runs FIRST so its block decision short-circuits before
-            // companion-preference and observe.sh see the call. companion-preference
-            // runs second on Skill tool calls; it is a no-op under ci-first (the
-            // default) and never blocks under companions-first. observe.sh stays in
-            // PreToolUse for the observation feed; the Claude Code host runs all
-            // three regardless of gateguard's decision.
+            // gateguard runs FIRST on PreToolUse so its block decision short-circuits
+            // before companion-preference sees the call. companion-preference runs
+            // second on Skill tool calls; it is a no-op under ci-first (the default)
+            // and never blocks under companions-first. observe.sh only runs on
+            // PostToolUse: gateguard-blocked calls are intentionally not observed so
+            // PreToolUse stays at two subprocesses on the hot path. route-prompt
+            // fires on UserPromptSubmit and emits a system-reminder when a prompt
+            // pattern in hooks/route-table.json matches; non-matching prompts pass
+            // through with no output.
             PreToolUse: [
-                { hooks: [gateguardCommand, companionPreferenceCommand, observeCommand] },
+                { hooks: [gateguardCommand, companionPreferenceCommand] },
             ],
             PostToolUse: [{ hooks: [observeCommand] }],
+            UserPromptSubmit: [{ hooks: [routePromptCommand] }],
             SessionStart: [{ hooks: [sessionCommand] }],
             SessionEnd: [{ hooks: [sessionCommand] }],
             Stop: [{ hooks: [threeSectionCloseCommand] }],

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -83,9 +83,10 @@
     "included": [
       "PreToolUse",
       "PostToolUse",
+      "UserPromptSubmit",
       "SessionStart",
       "SessionEnd"
     ],
-    "description": "Full hook suite: observation capture + session-level instinct loading and auto-reflection."
+    "description": "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection."
   }
 }

--- a/src/hooks/route-prompt.mts
+++ b/src/hooks/route-prompt.mts
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+/**
+ * Runtime UserPromptSubmit prompt-router hook.
+ *
+ * Reads the user prompt, matches it against patterns in
+ * hooks/route-table.json, and emits a single `<system-reminder>` recommending
+ * the matched skill. When no row matches, the hook emits nothing — the prompt
+ * passes through untouched.
+ *
+ * Stdin  : JSON { prompt, session_id?, transcript_path?, cwd? }
+ * Stdout : JSON { hookSpecificOutput: { hookEventName: "UserPromptSubmit",
+ *                                       additionalContext: string } }
+ *          OR empty when there is no match.
+ * Exit   : 0 always — routing decisions live in stdout, never in exit code.
+ *
+ * Fail-open: any unexpected error reading stdin / parsing the route table /
+ * compiling a pattern → emit nothing and exit 0. The hook never blocks a
+ * prompt on its own bugs.
+ *
+ * Telemetry: each match appends one JSONL line to
+ * ~/.claude/instincts/<project-hash>/route-prompt.jsonl with the row index,
+ * skill, and pattern. Telemetry failures never change the decision.
+ *
+ * Route table schema (hooks/route-table.json):
+ *   {
+ *     "rows": [
+ *       { "pattern": "regex source", "flags": "i", "skill": "skill-name",
+ *         "reason": "one-line description" }
+ *     ]
+ *   }
+ * Rows are evaluated in order; first match wins.
+ */
+
+import { createHash } from "node:crypto";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
+import { execFileSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+interface RouteRow {
+  pattern: string;
+  flags?: string;
+  skill: string;
+  reason?: string;
+}
+
+interface RouteTable {
+  rows: RouteRow[];
+}
+
+interface Payload {
+  prompt?: unknown;
+}
+
+interface HookOutput {
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit";
+    additionalContext: string;
+  };
+}
+
+function readStdin(): string {
+  try {
+    return readFileSync(0, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function resolveHome(): string {
+  return process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+}
+
+function resolveProjectRoot(): string {
+  const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+  if (fromEnv) return fromEnv;
+  try {
+    const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    if (root) return root;
+  } catch {
+    // not in a git repo
+  }
+  return "global";
+}
+
+function telemetryPath(home: string): string {
+  const hash = createHash("sha256")
+    .update(resolveProjectRoot())
+    .digest("hex")
+    .slice(0, 12);
+  return join(home, ".claude", "instincts", hash, "route-prompt.jsonl");
+}
+
+interface TelemetryEvent {
+  ts: string;
+  hook: "route-prompt";
+  matched: boolean;
+  row_index?: number;
+  skill?: string;
+  pattern?: string;
+}
+
+function writeTelemetry(home: string, event: TelemetryEvent): void {
+  try {
+    const path = telemetryPath(home);
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    appendFileSync(path, `${JSON.stringify(event)}\n`);
+  } catch {
+    // fail-open
+  }
+}
+
+function loadRouteTable(): RouteTable | null {
+  // Hook lives at <plugin-root>/hooks/route-prompt.mjs at runtime; the table
+  // sits next to it. import.meta.url gives the file:// URL of the compiled
+  // .mjs.
+  try {
+    const here = fileURLToPath(new URL(".", import.meta.url));
+    const tablePath = join(here, "route-table.json");
+    const raw = readFileSync(tablePath, "utf8");
+    const parsed = JSON.parse(raw) as RouteTable;
+    if (!parsed || !Array.isArray(parsed.rows)) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+function findMatch(
+  prompt: string,
+  table: RouteTable,
+): { row: RouteRow; index: number } | null {
+  for (let i = 0; i < table.rows.length; i++) {
+    const row = table.rows[i];
+    if (!row || typeof row.pattern !== "string" || typeof row.skill !== "string") {
+      continue;
+    }
+    let rx: RegExp;
+    try {
+      rx = new RegExp(row.pattern, row.flags ?? "");
+    } catch {
+      continue;
+    }
+    if (rx.test(prompt)) {
+      return { row, index: i };
+    }
+  }
+  return null;
+}
+
+function buildContext(row: RouteRow): string {
+  const reason = row.reason
+    ? `${row.reason}\nConsider invoking \`/${row.skill}\` now.`
+    : `Consider invoking \`/${row.skill}\` now.`;
+  return `<system-reminder>\nPrompt-router suggestion: ${reason}\n</system-reminder>`;
+}
+
+function emit(output: HookOutput | null): void {
+  if (output !== null) {
+    process.stdout.write(`${JSON.stringify(output)}\n`);
+  }
+  process.exit(0);
+}
+
+function main(): void {
+  const raw = readStdin();
+  let payload: Payload;
+  try {
+    payload = JSON.parse(raw) as Payload;
+  } catch {
+    emit(null);
+    return;
+  }
+  const prompt = payload.prompt;
+  if (typeof prompt !== "string" || prompt.length === 0) {
+    emit(null);
+    return;
+  }
+  const table = loadRouteTable();
+  if (!table) {
+    emit(null);
+    return;
+  }
+  const match = findMatch(prompt, table);
+  const home = resolveHome();
+  if (!match) {
+    writeTelemetry(home, {
+      ts: new Date().toISOString(),
+      hook: "route-prompt",
+      matched: false,
+    });
+    emit(null);
+    return;
+  }
+  writeTelemetry(home, {
+    ts: new Date().toISOString(),
+    hook: "route-prompt",
+    matched: true,
+    row_index: match.index,
+    skill: match.row.skill,
+    pattern: match.row.pattern,
+  });
+  emit({
+    hookSpecificOutput: {
+      hookEventName: "UserPromptSubmit",
+      additionalContext: buildContext(match.row),
+    },
+  });
+}
+
+main();

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -10,7 +10,13 @@ export const VERSION: string = (JSON.parse(readFileSync(PKG_PATH, "utf8")) as { 
 export const PLUGIN_MODES = ["beginner", "expert"] as const;
 
 export type PluginMode = typeof PLUGIN_MODES[number];
-export type HookType = "PreToolUse" | "PostToolUse" | "SessionStart" | "SessionEnd" | "Stop";
+export type HookType =
+  | "PreToolUse"
+  | "PostToolUse"
+  | "UserPromptSubmit"
+  | "SessionStart"
+  | "SessionEnd"
+  | "Stop";
 
 export interface SchemaProperty {
   default?: boolean | number | string | string[];
@@ -422,16 +428,16 @@ const MODE_METADATA: Record<PluginMode, ModeMetadata> = {
   beginner: {
     description:
       "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
-    hooks: ["PreToolUse", "PostToolUse"],
+    hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit"],
     hookDescription:
-      "Silently captures every tool call as observations. Lightweight and non-blocking.",
+      "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking.",
   },
   expert: {
     description:
       "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
-    hooks: ["PreToolUse", "PostToolUse", "SessionStart", "SessionEnd"],
+    hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd"],
     hookDescription:
-      "Full hook suite: observation capture + session-level instinct loading and auto-reflection.",
+      "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection.",
   },
 };
 
@@ -527,21 +533,30 @@ export function getPluginHooksConfig(): PluginHooksConfig {
     command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/three-section-close.mjs\"",
     timeout: 5,
   };
+  const routePromptCommand = {
+    type: "command" as const,
+    command: "node \"${CLAUDE_PLUGIN_ROOT}/hooks/route-prompt.mjs\"",
+    timeout: 5,
+  };
 
   return {
     description:
-      "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, and 3-section-close discipline hooks for continuous-improvement.",
+      "Gateguard fact-forcing PreToolUse, companion-preference enforcement, observation, session lifecycle, 3-section-close discipline, and UserPromptSubmit lazy-routing hooks for continuous-improvement.",
     hooks: {
-      // gateguard runs FIRST so its block decision short-circuits before
-      // companion-preference and observe.sh see the call. companion-preference
-      // runs second on Skill tool calls; it is a no-op under ci-first (the
-      // default) and never blocks under companions-first. observe.sh stays in
-      // PreToolUse for the observation feed; the Claude Code host runs all
-      // three regardless of gateguard's decision.
+      // gateguard runs FIRST on PreToolUse so its block decision short-circuits
+      // before companion-preference sees the call. companion-preference runs
+      // second on Skill tool calls; it is a no-op under ci-first (the default)
+      // and never blocks under companions-first. observe.sh only runs on
+      // PostToolUse: gateguard-blocked calls are intentionally not observed so
+      // PreToolUse stays at two subprocesses on the hot path. route-prompt
+      // fires on UserPromptSubmit and emits a system-reminder when a prompt
+      // pattern in hooks/route-table.json matches; non-matching prompts pass
+      // through with no output.
       PreToolUse: [
-        { hooks: [gateguardCommand, companionPreferenceCommand, observeCommand] },
+        { hooks: [gateguardCommand, companionPreferenceCommand] },
       ],
       PostToolUse: [{ hooks: [observeCommand] }],
+      UserPromptSubmit: [{ hooks: [routePromptCommand] }],
       SessionStart: [{ hooks: [sessionCommand] }],
       SessionEnd: [{ hooks: [sessionCommand] }],
       Stop: [{ hooks: [threeSectionCloseCommand] }],

--- a/src/test/companion-preference-doc-drift.test.mts
+++ b/src/test/companion-preference-doc-drift.test.mts
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+
+// __dirname resolves to <repo>/test/ at runtime — compiled .mjs lives under
+// test/ per tsconfig outDir. The doc + .mts source live under <repo>/skills/
+// and <repo>/src/hooks/ respectively.
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const DOC_PATH = join(REPO_ROOT, "skills", "superpowers.md");
+const HOOK_SOURCE_PATH = join(
+  REPO_ROOT,
+  "src",
+  "hooks",
+  "companion-preference.mts",
+);
+
+interface DocPair {
+  ciSkill: string;
+  companion: string;
+  plugin: string;
+}
+
+interface MapEntry {
+  companion: string;
+  plugin: string;
+}
+
+function parseDocTable(markdown: string): DocPair[] {
+  const sectionAnchor = "### Which rows the override affects";
+  const idx = markdown.indexOf(sectionAnchor);
+  assert.notEqual(
+    idx,
+    -1,
+    "superpowers.md is missing the '### Which rows the override affects' section",
+  );
+  const nextHeading = markdown.indexOf("\n### ", idx + sectionAnchor.length);
+  const section = markdown.slice(
+    idx,
+    nextHeading === -1 ? markdown.length : nextHeading,
+  );
+
+  const rowRegex = /^\|\s*[^|]+\|\s*`ci:([^`]+)`\s*\|\s*([^|]+)\|/gm;
+  const pairs: DocPair[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = rowRegex.exec(section)) !== null) {
+    const ciSkill = match[1]?.trim();
+    const companionCell = match[2]?.trim();
+    if (!ciSkill || !companionCell) continue;
+    const firstCompanion = companionCell.split(",")[0]?.trim();
+    if (!firstCompanion) continue;
+    const stripped = firstCompanion.replace(/^`|`$/g, "");
+    const colonIdx = stripped.indexOf(":");
+    if (colonIdx === -1) continue;
+    pairs.push({
+      ciSkill,
+      companion: stripped,
+      plugin: stripped.slice(0, colonIdx),
+    });
+  }
+  return pairs;
+}
+
+function parseOverridesMap(source: string): Record<string, MapEntry> {
+  const startMarker = "const OVERRIDES: Record<string, Override> = {";
+  const start = source.indexOf(startMarker);
+  assert.notEqual(
+    start,
+    -1,
+    "companion-preference.mts is missing 'const OVERRIDES: Record<string, Override> = {'",
+  );
+  let depth = 0;
+  let end = -1;
+  for (let i = start + startMarker.length - 1; i < source.length; i++) {
+    const ch = source[i];
+    if (ch === "{") depth++;
+    else if (ch === "}") {
+      depth--;
+      if (depth === 0) {
+        end = i + 1;
+        break;
+      }
+    }
+  }
+  assert.notEqual(end, -1, "OVERRIDES map: could not find closing brace");
+  const block = source.slice(start, end);
+
+  const entries: Record<string, MapEntry> = {};
+  const entryRegex =
+    /(?:"([^"]+)"|(\w[\w-]*))\s*:\s*\{\s*companion\s*:\s*"([^"]+)"\s*,\s*plugin\s*:\s*"([^"]+)"\s*,?\s*\}/g;
+  let m: RegExpExecArray | null;
+  while ((m = entryRegex.exec(block)) !== null) {
+    const key = m[1] ?? m[2];
+    if (!key) continue;
+    entries[key] = { companion: m[3] ?? "", plugin: m[4] ?? "" };
+  }
+  return entries;
+}
+
+describe("companion-preference doc drift", () => {
+  const doc = readFileSync(DOC_PATH, "utf8");
+  const source = readFileSync(HOOK_SOURCE_PATH, "utf8");
+  const docPairs = parseDocTable(doc);
+  const overrides = parseOverridesMap(source);
+
+  it("parses at least one doc-table row", () => {
+    assert.ok(
+      docPairs.length > 0,
+      "Expected to parse at least one row from superpowers.md doc table",
+    );
+  });
+
+  it("parses at least one OVERRIDES entry", () => {
+    assert.ok(
+      Object.keys(overrides).length > 0,
+      "Expected to parse at least one entry from OVERRIDES map",
+    );
+  });
+
+  it("every doc-table CI skill appears in OVERRIDES with matching companion + plugin", () => {
+    for (const pair of docPairs) {
+      const entry = overrides[pair.ciSkill];
+      assert.ok(
+        entry,
+        `Doc row 'ci:${pair.ciSkill}' has no corresponding key in OVERRIDES map. ` +
+          `Add { "${pair.ciSkill}": { companion: "${pair.companion}", plugin: "${pair.plugin}" } } to src/hooks/companion-preference.mts.`,
+      );
+      assert.equal(
+        entry.companion,
+        pair.companion,
+        `Doc row 'ci:${pair.ciSkill}' lists companion '${pair.companion}' but OVERRIDES has '${entry.companion}'.`,
+      );
+      assert.equal(
+        entry.plugin,
+        pair.plugin,
+        `Doc row 'ci:${pair.ciSkill}' lists plugin '${pair.plugin}' but OVERRIDES has '${entry.plugin}'.`,
+      );
+    }
+  });
+});

--- a/src/test/route-prompt-hook.test.mts
+++ b/src/test/route-prompt-hook.test.mts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname resolves to <repo>/test/ at runtime. Hook lives under <repo>/hooks/.
+const HOOK_PATH = join(__dirname, "..", "hooks", "route-prompt.mjs");
+
+interface HookResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface HookOutput {
+  hookSpecificOutput: {
+    hookEventName: "UserPromptSubmit";
+    additionalContext: string;
+  };
+}
+
+function buildIsolatedEnv(home: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  delete env.HOME;
+  delete env.USERPROFILE;
+  env.HOME = home;
+  env.USERPROFILE = home;
+  return env;
+}
+
+function runHook(payload: unknown, home: string): HookResult {
+  const input = typeof payload === "string" ? payload : JSON.stringify(payload);
+  const result = spawnSync(process.execPath, [HOOK_PATH], {
+    input,
+    env: buildIsolatedEnv(home),
+    encoding: "utf8",
+    timeout: 5000,
+  });
+  if (result.error) throw result.error;
+  return {
+    status: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("route-prompt hook", () => {
+  let home: string;
+
+  before(() => {
+    home = mkdtempSync(join(tmpdir(), "ci-route-prompt-"));
+  });
+
+  after(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it("emits empty stdout for malformed JSON stdin", () => {
+    const r = runHook("not json", home);
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout, "");
+  });
+
+  it("emits empty stdout when prompt is missing", () => {
+    const r = runHook({ session_id: "x" }, home);
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout, "");
+  });
+
+  it("emits empty stdout when prompt does not match any row", () => {
+    const r = runHook(
+      { prompt: "hello world, just saying hi today" },
+      home,
+    );
+    assert.equal(r.status, 0);
+    assert.equal(r.stdout, "");
+  });
+
+  it("matches a TDD prompt to tdd-workflow", () => {
+    const r = runHook(
+      { prompt: "Can you write a failing test for the auth module?" },
+      home,
+    );
+    assert.equal(r.status, 0);
+    const parsed = JSON.parse(r.stdout) as HookOutput;
+    assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+    assert.match(parsed.hookSpecificOutput.additionalContext, /tdd-workflow/);
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /system-reminder/,
+    );
+  });
+
+  it("matches a verify prompt to verification-loop", () => {
+    const r = runHook(
+      { prompt: "Please verify the build before declaring it done." },
+      home,
+    );
+    assert.equal(r.status, 0);
+    const parsed = JSON.parse(r.stdout) as HookOutput;
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /verification-loop/,
+    );
+  });
+
+  it("matches a plan prompt to planning-with-files", () => {
+    const r = runHook(
+      { prompt: "Give me a step-by-step plan before any code changes." },
+      home,
+    );
+    assert.equal(r.status, 0);
+    const parsed = JSON.parse(r.stdout) as HookOutput;
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /planning-with-files/,
+    );
+  });
+
+  it("matches a security prompt to security-review", () => {
+    const r = runHook(
+      { prompt: "Run a security review on the authorization check." },
+      home,
+    );
+    assert.equal(r.status, 0);
+    const parsed = JSON.parse(r.stdout) as HookOutput;
+    assert.match(
+      parsed.hookSpecificOutput.additionalContext,
+      /security-review/,
+    );
+  });
+
+  it("matches a code-review prompt to code-review", () => {
+    const r = runHook(
+      { prompt: "Please review my code on the latest diff." },
+      home,
+    );
+    assert.equal(r.status, 0);
+    const parsed = JSON.parse(r.stdout) as HookOutput;
+    assert.match(parsed.hookSpecificOutput.additionalContext, /code-review/);
+  });
+
+  it("first match wins — TDD pattern beats verify pattern in the same prompt", () => {
+    // TDD row comes before verify row; both could match this phrasing.
+    const r = runHook(
+      { prompt: "Write a failing test and then verify it passes." },
+      home,
+    );
+    assert.equal(r.status, 0);
+    const parsed = JSON.parse(r.stdout) as HookOutput;
+    assert.match(parsed.hookSpecificOutput.additionalContext, /tdd-workflow/);
+    assert.doesNotMatch(
+      parsed.hookSpecificOutput.additionalContext,
+      /verification-loop/,
+    );
+  });
+});

--- a/test/companion-preference-doc-drift.test.mjs
+++ b/test/companion-preference-doc-drift.test.mjs
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { join } from "node:path";
+// __dirname resolves to <repo>/test/ at runtime — compiled .mjs lives under
+// test/ per tsconfig outDir. The doc + .mts source live under <repo>/skills/
+// and <repo>/src/hooks/ respectively.
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const DOC_PATH = join(REPO_ROOT, "skills", "superpowers.md");
+const HOOK_SOURCE_PATH = join(REPO_ROOT, "src", "hooks", "companion-preference.mts");
+function parseDocTable(markdown) {
+    const sectionAnchor = "### Which rows the override affects";
+    const idx = markdown.indexOf(sectionAnchor);
+    assert.notEqual(idx, -1, "superpowers.md is missing the '### Which rows the override affects' section");
+    const nextHeading = markdown.indexOf("\n### ", idx + sectionAnchor.length);
+    const section = markdown.slice(idx, nextHeading === -1 ? markdown.length : nextHeading);
+    const rowRegex = /^\|\s*[^|]+\|\s*`ci:([^`]+)`\s*\|\s*([^|]+)\|/gm;
+    const pairs = [];
+    let match;
+    while ((match = rowRegex.exec(section)) !== null) {
+        const ciSkill = match[1]?.trim();
+        const companionCell = match[2]?.trim();
+        if (!ciSkill || !companionCell)
+            continue;
+        const firstCompanion = companionCell.split(",")[0]?.trim();
+        if (!firstCompanion)
+            continue;
+        const stripped = firstCompanion.replace(/^`|`$/g, "");
+        const colonIdx = stripped.indexOf(":");
+        if (colonIdx === -1)
+            continue;
+        pairs.push({
+            ciSkill,
+            companion: stripped,
+            plugin: stripped.slice(0, colonIdx),
+        });
+    }
+    return pairs;
+}
+function parseOverridesMap(source) {
+    const startMarker = "const OVERRIDES: Record<string, Override> = {";
+    const start = source.indexOf(startMarker);
+    assert.notEqual(start, -1, "companion-preference.mts is missing 'const OVERRIDES: Record<string, Override> = {'");
+    let depth = 0;
+    let end = -1;
+    for (let i = start + startMarker.length - 1; i < source.length; i++) {
+        const ch = source[i];
+        if (ch === "{")
+            depth++;
+        else if (ch === "}") {
+            depth--;
+            if (depth === 0) {
+                end = i + 1;
+                break;
+            }
+        }
+    }
+    assert.notEqual(end, -1, "OVERRIDES map: could not find closing brace");
+    const block = source.slice(start, end);
+    const entries = {};
+    const entryRegex = /(?:"([^"]+)"|(\w[\w-]*))\s*:\s*\{\s*companion\s*:\s*"([^"]+)"\s*,\s*plugin\s*:\s*"([^"]+)"\s*,?\s*\}/g;
+    let m;
+    while ((m = entryRegex.exec(block)) !== null) {
+        const key = m[1] ?? m[2];
+        if (!key)
+            continue;
+        entries[key] = { companion: m[3] ?? "", plugin: m[4] ?? "" };
+    }
+    return entries;
+}
+describe("companion-preference doc drift", () => {
+    const doc = readFileSync(DOC_PATH, "utf8");
+    const source = readFileSync(HOOK_SOURCE_PATH, "utf8");
+    const docPairs = parseDocTable(doc);
+    const overrides = parseOverridesMap(source);
+    it("parses at least one doc-table row", () => {
+        assert.ok(docPairs.length > 0, "Expected to parse at least one row from superpowers.md doc table");
+    });
+    it("parses at least one OVERRIDES entry", () => {
+        assert.ok(Object.keys(overrides).length > 0, "Expected to parse at least one entry from OVERRIDES map");
+    });
+    it("every doc-table CI skill appears in OVERRIDES with matching companion + plugin", () => {
+        for (const pair of docPairs) {
+            const entry = overrides[pair.ciSkill];
+            assert.ok(entry, `Doc row 'ci:${pair.ciSkill}' has no corresponding key in OVERRIDES map. ` +
+                `Add { "${pair.ciSkill}": { companion: "${pair.companion}", plugin: "${pair.plugin}" } } to src/hooks/companion-preference.mts.`);
+            assert.equal(entry.companion, pair.companion, `Doc row 'ci:${pair.ciSkill}' lists companion '${pair.companion}' but OVERRIDES has '${entry.companion}'.`);
+            assert.equal(entry.plugin, pair.plugin, `Doc row 'ci:${pair.ciSkill}' lists plugin '${pair.plugin}' but OVERRIDES has '${entry.plugin}'.`);
+        }
+    });
+});

--- a/test/route-prompt-hook.test.mjs
+++ b/test/route-prompt-hook.test.mjs
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname resolves to <repo>/test/ at runtime. Hook lives under <repo>/hooks/.
+const HOOK_PATH = join(__dirname, "..", "hooks", "route-prompt.mjs");
+function buildIsolatedEnv(home) {
+    const env = { ...process.env };
+    delete env.HOME;
+    delete env.USERPROFILE;
+    env.HOME = home;
+    env.USERPROFILE = home;
+    return env;
+}
+function runHook(payload, home) {
+    const input = typeof payload === "string" ? payload : JSON.stringify(payload);
+    const result = spawnSync(process.execPath, [HOOK_PATH], {
+        input,
+        env: buildIsolatedEnv(home),
+        encoding: "utf8",
+        timeout: 5000,
+    });
+    if (result.error)
+        throw result.error;
+    return {
+        status: result.status,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+describe("route-prompt hook", () => {
+    let home;
+    before(() => {
+        home = mkdtempSync(join(tmpdir(), "ci-route-prompt-"));
+    });
+    after(() => {
+        rmSync(home, { recursive: true, force: true });
+    });
+    it("emits empty stdout for malformed JSON stdin", () => {
+        const r = runHook("not json", home);
+        assert.equal(r.status, 0);
+        assert.equal(r.stdout, "");
+    });
+    it("emits empty stdout when prompt is missing", () => {
+        const r = runHook({ session_id: "x" }, home);
+        assert.equal(r.status, 0);
+        assert.equal(r.stdout, "");
+    });
+    it("emits empty stdout when prompt does not match any row", () => {
+        const r = runHook({ prompt: "hello world, just saying hi today" }, home);
+        assert.equal(r.status, 0);
+        assert.equal(r.stdout, "");
+    });
+    it("matches a TDD prompt to tdd-workflow", () => {
+        const r = runHook({ prompt: "Can you write a failing test for the auth module?" }, home);
+        assert.equal(r.status, 0);
+        const parsed = JSON.parse(r.stdout);
+        assert.equal(parsed.hookSpecificOutput.hookEventName, "UserPromptSubmit");
+        assert.match(parsed.hookSpecificOutput.additionalContext, /tdd-workflow/);
+        assert.match(parsed.hookSpecificOutput.additionalContext, /system-reminder/);
+    });
+    it("matches a verify prompt to verification-loop", () => {
+        const r = runHook({ prompt: "Please verify the build before declaring it done." }, home);
+        assert.equal(r.status, 0);
+        const parsed = JSON.parse(r.stdout);
+        assert.match(parsed.hookSpecificOutput.additionalContext, /verification-loop/);
+    });
+    it("matches a plan prompt to planning-with-files", () => {
+        const r = runHook({ prompt: "Give me a step-by-step plan before any code changes." }, home);
+        assert.equal(r.status, 0);
+        const parsed = JSON.parse(r.stdout);
+        assert.match(parsed.hookSpecificOutput.additionalContext, /planning-with-files/);
+    });
+    it("matches a security prompt to security-review", () => {
+        const r = runHook({ prompt: "Run a security review on the authorization check." }, home);
+        assert.equal(r.status, 0);
+        const parsed = JSON.parse(r.stdout);
+        assert.match(parsed.hookSpecificOutput.additionalContext, /security-review/);
+    });
+    it("matches a code-review prompt to code-review", () => {
+        const r = runHook({ prompt: "Please review my code on the latest diff." }, home);
+        assert.equal(r.status, 0);
+        const parsed = JSON.parse(r.stdout);
+        assert.match(parsed.hookSpecificOutput.additionalContext, /code-review/);
+    });
+    it("first match wins — TDD pattern beats verify pattern in the same prompt", () => {
+        // TDD row comes before verify row; both could match this phrasing.
+        const r = runHook({ prompt: "Write a failing test and then verify it passes." }, home);
+        assert.equal(r.status, 0);
+        const parsed = JSON.parse(r.stdout);
+        assert.match(parsed.hookSpecificOutput.additionalContext, /tdd-workflow/);
+        assert.doesNotMatch(parsed.hookSpecificOutput.additionalContext, /verification-loop/);
+    });
+});


### PR DESCRIPTION
## Summary

Three-part hook surface cleanup, all sourced from the `.mts` layer per the PR #66 lesson (`.mjs` is generated; never edit it directly).

### 1. Drop `observe.sh` from PreToolUse — latency win
PreToolUse now runs `gateguard` + `companion-preference` only. `observe.sh` stays on PostToolUse. gateguard-blocked calls are intentionally not observed so the hot path stays at two subprocesses, not three.

### 2. Add companion-preference doc-drift test — invariant
New `src/test/companion-preference-doc-drift.test.mts` walks the "Which rows the override affects" table in `skills/superpowers.md` and asserts every row appears in the `OVERRIDES` map in `src/hooks/companion-preference.mts`. The doc-comment at `companion-preference.mts:22-24` says drift "will surface when the test suite walks the table against this map" — this is that test. Currently 5 rows in doc / 5 rows in code → green. Future doc-table additions must land in code or the test fails.

### 3. Add UserPromptSubmit prompt-router — lazy routing
New `src/hooks/route-prompt.mts` + hand-authored `hooks/route-table.json` with 5 seed patterns:

| Pattern (summarized) | Suggested skill |
|---|---|
| TDD verbs ("write a failing test", "tdd", "red-green-refactor") | `tdd-workflow` |
| Verification verbs ("verify", "prove it works", "check it passes") | `verification-loop` |
| Planning verbs ("plan", "blueprint", "step-by-step plan") | `planning-with-files` |
| Security verbs ("security review", "threat model", "owasp", "auth check") | `security-review` |
| Code-review verbs ("code review", "review my code/pr/diff") | `code-review` |

First match wins. Matched prompts emit a single `<system-reminder>` with the suggestion. Fail-open on any stdin/parse/regex error — the hook never blocks a prompt on its own bug. Telemetry appends one JSONL line per invocation to `~/.claude/instincts/<project-hash>/route-prompt.jsonl` alongside the existing `companion-preference.jsonl`.

`HookType` union + `MODE_METADATA` hook lists extended to include `UserPromptSubmit`.

## What is intentionally not in this PR

Item 4 of the source recommendation list — "inventory `~/.claude/plugins/` + uninstall dormant" — touches user-level state outside this repo. It is held for operator approval, not bundled here.

## Test plan

- [x] `npm test` → 568 / 568 pass (9 new route-prompt tests + 3 new drift tests + 556 existing)
- [x] `npm run verify:all` → 7/7 invariants pass
  - skill-mirror (20 pairs)
  - skill-tiers (20 sources)
  - skill-law-tag (20 sources)
  - docs-substrings (176 assertions)
  - everything-mirror (42 mirrored files; +2 for `route-prompt.mjs` + `route-table.json`)
  - routing-targets (37 targets)
  - doc-runtime-claims (21 scanned files)
  - typecheck (0 errors)
- [x] `npm run verify:generated` runs clean post-build (no orphan `.mjs` drift)
- [ ] Manual smoke after merge: with `companion_preference=ci-first`, type a TDD prompt — confirm system-reminder appears suggesting `tdd-workflow`.