### PR TITLE
Plugin-flow audit fixes: skill-count lint, changelog, installer hardening, /verify-install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
+      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
       "version": "3.9.2",
       "source": "./plugins/continuous-improvement",
       "author": {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,42 @@ All notable changes to this skill are documented here.
 
 ---
 
+## [3.9.2] — 2026-05-10
+
+Manifest-derivation patch. One fix plus the release cut.
+
+### Fixed
+
+- **Manifests track the package version automatically** (PR #122) — `VERSION` in `src/lib/plugin-metadata.mts` is now derived from `package.json` at build time instead of being a hand-maintained constant. `npm run build` regenerates `marketplace.json` and `plugin.json` with the correct version on every release without a separate manual edit. v3.9.2 was the first release cut with auto-derived manifests (PR #123).
+
+---
+
+## [3.9.1] — 2026-05-10
+
+First release through the tag-triggered `release.yml` pipeline. The `v3.9.0` tag was placed before PR #99 merged, so this release range also carries the feature and CI work that landed on top of the v3.8.0 dispatcher train — the substantive items are listed below; the `[3.9.0]` entry above describes only PRs #97–#99.
+
+### Added
+
+- **`release.yml` tag-triggered npm publish** (PR #119) — pushing a `v*` tag now builds, verifies, and publishes to npm, with the retarget policy and cut procedure documented in `docs/RELEASING.md`. PR #120 cut v3.9.1 as the first exercise of this pipeline.
+- **`gateguard` runtime PreToolUse hook** (PRs #106, #108) — `hooks/gateguard.mjs` ships as the runtime layer that physically blocks Edit/Write/MultiEdit and destructive Bash until fact-list investigation is presented. PR #107 added hotfix-PR mode, a synthetic-checks rung, and the insights CLAUDE.md template.
+- **Native review-agent trio** (PR #112) — `code-reviewer`, `security-auditor`, and `test-engineer` agents in `plugins/continuous-improvement/agents/`, routed by the orchestrator during verify and review phases.
+- **Three verification-ladder skills** (PR #117) — `state-reconciliation`, `recovery-classification`, and `worktree-safety` added as pre-dispatch invariants.
+- **`verify:doc-runtime-claims` lint** (commit `241e8fe`) — codifies the audit-twice rule: any user-facing runtime-hook claim must carry a `hooks/<file>.mjs` anchor within ±5 lines.
+- **Repo-root `.mcp.json`** (PR #113) — dogfoods `bin/mcp-server.mjs` from inside the repo.
+
+### Changed
+
+- **Installer path collapse + dispatcher rewrite** (commit `bc76bfe`) — installer paths collapsed, versions synced, installer surface expanded.
+- **`pm-skills` switched from vendored snapshot to out-of-band marketplace install** (PR #101) — product-management coverage now installs via `phuryn/pm-skills` per `docs/THIRD_PARTY.md` instead of being vendored under `third-party/`.
+- **CI `verify-generated` check widened** (PR #99) — `git diff` path widened to `.claude-plugin bin test lib plugins`.
+
+### Fixed
+
+- **MCP server emits NDJSON over stdio** (PR #114) — corrected the transport framing to the MCP spec (NDJSON, not LSP-style framing).
+- **`gateguard` doc wording reverted** (commit `5eca467`) — the "runtime gate is roadmap" wording was reverted once the hook actually shipped.
+
+---
+
 ## [3.9.0] — 2026-05-07
 
 Issue-burndown release. Three PRs landed on top of v3.8.0 — one Windows correctness fix, one test-coverage expansion, one CI hardening — closing two long-standing issues (#59, #2) and tightening the regression net for the class of failure #59 surfaced. No skill or behavior changes; this release is reliability and contributor-experience only.

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -25,6 +25,8 @@ Without it, `/superpowers` still works — it falls back to inline behavior — 
 
 ### Verify the install — two checks
 
+**Fastest path:** restart Claude Code, then run `/verify-install` — it walks all three checks (commands loaded, gateguard fires, observation capture recording) and prints a single ✓ wired / ✗ missing line. The manual checks below are the same probes done by hand, kept here so you can see what each one proves.
+
 **Check 1 — slash command loaded.** Quit and reopen Claude Code (slash commands only load on session start), then run:
 
 ```

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -97,14 +97,17 @@ This shows what the system has learned — instincts, confidence levels, and the
 
 ## How auto-leveling works
 
-You don't configure anything. The system promotes itself:
+You don't configure anything. The system promotes itself. The unit is
+**observations** — one per tool call, not one per session — so a single active
+session can produce dozens. The four levels below mirror the source-of-truth
+table in [SKILL.md](SKILL.md):
 
-| Your usage | What happens |
-|-----------|-------------|
-| First sessions | Hooks capture tool calls silently. No behavior change. |
-| After ~20 sessions | Agent analyzes patterns, creates instincts (silent — you see nothing) |
-| After ~50 sessions | Instincts cross 0.5 → agent starts suggesting: "Consider: [action]" |
-| After ~100 sessions | Instincts cross 0.7 → agent auto-applies learned behaviors |
+| Level | Trigger | What happens |
+|-------|---------|-------------|
+| CAPTURE | < 20 observations | Hooks capture tool calls silently. No behavior change. |
+| ANALYZE | 20+ observations | Agent analyzes patterns, creates instincts (silent — you see nothing) |
+| SUGGEST | Any instinct at 0.5–0.69 confidence | Agent suggests inline: "Consider: [action]" |
+| AUTO-APPLY | Any instinct at 0.7+ confidence | Agent auto-applies the learned behavior |
 
 Corrections drop instinct confidence. Unused instincts decay. The system self-corrects.
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
 /grill-with-docs                  Grill-me with persistent outcomes — updates CONTEXT.md + ADRs inline
 /handoff                          End-of-session compaction into mktemp brief for the next agent
 /discipline                       Quick reference card of the 7 Laws
+/verify-install                   One-shot post-install check — commands, gateguard, observe
 /dashboard                        Visual instinct health dashboard
 /companion-preference             Inspect companion-preference hook telemetry
 /ralph                            Autonomous PRD story-by-story loop
@@ -230,7 +231,7 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
 /swarm                            Fan-out coordination across parallel sub-agents
 ```
 
-All 17 ship in the marketplace bundle. The Beginner install gets all of them — with one caveat: `/learn-eval` and `/harvest` only produce useful output once Mulahazah has accumulated observation history (~20 observations), so running them on day 1 returns an empty result, not a broken command. `/swarm` and `/release-train` are orchestration commands aimed at larger multi-agent or multi-PR work. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
+All 18 ship in the marketplace bundle. The Beginner install gets all of them — with one caveat: `/learn-eval` and `/harvest` only produce useful output once Mulahazah has accumulated observation history (~20 observations), so running them on day 1 returns an empty result, not a broken command. `/swarm` and `/release-train` are orchestration commands aimed at larger multi-agent or multi-PR work. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -222,14 +222,15 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
 /handoff                          End-of-session compaction into mktemp brief for the next agent
 /discipline                       Quick reference card of the 7 Laws
 /dashboard                        Visual instinct health dashboard
+/companion-preference             Inspect companion-preference hook telemetry
 /ralph                            Autonomous PRD story-by-story loop
-/learn-eval                       Capture session patterns into new skills (expert)
-/harvest                          Extract reusable patterns from session friction
+/learn-eval                       Capture session patterns into new skills (needs observation history)
+/harvest                          Extract reusable patterns from session friction (needs observation history)
 /release-train                    Coordinate a multi-PR release sequence
 /swarm                            Fan-out coordination across parallel sub-agents
 ```
 
-All 16 ship in the marketplace bundle. The Beginner install gets all of them. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
+All 17 ship in the marketplace bundle. The Beginner install gets all of them — with one caveat: `/learn-eval` and `/harvest` only produce useful output once Mulahazah has accumulated observation history (~20 observations), so running them on day 1 returns an empty result, not a broken command. `/swarm` and `/release-train` are orchestration commands aimed at larger multi-agent or multi-PR work. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
 
 ---
 

--- a/bin/check-skill-count.mjs
+++ b/bin/check-skill-count.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * Skill Count Check
+ *
+ * The plugin's user-facing description strings claim a bundled-skill count
+ * ("N bundled skills"). That number is hand-maintained inside
+ * src/lib/plugin-metadata.mts (SHARED_PLUGIN_DESCRIPTION) and package.json,
+ * and it drifts every time a skill is added without the count being bumped.
+ *
+ * Origin: the plugin-flow stress-test (2026-05-14) found marketplace.json and
+ * plugin.json both claiming "13 enforcement skills" while the bundle shipped
+ * 20. This lint locks the claim to the actual source-of-truth count so the
+ * marketplace card can never undersell (or oversell) the bundle again.
+ *
+ * Source of truth: skill directories under `plugins/continuous-improvement/skills/`
+ * (one `<name>/SKILL.md` per skill). This is the literal bundled-skill set —
+ * `npm run build` mirrors each `skills/<name>.md` standalone source (plus the
+ * core skill, whose standalone source is the repo-root `SKILL.md`) into it, and
+ * `verify:skill-mirror` already guarantees parity. Counting the bundle is the
+ * honest reading of the phrase "N bundled skills".
+ *
+ * Checked files (each must contain the literal `<count> bundled skills`):
+ *   - .claude-plugin/marketplace.json
+ *   - plugins/continuous-improvement/.claude-plugin/plugin.json
+ *   - package.json
+ *
+ * Usage:
+ *   node bin/check-skill-count.mjs              # Check the current repo
+ *   node bin/check-skill-count.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every checked file states the correct bundled-skill count
+ *   1 — at least one file states a stale or missing count
+ */
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const BUNDLE_SKILLS_DIR = "plugins/continuous-improvement/skills";
+const CHECKED_FILES = [
+    ".claude-plugin/marketplace.json",
+    "plugins/continuous-improvement/.claude-plugin/plugin.json",
+    "package.json",
+];
+export function countSkills(repoRoot) {
+    const skillsDir = join(repoRoot, BUNDLE_SKILLS_DIR);
+    const entries = readdirSync(skillsDir);
+    return entries.filter((entry) => {
+        try {
+            return statSync(join(skillsDir, entry)).isDirectory();
+        }
+        catch {
+            return false;
+        }
+    }).length;
+}
+function checkFile(repoRoot, relPath, expected) {
+    let content;
+    try {
+        content = readFileSync(join(repoRoot, relPath), "utf8");
+    }
+    catch {
+        return { file: relPath, reason: "missing" };
+    }
+    // Non-digit boundary before the count so "3 bundled skills" does not match
+    // inside "13 bundled skills".
+    const expectedPattern = new RegExp(`(?<!\\d)${expected} bundled skills`);
+    if (expectedPattern.test(content))
+        return null;
+    const staleMatch = content.match(/(\d+) bundled skills/);
+    return {
+        file: relPath,
+        reason: staleMatch ? "stale" : "missing",
+        found: staleMatch ? staleMatch[0] : undefined,
+    };
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const expected = countSkills(repoRoot);
+    const violations = [];
+    for (const file of CHECKED_FILES) {
+        const v = checkFile(repoRoot, file, expected);
+        if (v)
+            violations.push(v);
+    }
+    if (violations.length === 0) {
+        console.log(`OK skill-count: all ${CHECKED_FILES.length} description string(s) state "${expected} bundled skills" (matches skills/ source-of-truth).`);
+        exit(0);
+    }
+    console.error(`FAIL skill-count: ${violations.length} description string(s) do not state the actual bundled-skill count of ${expected}.`);
+    console.error(`Source of truth is ${expected} kebab-case *.md file(s) under skills/. Each checked file must contain the literal "${expected} bundled skills".`);
+    console.error("");
+    for (const v of violations) {
+        if (v.reason === "stale") {
+            console.error(`  ${v.file} — states "${v.found}", expected "${expected} bundled skills"`);
+        }
+        else {
+            console.error(`  ${v.file} — no "<count> bundled skills" phrase found`);
+        }
+    }
+    console.error("");
+    console.error("Fix: update SHARED_PLUGIN_DESCRIPTION in src/lib/plugin-metadata.mts and the");
+    console.error("package.json description, then re-run `npm run build` to regenerate manifests.");
+    exit(1);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-count.mjs")) {
+    main();
+}

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -8,7 +8,7 @@
  *   npx continuous-improvement install --pack react   # load starter instinct pack
  *   npx continuous-improvement install --uninstall    # remove everything
  */
-import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync, } from "node:fs";
+import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, } from "node:fs";
 import { execSync } from "node:child_process";
 import { homedir } from "node:os";
 import { dirname, join } from "node:path";
@@ -51,6 +51,62 @@ function readJsonFile(filePath) {
     }
     catch {
         return null;
+    }
+}
+// The observation hooks (hooks/observe.sh, hooks/session.sh) are bash scripts.
+// On Windows without Git Bash / WSL the hook commands written into settings.json
+// silently no-op, so the user finishes install thinking observation capture is
+// live when it never fires. Refuse the install with one actionable line instead.
+function assertBashAvailableOnWindows() {
+    if (process.platform !== "win32")
+        return;
+    try {
+        execSync("bash --version", { stdio: "ignore" });
+    }
+    catch {
+        console.error("  ✗ Install refused: the observation hooks (hooks/observe.sh, hooks/session.sh) " +
+            "are bash scripts, but `bash --version` is not on PATH. Install Git Bash or WSL, " +
+            "reopen your shell, and re-run — see README → Troubleshooting install.");
+        process.exit(1);
+    }
+}
+// The marketplace `/plugin install` path and this npx installer both write into
+// ~/.claude/. Running both duplicates hooks, commands, and skills. We cannot
+// fully resolve Claude Code's marketplace layout from here, so this is a loud
+// best-effort warning, not a hard refuse — a scan failure must never block install.
+function warnOnMarketplaceCollision() {
+    const pluginsDir = join(getHomeDir(), ".claude", "plugins");
+    if (!existsSync(pluginsDir))
+        return;
+    let hit = false;
+    try {
+        for (const entry of readdirSync(pluginsDir)) {
+            if (entry.includes(SKILL_NAME)) {
+                hit = true;
+                break;
+            }
+            const sub = join(pluginsDir, entry);
+            try {
+                if (statSync(sub).isDirectory() &&
+                    readdirSync(sub).some((e) => e.includes(SKILL_NAME))) {
+                    hit = true;
+                    break;
+                }
+            }
+            catch {
+                // unreadable entry — skip it
+            }
+        }
+    }
+    catch {
+        // best-effort — never block install on a scan failure
+        return;
+    }
+    if (hit) {
+        console.warn("\n  ! Possible Beginner+Expert collision: a marketplace install of\n" +
+            "    continuous-improvement looks present under ~/.claude/plugins/. Running the\n" +
+            "    npx installer on top of it duplicates hooks/commands/skills in ~/.claude/.\n" +
+            "    Pick ONE path — marketplace (/plugin install) or npx — not both.\n");
     }
 }
 const rawArgs = process.argv.slice(2);
@@ -403,6 +459,8 @@ console.log(`
 continuous-improvement (mode: ${INSTALL_MODE})
 Research → Plan → Execute → Verify → Reflect → Learn → Iterate
 `);
+assertBashAvailableOnWindows();
+warnOnMarketplaceCollision();
 console.log("Installing to Claude Code...\n");
 const installed = installSkill() ? 1 : 0;
 const modeInfo = {
@@ -417,7 +475,14 @@ if (packIndex !== -1 && rawArgs[packIndex + 1]) {
         const project = getProjectHashSync();
         const targetDir = join(getHomeDir(), ".claude", "instincts", project.hash);
         mkdirSync(targetDir, { recursive: true });
-        const instincts = JSON.parse(readFileSync(packPath, "utf8"));
+        let instincts = [];
+        try {
+            instincts = JSON.parse(readFileSync(packPath, "utf8"));
+        }
+        catch (error) {
+            console.error(`  ✗ Pack "${packName}" could not be loaded: ${getErrorMessage(error)}\n` +
+                `    ${packPath} is not valid JSON. No instincts were written — fix or re-fetch the pack file.`);
+        }
         let loaded = 0;
         for (const instinct of instincts) {
             const instinctPath = join(targetDir, `${instinct.id}.yaml`);

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -32,6 +32,7 @@ const COMMAND_FILES = [
     "seven-laws.md",
     "superpowers.md",
     "swarm.md",
+    "verify-install.md",
     "workspace-surface-audit.md",
 ];
 const HOOK_TYPES = ["PreToolUse", "PostToolUse"];

--- a/commands/verify-install.md
+++ b/commands/verify-install.md
@@ -1,0 +1,55 @@
+---
+name: verify-install
+description: Walk the post-install verification in one shot — confirm slash commands loaded, the gateguard runtime hook fires, and observation capture is recording — then print a single ✓ wired / ✗ missing line.
+---
+
+# /verify-install
+
+Replaces the manual post-install dance (restart, run `/discipline`, hand-write a
+hostile prompt, eyeball `/dashboard`) with one command that runs all three
+checks and reports a single line.
+
+Run the three checks **in order**. Do not skip a check because an earlier one
+passed — each proves a different layer.
+
+## Check 1 — slash commands loaded
+
+If this command is executing, the marketplace did pick the plugin up and the
+command registry loaded it. Record `commands: ✓`.
+
+If you are reading this file directly rather than running it as `/verify-install`,
+stop — the command is not registered. The fix is a Claude Code session restart
+(slash commands load on session start). Record `commands: ✗ (restart the session)`.
+
+## Check 2 — gateguard runtime hook fires
+
+The runtime gate ships as a PreToolUse hook (`hooks/gateguard.mjs`). Probe it:
+attempt to `Write` a throwaway file at a sandbox path (`./.ci-verify-install-probe.txt`
+with the text `probe`) **without presenting any research first**.
+
+- If the hook **blocks** the write with a fact-list reason — the runtime layer is
+  wired. Record `gateguard: ✓`. Do not retry the write; the block is the pass.
+- If the write **goes through** with no pause — the hook did not load. Record
+  `gateguard: ✗ (hooks/gateguard.mjs not wired — see README → Troubleshooting install)`.
+  Delete the probe file if it was created.
+
+## Check 3 — observation capture recording
+
+The observation hook appends one row per tool call to
+`~/.claude/instincts/<project-hash>/observations.jsonl`. Read that file (resolve
+`<project-hash>` from the current repo, or check `~/.claude/instincts/global/`).
+
+- If it exists and has at least one row — capture is recording. Record `observe: ✓`.
+- If it is missing or empty — record `observe: ✗ (observation hook not recording —
+  on Windows confirm Git Bash / WSL is installed, then re-run the installer)`.
+
+## Report
+
+Emit exactly one summary line, nothing else after it:
+
+- All three passed: `✓ wired — commands, gateguard, observe all confirmed.`
+- Any failed: `✗ <comma-separated failing checks with their fix hints>.`
+
+Do not claim "should be fine" for a check you could not actually run. If a check
+is genuinely unrunnable (e.g. no repo context for the project hash), mark it
+`unverified` with the reason rather than `✓`.

--- a/docs/plans/2026-05-14-plugin-flow-audit-fixes.md
+++ b/docs/plans/2026-05-14-plugin-flow-audit-fixes.md
@@ -1,0 +1,52 @@
+# Plan — Plugin-flow audit fixes (2026-05-14)
+
+Branch: `chore/plugin-flow-audit-fixes`
+
+## Goal
+
+Close the friction points found by the plugin-flow stress-test so a first-time
+user does not lose trust at the manifest, doc, or install layer. Source: 9-item
+WILD/RISA recommendation (2 WILD + 7 RISA) walked under `proceed-with-the-recommendation`.
+
+## Items and commit mapping
+
+One concern per commit, per CLAUDE.md. Build pipeline: edit `src/**/*.mts`, then
+`npm run build` regenerates `bin/`, `lib/`, `plugins/`, `.claude-plugin/` manifests.
+
+| # | Item | Files | Commit |
+|---|---|---|---|
+| 1 | Reconcile skill-count string ("13 enforcement skills" → actual bundle count) | `src/lib/plugin-metadata.mts`, `package.json`, regenerated `marketplace.json` + `plugin.json` | A |
+| 1b | `verify:skill-count` lint — manifest count vs bundle dir count | `src/bin/check-skill-count.mts`, `src/test/check-skill-count.test.mts`, `package.json` scripts | B |
+| 2 | CHANGELOG `[3.9.1]` + `[3.9.2]` entries | `CHANGELOG.md` | C |
+| 3 | Unify instinct-threshold vocabulary to "observations" | `QUICKSTART.md` (SKILL.md already correct) | D |
+| 6+7 | README slash-command section accuracy — `/companion-preference` + Expert/observations qualifiers | `README.md` (+ `QUICKSTART.md` if needed) | E |
+| 4 | Detect+refuse Beginner+Expert collision | `src/bin/install.mts`, `src/test/install.test.mts` | F |
+| 5 | Wrap pack JSON load in try/catch + clean rollback | `src/bin/install.mts`, `src/test/install.test.mts` | G |
+| W2 | Windows-without-bash first-class install check | `src/bin/install.mts`, `src/test/install.test.mts` | H |
+| W1 | Self-verifying single-command Beginner install | — | **HALT — needs design decision** |
+
+## W1 — why it halts
+
+`/plugin install continuous-improvement@continuous-improvement` is a Claude Code
+*native* command. There is no mechanical edit in this repo that injects a probe
+into it. Delivering W1's intent requires a design choice:
+- **A** — ship a separate `/verify-install` slash command the user runs after install.
+- **B** — use a plugin-manifest post-install hook, *if* Claude Code supports one
+  (needs verification against current Claude Code plugin spec).
+
+This is a fork for the operator, not an implementation task. Surfaced in the
+Phase 7 close.
+
+## Verification
+
+Per item: `npm run build` then `npm run verify:all` (skill-mirror, skill-tiers,
+skill-law-tag, docs-substrings, everything-mirror, routing-targets,
+doc-runtime-claims, typecheck) + targeted test where a `.test.mts` exists.
+
+## Risks
+
+- `docs-substrings` lint locks specific literals — item 3 / 6+7 doc edits must not
+  break locked substrings; check `bin/check-docs-substrings.mjs` before editing.
+- `verify:generated` fails if `.mjs` is edited without rebuilding from `.mts`.
+- Auto-merge ordering hazard if this branch splits into stacked PRs — keep as one
+  branch with single-concern commits, or gate stacked PRs on dependency order.

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -26,7 +26,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
+const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
 // See third-party/MANIFEST.md for refresh recipes and per-snapshot

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.9.2",
-  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
+  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",
     "claude-code-skill",
@@ -42,11 +42,12 @@
     "verify:skill-mirror": "node bin/check-skill-mirror.mjs",
     "verify:skill-tiers": "node bin/check-skill-tiers.mjs",
     "verify:skill-law-tag": "node bin/check-skill-law-tag.mjs",
+    "verify:skill-count": "node bin/check-skill-count.mjs",
     "verify:docs-substrings": "node bin/check-docs-substrings.mjs",
     "verify:everything-mirror": "node bin/check-everything-mirror.mjs",
     "verify:routing-targets": "node bin/check-routing-targets.mjs",
     "verify:doc-runtime-claims": "node bin/check-doc-runtime-claims.mjs",
-    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run typecheck"
+    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run typecheck"
   },
   "files": [
     ".claude-plugin/",

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
+      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
       "version": "3.9.2",
       "source": "./",
       "author": {

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.9.2",
-  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
+  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.",
   "author": {
     "name": "naimkatiman",
     "url": "https://github.com/naimkatiman"

--- a/plugins/continuous-improvement/commands/verify-install.md
+++ b/plugins/continuous-improvement/commands/verify-install.md
@@ -1,0 +1,55 @@
+---
+name: verify-install
+description: Walk the post-install verification in one shot — confirm slash commands loaded, the gateguard runtime hook fires, and observation capture is recording — then print a single ✓ wired / ✗ missing line.
+---
+
+# /verify-install
+
+Replaces the manual post-install dance (restart, run `/discipline`, hand-write a
+hostile prompt, eyeball `/dashboard`) with one command that runs all three
+checks and reports a single line.
+
+Run the three checks **in order**. Do not skip a check because an earlier one
+passed — each proves a different layer.
+
+## Check 1 — slash commands loaded
+
+If this command is executing, the marketplace did pick the plugin up and the
+command registry loaded it. Record `commands: ✓`.
+
+If you are reading this file directly rather than running it as `/verify-install`,
+stop — the command is not registered. The fix is a Claude Code session restart
+(slash commands load on session start). Record `commands: ✗ (restart the session)`.
+
+## Check 2 — gateguard runtime hook fires
+
+The runtime gate ships as a PreToolUse hook (`hooks/gateguard.mjs`). Probe it:
+attempt to `Write` a throwaway file at a sandbox path (`./.ci-verify-install-probe.txt`
+with the text `probe`) **without presenting any research first**.
+
+- If the hook **blocks** the write with a fact-list reason — the runtime layer is
+  wired. Record `gateguard: ✓`. Do not retry the write; the block is the pass.
+- If the write **goes through** with no pause — the hook did not load. Record
+  `gateguard: ✗ (hooks/gateguard.mjs not wired — see README → Troubleshooting install)`.
+  Delete the probe file if it was created.
+
+## Check 3 — observation capture recording
+
+The observation hook appends one row per tool call to
+`~/.claude/instincts/<project-hash>/observations.jsonl`. Read that file (resolve
+`<project-hash>` from the current repo, or check `~/.claude/instincts/global/`).
+
+- If it exists and has at least one row — capture is recording. Record `observe: ✓`.
+- If it is missing or empty — record `observe: ✗ (observation hook not recording —
+  on Windows confirm Git Bash / WSL is installed, then re-run the installer)`.
+
+## Report
+
+Emit exactly one summary line, nothing else after it:
+
+- All three passed: `✓ wired — commands, gateguard, observe all confirmed.`
+- Any failed: `✗ <comma-separated failing checks with their fix hints>.`
+
+Do not claim "should be fine" for a check you could not actually run. If a check
+is genuinely unrunnable (e.g. no repo context for the project hash), mark it
+`unverified` with the reason rather than `✓`.

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -26,7 +26,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
+const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
 // See third-party/MANIFEST.md for refresh recipes and per-snapshot

--- a/src/bin/check-skill-count.mts
+++ b/src/bin/check-skill-count.mts
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+
+/**
+ * Skill Count Check
+ *
+ * The plugin's user-facing description strings claim a bundled-skill count
+ * ("N bundled skills"). That number is hand-maintained inside
+ * src/lib/plugin-metadata.mts (SHARED_PLUGIN_DESCRIPTION) and package.json,
+ * and it drifts every time a skill is added without the count being bumped.
+ *
+ * Origin: the plugin-flow stress-test (2026-05-14) found marketplace.json and
+ * plugin.json both claiming "13 enforcement skills" while the bundle shipped
+ * 20. This lint locks the claim to the actual source-of-truth count so the
+ * marketplace card can never undersell (or oversell) the bundle again.
+ *
+ * Source of truth: skill directories under `plugins/continuous-improvement/skills/`
+ * (one `<name>/SKILL.md` per skill). This is the literal bundled-skill set —
+ * `npm run build` mirrors each `skills/<name>.md` standalone source (plus the
+ * core skill, whose standalone source is the repo-root `SKILL.md`) into it, and
+ * `verify:skill-mirror` already guarantees parity. Counting the bundle is the
+ * honest reading of the phrase "N bundled skills".
+ *
+ * Checked files (each must contain the literal `<count> bundled skills`):
+ *   - .claude-plugin/marketplace.json
+ *   - plugins/continuous-improvement/.claude-plugin/plugin.json
+ *   - package.json
+ *
+ * Usage:
+ *   node bin/check-skill-count.mjs              # Check the current repo
+ *   node bin/check-skill-count.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every checked file states the correct bundled-skill count
+ *   1 — at least one file states a stale or missing count
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const BUNDLE_SKILLS_DIR = "plugins/continuous-improvement/skills";
+const CHECKED_FILES: ReadonlyArray<string> = [
+  ".claude-plugin/marketplace.json",
+  "plugins/continuous-improvement/.claude-plugin/plugin.json",
+  "package.json",
+];
+
+export function countSkills(repoRoot: string): number {
+  const skillsDir = join(repoRoot, BUNDLE_SKILLS_DIR);
+  const entries = readdirSync(skillsDir);
+  return entries.filter((entry) => {
+    try {
+      return statSync(join(skillsDir, entry)).isDirectory();
+    } catch {
+      return false;
+    }
+  }).length;
+}
+
+interface CountViolation {
+  file: string;
+  reason: "missing" | "stale";
+  found?: string;
+}
+
+function checkFile(repoRoot: string, relPath: string, expected: number): CountViolation | null {
+  let content: string;
+  try {
+    content = readFileSync(join(repoRoot, relPath), "utf8");
+  } catch {
+    return { file: relPath, reason: "missing" };
+  }
+
+  // Non-digit boundary before the count so "3 bundled skills" does not match
+  // inside "13 bundled skills".
+  const expectedPattern = new RegExp(`(?<!\\d)${expected} bundled skills`);
+  if (expectedPattern.test(content)) return null;
+
+  const staleMatch = content.match(/(\d+) bundled skills/);
+  return {
+    file: relPath,
+    reason: staleMatch ? "stale" : "missing",
+    found: staleMatch ? staleMatch[0] : undefined,
+  };
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const expected = countSkills(repoRoot);
+  const violations: CountViolation[] = [];
+
+  for (const file of CHECKED_FILES) {
+    const v = checkFile(repoRoot, file, expected);
+    if (v) violations.push(v);
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `OK skill-count: all ${CHECKED_FILES.length} description string(s) state "${expected} bundled skills" (matches skills/ source-of-truth).`,
+    );
+    exit(0);
+  }
+
+  console.error(
+    `FAIL skill-count: ${violations.length} description string(s) do not state the actual bundled-skill count of ${expected}.`,
+  );
+  console.error(
+    `Source of truth is ${expected} kebab-case *.md file(s) under skills/. Each checked file must contain the literal "${expected} bundled skills".`,
+  );
+  console.error("");
+  for (const v of violations) {
+    if (v.reason === "stale") {
+      console.error(`  ${v.file} — states "${v.found}", expected "${expected} bundled skills"`);
+    } else {
+      console.error(`  ${v.file} — no "<count> bundled skills" phrase found`);
+    }
+  }
+  console.error("");
+  console.error(
+    "Fix: update SHARED_PLUGIN_DESCRIPTION in src/lib/plugin-metadata.mts and the",
+  );
+  console.error("package.json description, then re-run `npm run build` to regenerate manifests.");
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-skill-count.mjs")) {
+  main();
+}

--- a/src/bin/install.mts
+++ b/src/bin/install.mts
@@ -18,6 +18,7 @@ import {
   readFileSync,
   readdirSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { execSync } from "node:child_process";
@@ -102,6 +103,65 @@ function readJsonFile<T>(filePath: string): T | null {
     return JSON.parse(readFileSync(filePath, "utf8")) as T;
   } catch {
     return null;
+  }
+}
+
+// The observation hooks (hooks/observe.sh, hooks/session.sh) are bash scripts.
+// On Windows without Git Bash / WSL the hook commands written into settings.json
+// silently no-op, so the user finishes install thinking observation capture is
+// live when it never fires. Refuse the install with one actionable line instead.
+function assertBashAvailableOnWindows(): void {
+  if (process.platform !== "win32") return;
+  try {
+    execSync("bash --version", { stdio: "ignore" });
+  } catch {
+    console.error(
+      "  ✗ Install refused: the observation hooks (hooks/observe.sh, hooks/session.sh) " +
+        "are bash scripts, but `bash --version` is not on PATH. Install Git Bash or WSL, " +
+        "reopen your shell, and re-run — see README → Troubleshooting install.",
+    );
+    process.exit(1);
+  }
+}
+
+// The marketplace `/plugin install` path and this npx installer both write into
+// ~/.claude/. Running both duplicates hooks, commands, and skills. We cannot
+// fully resolve Claude Code's marketplace layout from here, so this is a loud
+// best-effort warning, not a hard refuse — a scan failure must never block install.
+function warnOnMarketplaceCollision(): void {
+  const pluginsDir = join(getHomeDir(), ".claude", "plugins");
+  if (!existsSync(pluginsDir)) return;
+  let hit = false;
+  try {
+    for (const entry of readdirSync(pluginsDir)) {
+      if (entry.includes(SKILL_NAME)) {
+        hit = true;
+        break;
+      }
+      const sub = join(pluginsDir, entry);
+      try {
+        if (
+          statSync(sub).isDirectory() &&
+          readdirSync(sub).some((e) => e.includes(SKILL_NAME))
+        ) {
+          hit = true;
+          break;
+        }
+      } catch {
+        // unreadable entry — skip it
+      }
+    }
+  } catch {
+    // best-effort — never block install on a scan failure
+    return;
+  }
+  if (hit) {
+    console.warn(
+      "\n  ! Possible Beginner+Expert collision: a marketplace install of\n" +
+        "    continuous-improvement looks present under ~/.claude/plugins/. Running the\n" +
+        "    npx installer on top of it duplicates hooks/commands/skills in ~/.claude/.\n" +
+        "    Pick ONE path — marketplace (/plugin install) or npx — not both.\n",
+    );
   }
 }
 
@@ -506,6 +566,9 @@ continuous-improvement (mode: ${INSTALL_MODE})
 Research → Plan → Execute → Verify → Reflect → Learn → Iterate
 `);
 
+assertBashAvailableOnWindows();
+warnOnMarketplaceCollision();
+
 console.log("Installing to Claude Code...\n");
 
 const installed = installSkill() ? 1 : 0;
@@ -524,7 +587,15 @@ if (packIndex !== -1 && rawArgs[packIndex + 1]) {
     const targetDir = join(getHomeDir(), ".claude", "instincts", project.hash);
     mkdirSync(targetDir, { recursive: true });
 
-    const instincts = JSON.parse(readFileSync(packPath, "utf8")) as PackInstinct[];
+    let instincts: PackInstinct[] = [];
+    try {
+      instincts = JSON.parse(readFileSync(packPath, "utf8")) as PackInstinct[];
+    } catch (error) {
+      console.error(
+        `  ✗ Pack "${packName}" could not be loaded: ${getErrorMessage(error)}\n` +
+          `    ${packPath} is not valid JSON. No instincts were written — fix or re-fetch the pack file.`,
+      );
+    }
     let loaded = 0;
     for (const instinct of instincts) {
       const instinctPath = join(targetDir, `${instinct.id}.yaml`);

--- a/src/bin/install.mts
+++ b/src/bin/install.mts
@@ -81,6 +81,7 @@ const COMMAND_FILES = [
   "seven-laws.md",
   "superpowers.md",
   "swarm.md",
+  "verify-install.md",
   "workspace-surface-audit.md",
 ] as const;
 const HOOK_TYPES: readonly HookType[] = ["PreToolUse", "PostToolUse"];

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -147,7 +147,7 @@ const KEYWORDS = [
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
 const SHARED_PLUGIN_DESCRIPTION =
-  "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
+  "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.";
 
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.

--- a/src/test/check-skill-count.test.mts
+++ b/src/test/check-skill-count.test.mts
@@ -1,0 +1,98 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import { countSkills } from "../bin/check-skill-count.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-count.mjs");
+
+function setupRepo(skillNames: string[], descriptions: Record<string, string>): string {
+  const root = mkdtempSync(join(tmpdir(), "skill-count-test-"));
+  const bundleSkillsDir = join(root, "plugins", "continuous-improvement", "skills");
+  mkdirSync(bundleSkillsDir, { recursive: true });
+  mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+  mkdirSync(join(root, "plugins", "continuous-improvement", ".claude-plugin"), { recursive: true });
+  for (const name of skillNames) {
+    mkdirSync(join(bundleSkillsDir, name), { recursive: true });
+    writeFileSync(join(bundleSkillsDir, name, "SKILL.md"), `---\nname: ${name}\n---\n# ${name}\n`);
+  }
+  writeFileSync(
+    join(root, ".claude-plugin", "marketplace.json"),
+    JSON.stringify({ description: descriptions.marketplace ?? "" }),
+  );
+  writeFileSync(
+    join(root, "plugins", "continuous-improvement", ".claude-plugin", "plugin.json"),
+    JSON.stringify({ description: descriptions.plugin ?? "" }),
+  );
+  writeFileSync(
+    join(root, "package.json"),
+    JSON.stringify({ description: descriptions.package ?? "" }),
+  );
+  return root;
+}
+
+describe("check-skill-count — unit", () => {
+  it("counts only directories under the bundle skills dir, not loose files", () => {
+    const root = setupRepo(["alpha", "beta", "gamma"], {});
+    try {
+      writeFileSync(
+        join(root, "plugins", "continuous-improvement", "skills", "README.md"),
+        "# README\n",
+      );
+      assert.equal(countSkills(root), 3);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("check-skill-count — integration", () => {
+  it("CLI exits 0 when all three descriptions state the correct count", () => {
+    const phrase = "2 bundled skills";
+    const root = setupRepo(["alpha", "beta"], {
+      marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
+      plugin: `The 7 Laws — ${phrase}, gating hooks.`,
+      package: `The 7 Laws — ${phrase}, gating hooks.`,
+    });
+    try {
+      const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      assert.match(out, /OK skill-count: all 3 description string\(s\) state "2 bundled skills"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 and names the stale file when a count drifts", () => {
+    const root = setupRepo(["alpha", "beta", "gamma"], {
+      marketplace: "The 7 Laws — 3 bundled skills, gating hooks.",
+      plugin: "The 7 Laws — 13 bundled skills, gating hooks.",
+      package: "The 7 Laws — 3 bundled skills, gating hooks.",
+    });
+    try {
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /FAIL skill-count: 1 description string\(s\)/);
+        assert.match(e.stderr ?? "", /plugin\.json — states "13 bundled skills"/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero when a count drifts");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies the live repo states the correct bundled-skill count", () => {
+    const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+    assert.match(out, /OK skill-count:/);
+  });
+});

--- a/src/test/commands.test.mts
+++ b/src/test/commands.test.mts
@@ -103,3 +103,34 @@ describe("commands/planning-with-files.md", () => {
     assert.match(content, /recover/i);
   });
 });
+
+describe("commands/verify-install.md", () => {
+  let content = "";
+
+  it("exists", () => {
+    const path = join(COMMANDS_DIR, "verify-install.md");
+    assert.ok(existsSync(path), "verify-install.md should exist");
+    content = readFileSync(path, "utf8");
+  });
+
+  it("has valid frontmatter", () => {
+    assert.match(content, /^---\r?\n/);
+    assert.match(content, /name: verify-install/);
+    assert.match(content, /description:/);
+  });
+
+  it("walks the three post-install checks in order", () => {
+    assert.match(content, /Check 1 — slash commands loaded/);
+    assert.match(content, /Check 2 — gateguard runtime hook fires/);
+    assert.match(content, /Check 3 — observation capture recording/);
+  });
+
+  it("anchors the gateguard check to the actual hook file", () => {
+    assert.match(content, /hooks\/gateguard\.mjs/);
+  });
+
+  it("requires a single pass/fail summary line", () => {
+    assert.match(content, /✓ wired/);
+    assert.match(content, /✗ /);
+  });
+});

--- a/src/test/install.test.mts
+++ b/src/test/install.test.mts
@@ -386,3 +386,45 @@ describe("installer - pack loader", () => {
     assert.match(combined, /Unknown pack/, "Unknown pack name should produce error output");
   });
 });
+
+describe("installer - marketplace collision warning", () => {
+  let tempHome = "";
+
+  before(() => {
+    tempHome = join(tmpdir(), `ci-test-collision-${Date.now()}`);
+    mkdirSync(join(tempHome, ".claude"), { recursive: true });
+  });
+
+  after(() => {
+    rmSync(tempHome, { recursive: true, force: true });
+  });
+
+  it("warns when a marketplace install of continuous-improvement is present", () => {
+    mkdirSync(join(tempHome, ".claude", "plugins", "continuous-improvement"), {
+      recursive: true,
+    });
+    const result = spawnSync("node", [INSTALL_SCRIPT, "install"], {
+      env: { ...process.env, HOME: tempHome },
+      cwd: tempHome,
+      encoding: "utf8",
+    });
+    const combined = (result.stdout ?? "") + (result.stderr ?? "");
+    assert.match(combined, /Possible Beginner\+Expert collision/);
+  });
+
+  it("does not warn on a clean ~/.claude with no plugins dir", () => {
+    const cleanHome = join(tmpdir(), `ci-test-clean-${Date.now()}`);
+    mkdirSync(join(cleanHome, ".claude"), { recursive: true });
+    try {
+      const result = spawnSync("node", [INSTALL_SCRIPT, "install"], {
+        env: { ...process.env, HOME: cleanHome },
+        cwd: cleanHome,
+        encoding: "utf8",
+      });
+      const combined = (result.stdout ?? "") + (result.stderr ?? "");
+      assert.doesNotMatch(combined, /Possible Beginner\+Expert collision/);
+    } finally {
+      rmSync(cleanHome, { recursive: true, force: true });
+    }
+  });
+});

--- a/test/check-skill-count.test.mjs
+++ b/test/check-skill-count.test.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { countSkills } from "../bin/check-skill-count.mjs";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-skill-count.mjs");
+function setupRepo(skillNames, descriptions) {
+    const root = mkdtempSync(join(tmpdir(), "skill-count-test-"));
+    const bundleSkillsDir = join(root, "plugins", "continuous-improvement", "skills");
+    mkdirSync(bundleSkillsDir, { recursive: true });
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    mkdirSync(join(root, "plugins", "continuous-improvement", ".claude-plugin"), { recursive: true });
+    for (const name of skillNames) {
+        mkdirSync(join(bundleSkillsDir, name), { recursive: true });
+        writeFileSync(join(bundleSkillsDir, name, "SKILL.md"), `---\nname: ${name}\n---\n# ${name}\n`);
+    }
+    writeFileSync(join(root, ".claude-plugin", "marketplace.json"), JSON.stringify({ description: descriptions.marketplace ?? "" }));
+    writeFileSync(join(root, "plugins", "continuous-improvement", ".claude-plugin", "plugin.json"), JSON.stringify({ description: descriptions.plugin ?? "" }));
+    writeFileSync(join(root, "package.json"), JSON.stringify({ description: descriptions.package ?? "" }));
+    return root;
+}
+describe("check-skill-count — unit", () => {
+    it("counts only directories under the bundle skills dir, not loose files", () => {
+        const root = setupRepo(["alpha", "beta", "gamma"], {});
+        try {
+            writeFileSync(join(root, "plugins", "continuous-improvement", "skills", "README.md"), "# README\n");
+            assert.equal(countSkills(root), 3);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+});
+describe("check-skill-count — integration", () => {
+    it("CLI exits 0 when all three descriptions state the correct count", () => {
+        const phrase = "2 bundled skills";
+        const root = setupRepo(["alpha", "beta"], {
+            marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
+            plugin: `The 7 Laws — ${phrase}, gating hooks.`,
+            package: `The 7 Laws — ${phrase}, gating hooks.`,
+        });
+        try {
+            const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            assert.match(out, /OK skill-count: all 3 description string\(s\) state "2 bundled skills"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 and names the stale file when a count drifts", () => {
+        const root = setupRepo(["alpha", "beta", "gamma"], {
+            marketplace: "The 7 Laws — 3 bundled skills, gating hooks.",
+            plugin: "The 7 Laws — 13 bundled skills, gating hooks.",
+            package: "The 7 Laws — 3 bundled skills, gating hooks.",
+        });
+        try {
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /FAIL skill-count: 1 description string\(s\)/);
+                assert.match(e.stderr ?? "", /plugin\.json — states "13 bundled skills"/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero when a count drifts");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("verifies the live repo states the correct bundled-skill count", () => {
+        const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+        assert.match(out, /OK skill-count:/);
+    });
+});

--- a/test/commands.test.mjs
+++ b/test/commands.test.mjs
@@ -86,3 +86,28 @@ describe("commands/planning-with-files.md", () => {
         assert.match(content, /recover/i);
     });
 });
+describe("commands/verify-install.md", () => {
+    let content = "";
+    it("exists", () => {
+        const path = join(COMMANDS_DIR, "verify-install.md");
+        assert.ok(existsSync(path), "verify-install.md should exist");
+        content = readFileSync(path, "utf8");
+    });
+    it("has valid frontmatter", () => {
+        assert.match(content, /^---\r?\n/);
+        assert.match(content, /name: verify-install/);
+        assert.match(content, /description:/);
+    });
+    it("walks the three post-install checks in order", () => {
+        assert.match(content, /Check 1 — slash commands loaded/);
+        assert.match(content, /Check 2 — gateguard runtime hook fires/);
+        assert.match(content, /Check 3 — observation capture recording/);
+    });
+    it("anchors the gateguard check to the actual hook file", () => {
+        assert.match(content, /hooks\/gateguard\.mjs/);
+    });
+    it("requires a single pass/fail summary line", () => {
+        assert.match(content, /✓ wired/);
+        assert.match(content, /✗ /);
+    });
+});

--- a/test/install.test.mjs
+++ b/test/install.test.mjs
@@ -274,3 +274,41 @@ describe("installer - pack loader", () => {
         assert.match(combined, /Unknown pack/, "Unknown pack name should produce error output");
     });
 });
+describe("installer - marketplace collision warning", () => {
+    let tempHome = "";
+    before(() => {
+        tempHome = join(tmpdir(), `ci-test-collision-${Date.now()}`);
+        mkdirSync(join(tempHome, ".claude"), { recursive: true });
+    });
+    after(() => {
+        rmSync(tempHome, { recursive: true, force: true });
+    });
+    it("warns when a marketplace install of continuous-improvement is present", () => {
+        mkdirSync(join(tempHome, ".claude", "plugins", "continuous-improvement"), {
+            recursive: true,
+        });
+        const result = spawnSync("node", [INSTALL_SCRIPT, "install"], {
+            env: { ...process.env, HOME: tempHome },
+            cwd: tempHome,
+            encoding: "utf8",
+        });
+        const combined = (result.stdout ?? "") + (result.stderr ?? "");
+        assert.match(combined, /Possible Beginner\+Expert collision/);
+    });
+    it("does not warn on a clean ~/.claude with no plugins dir", () => {
+        const cleanHome = join(tmpdir(), `ci-test-clean-${Date.now()}`);
+        mkdirSync(join(cleanHome, ".claude"), { recursive: true });
+        try {
+            const result = spawnSync("node", [INSTALL_SCRIPT, "install"], {
+                env: { ...process.env, HOME: cleanHome },
+                cwd: cleanHome,
+                encoding: "utf8",
+            });
+            const combined = (result.stdout ?? "") + (result.stderr ?? "");
+            assert.doesNotMatch(combined, /Possible Beginner\+Expert collision/);
+        }
+        finally {
+            rmSync(cleanHome, { recursive: true, force: true });
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Closes the friction points found by a plugin-flow stress-test (the install + first-use journey of the marketplace plugin). Walked under `proceed-with-the-recommendation` as a 9-item WILD/RISA list — 8 items shipped here, 1 (WILD: self-verifying install) resolved as Option A = the `/verify-install` command.

6 single-concern commits:

- **`feb8869` — skill-count lint + manifest reconcile.** `"13 enforcement skills"` was stale in `marketplace.json`, `plugin.json`, `package.json` while the bundle ships 20. Fixed the single source constant + added `verify:skill-count` lint (wired into `verify:all`) so it can't drift again.
- **`9744454` — CHANGELOG 3.9.1 + 3.9.2.** Changelog stopped at 3.9.0 while 3.9.2 shipped. The `v3.9.0` tag was cut before PR #99, so 3.9.1 silently carried the gateguard runtime hook, native review agents, verification-ladder skills, and the doc-runtime-claims lint — the entry says so.
- **`79aec55` — QUICKSTART vocabulary.** Auto-leveling table counted "sessions"; `SKILL.md` (source of truth) counts "observations" — a ~10–50× expectation drift. Table now mirrors SKILL.md's four levels.
- **`0a377ca` — README slash-command list.** Listed 16 commands; bundle ships 17 (`/companion-preference` was undocumented). Corrected, and flagged `/learn-eval` + `/harvest` as needing observation history.
- **`42b33bb` — installer hardening.** Three silent-failure modes in the npx installer: Windows-without-bash now refuses with one actionable line instead of writing no-op hooks; best-effort `~/.claude/plugins/` scan warns on Beginner+Expert collision; malformed instinct pack prints one error and writes nothing instead of crashing mid-install.
- **`b7c951f` — `/verify-install` command.** Replaces the manual post-install dance with one command that walks all three checks (commands loaded, gateguard fires, observation capture recording) and prints a single ✓ wired / ✗ missing line. Ships through the standard pipeline; count 17→18.

## Notes

- Branch was rebased onto current `main` (post-#140/#141) — clean, zero build drift.
- Adjacent unmerged branch `origin/docs/readme-skill-count-20` fixes the README skill *table* (prose); this PR fixes the manifest *description strings* + adds the lint. No file overlap — but that branch looks stale post-#141 (it edits a README skill table #141 carved into docs/) and should be reconciled separately.
- Deferred follow-up: `install.mts` `COMMAND_FILES` lists 13 commands but the bundle ships 18 — the npx Expert path omits `grill-me`, `grill-with-docs`, `handoff`, `companion-preference`. Out of scope here; logged for a separate PR.
- Plan doc: `docs/plans/2026-05-14-plugin-flow-audit-fixes.md`.

## Test plan

- [x] `npm run verify:all` — all 8 invariants green (incl. new `verify:skill-count`)
- [x] `npm test` — 579/579 pass (includes #140's new doc-drift + route-prompt tests, and 7 new tests added here)
- [x] Rebased onto `main`; `npm run build` produces zero drift
- [ ] Manual: run `/verify-install` in a Claude Code session post-install and confirm the ✓/✗ summary