### PR TITLE
feat(scripts): extract git-state-snapshot.sh as shared primitive (audit composability #1)

### DIFF
--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -97,30 +97,37 @@ A second Claude/Codex/Maulana session can be running on the same host and the sa
 
 **On the first Edit / Write / mutating Bash of a session:**
 
-```
-Baseline these three values and quote them in your response:
+Run [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) and quote its JSON envelope verbatim. Example output:
 
-1. `git rev-parse HEAD` — record the commit you started on
-2. `git rev-parse @{u}` (if branch tracks an upstream) — record where origin was
-3. `git status --porcelain` — record the working tree state
-
-If any value is "unknown" (detached HEAD, no upstream, untracked-only tree),
-say so explicitly. Do not proceed past the baseline silently.
 ```
+{"head":"966ce51","upstream":"966ce51","dirty":0,"root":"/path/to/repo","branch":"main"}
+```
+
+Field meanings:
+
+1. `head` — short SHA of the commit you started on
+2. `upstream` — short SHA of `@{u}` if the branch tracks an upstream, else the literal `"none"`
+3. `dirty` — integer count of `git status --porcelain` lines (0 == clean)
+4. `root` — repo root path from `git rev-parse --show-toplevel`
+5. `branch` — current branch name, or the literal `"detached"`
+
+If `upstream` is `"none"` or `branch` is `"detached"`, say so explicitly. Do not proceed past the baseline silently. If the script exits non-zero (output is `{"error":"not-a-git-repo"}`), HALT — the harness is not running in a git checkout and no mutation should land here.
 
 **On every subsequent Edit / Write / mutating Bash, before allowing the action:**
 
-```
-Re-check the three baselines against current state:
+Re-run [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) and diff against the baseline:
 
-1. `git rev-parse HEAD` — has it advanced past your baseline without your commits?
-2. `git rev-parse @{u}` — did upstream move while you worked?
-3. `git status --porcelain` — are there modifications you did not introduce?
+1. `head` — has it advanced past your baseline without your commits?
+2. `upstream` — did upstream move while you worked?
+3. `dirty` — are there modifications you did not introduce (count increased)?
+4. `branch` — did the working tree switch branches under you?
 
 If ANY of those drifted from baseline, HALT. Emit:
-"Parallel-actor divergence: <field> moved from <baseline> to <current>.
+
+```
+Parallel-actor divergence: <field> moved from <baseline> to <current>.
 Working tree may belong to another session. Stop, surface to operator,
-get clearance before next mutation."
+get clearance before next mutation.
 ```
 
 This gate is what catches the squash-merge / ahead-of-origin trap recorded in the operator's memory (`feedback_pre_branch_check.md`, `feedback_parallel_actor.md`) — both classes of failure occurred because a baseline was never captured at session start.

--- a/plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md
+++ b/plugins/continuous-improvement/skills/workspace-surface-audit/SKILL.md
@@ -74,7 +74,7 @@ Probe and record (no destructive commands; quote results inline):
 - **jq availability.** `command -v jq` (or `Get-Command jq`). When jq is missing, observation-pipeline hooks fall back to a thin schema and curl/JSON one-liners need a node/python rewrite.
 - **Case-sensitive filesystem.** Test by creating two paths differing only in case in a tempdir. NTFS (Windows) and APFS (macOS default) are case-insensitive; Linux ext4 and case-sensitive APFS are case-sensitive. Affects `CLAUDE.md` vs `claude.md` resolution and import paths.
 - **CWD baseline.** `pwd` (or `Get-Location`) recorded at session start. `tsc`, build scripts, and some test runners change CWD as a side effect; subsequent commands run from the wrong directory return "deps not installed" or "config not found" misreads.
-- **Parallel-actor expectation.** Document whether a second Claude / Codex / Maulana session may operate on the same working tree. If yes, the `gateguard` Parallel-Actor Gate must baseline `git rev-parse HEAD` + `git status --porcelain` + upstream before the first mutation, and re-check on every subsequent mutation.
+- **Parallel-actor expectation.** Document whether a second Claude / Codex / Maulana session may operate on the same working tree. If yes, the `gateguard` Parallel-Actor Gate uses [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) to produce a single JSON envelope (`{head, upstream, dirty, root, branch}`) for the baseline and the divergence check. This skill records whether parallel-actor is expected; gateguard owns the runtime mechanics, so the audit doesn't restate the git-command triple.
 
 Output the recorded grain as a single fenced block so it survives context compaction and any later phase can reference it without re-probing:
 

--- a/plugins/continuous-improvement/skills/worktree-safety/SKILL.md
+++ b/plugins/continuous-improvement/skills/worktree-safety/SKILL.md
@@ -32,10 +32,10 @@ The continuous-improvement repo runs on Windows + Git Bash with `autocrlf=true` 
 
 Before any source-writing call, verify all five. Fail closed on any miss.
 
-1. **Root validity** — `git rev-parse --show-toplevel` resolves; the resolved path matches CWD after symlink-safe canonicalization.
+1. **Root validity** — `git rev-parse --show-toplevel` resolves; the resolved path matches CWD after symlink-safe canonicalization. The `root` field of [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) carries the canonicalized root, and its non-zero exit on `{"error":"not-a-git-repo"}` is itself the fail-closed signal — no second probe needed.
 2. **`.git` presence** — `.git` exists (file pointer for worktrees, directory for primary checkout). A missing or unreadable `.git` is an immediate stop.
 3. **Worktree registration** — `git worktree list` includes the resolved root with no `prunable` flag. Prunable worktrees can be deleted by another process at any moment.
-4. **Branch alignment** — current branch matches the lease ledger; `HEAD` is not detached unless the unit explicitly asked for detached state.
+4. **Branch alignment** — current branch matches the lease ledger; `HEAD` is not detached unless the unit explicitly asked for detached state. The snapshot script's `branch` field carries either the branch name or the literal `"detached"`, so detached-state is observable without a second probe.
 5. **Lease ownership** — the session ID in `.git/worktrees/<name>/lease` (or your equivalent ledger) matches this session. Stale or foreign leases block the call.
 
 Output a single fenced block before any source-writing dispatch:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,27 @@
+# `scripts/` — deterministic primitives skills cite
+
+This directory holds small, hand-authored scripts that skills (and hooks) cite instead of restating fixed operations inline. The motivation is the skills audit's "deterministic vs non-deterministic" axis: when a step inside a skill is the same operation every time (a fixed git command, a regex parse, a path lookup), it does not belong in the LLM-driven part of the skill — it belongs here, where the script runs the same way every invocation, costs no tokens, and stays in one place so multiple skills can share it.
+
+## Conventions
+
+- **Hand-authored, no `.mts` source.** Files in `scripts/` are not part of the `tsc` build pipeline (see [`CLAUDE.md`](../CLAUDE.md) → "Build pipeline"). The pipeline owns `bin/`, `lib/`, `test/`. `scripts/` is the bare-metal home for shell scripts and one-off Node utilities skills cite directly.
+- **One concern per script.** Each script does one thing and prints either machine-readable output (JSON envelope, single value) or a stable fenced block. Skills consume the output; they do not re-derive it.
+- **Cross-platform shape.** Bash scripts run via Git Bash on Windows, native bash on macOS/Linux. Tests for bash scripts skip when bash is not on PATH (see `src/test/hook.test.mts` for the established skip pattern).
+- **Cite from skills.** When a skill needs a primitive, the skill body cites the script path (`scripts/<name>.<ext>`) and quotes the expected output shape once. The skill does not restate the script's inner mechanics.
+
+## Inventory
+
+| Script | Purpose | Cited by |
+|---|---|---|
+| `git-state-snapshot.sh` | JSON envelope `{head, upstream, dirty, root, branch}` for the current git working tree | `skills/gateguard.md` (Parallel-Actor Gate), `skills/worktree-safety.md` (Root + branch), `skills/workspace-surface-audit.md` (Environment Grain — parallel-actor row) |
+
+When a new script lands here, add a row to this table in the same PR and cite the script from at least one skill — otherwise the script is dead code on arrival.
+
+## Relationship to other locations
+
+- `bin/` — generated CLI entrypoints (`.mjs` from `src/bin/*.mts`). Do not hand-edit; see [`CLAUDE.md`](../CLAUDE.md) → "Build pipeline".
+- `lib/` — generated library code (`.mjs` from `src/lib/*.mts`). Same rule.
+- `hooks/` — generated PreToolUse / PostToolUse / Stop hooks (`.mjs` from `src/hooks/*.mts`). Wired in `plugins/continuous-improvement/hooks/hooks.json`.
+- `scripts/` — this directory. Hand-authored primitives skills cite.
+
+When deciding where a new piece of code belongs: if it implements a runtime hook the harness will call, it goes in `src/hooks/`. If it's a verification or CLI entrypoint the plugin or `npm run` invokes, it goes in `src/bin/`. If it's reusable logic shared between those, it goes in `src/lib/`. If it's a small primitive a skill body cites by path (and the operator or harness runs ad hoc), it goes here.

--- a/scripts/git-state-snapshot.sh
+++ b/scripts/git-state-snapshot.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# scripts/git-state-snapshot.sh
+#
+# Emit a single-line JSON envelope describing the current git working-tree
+# state. Composability primitive used by skills that need to baseline or check
+# git state without each restating the same 3-command triple.
+#
+# Fields:
+#   - head:     short SHA returned by `git rev-parse --short HEAD`
+#   - upstream: short SHA of `@{u}` if the branch tracks an upstream, else "none"
+#   - dirty:    integer count of lines from `git status --porcelain` (0 == clean)
+#   - root:     absolute path from `git rev-parse --show-toplevel`
+#   - branch:   `git symbolic-ref --short HEAD`, else "detached"
+#
+# Outside a git repository the script prints `{"error":"not-a-git-repo"}` and
+# exits 1. All other failures are treated as a non-git-repo condition rather
+# than emitting a partial envelope.
+#
+# Cited by:
+#   - skills/gateguard.md            (Parallel-Actor Gate baseline + divergence)
+#   - skills/worktree-safety.md      (Root + branch alignment)
+#   - skills/workspace-surface-audit.md (Environment Grain — parallel-actor row)
+
+set -u
+
+head=$(git rev-parse --short HEAD 2>/dev/null) || {
+  printf '{"error":"not-a-git-repo"}\n'
+  exit 1
+}
+
+if upstream=$(git rev-parse --short '@{u}' 2>/dev/null); then
+  upstream_field=$(printf '"%s"' "$upstream")
+else
+  upstream_field='"none"'
+fi
+
+dirty=$(git status --porcelain 2>/dev/null | wc -l | tr -d ' ')
+
+root=$(git rev-parse --show-toplevel 2>/dev/null || printf 'unknown')
+
+if branch=$(git symbolic-ref --short HEAD 2>/dev/null); then
+  branch_field=$(printf '"%s"' "$branch")
+else
+  branch_field='"detached"'
+fi
+
+printf '{"head":"%s","upstream":%s,"dirty":%s,"root":"%s","branch":%s}\n' \
+  "$head" "$upstream_field" "$dirty" "$root" "$branch_field"

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -97,30 +97,37 @@ A second Claude/Codex/Maulana session can be running on the same host and the sa
 
 **On the first Edit / Write / mutating Bash of a session:**
 
-```
-Baseline these three values and quote them in your response:
+Run [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) and quote its JSON envelope verbatim. Example output:
 
-1. `git rev-parse HEAD` — record the commit you started on
-2. `git rev-parse @{u}` (if branch tracks an upstream) — record where origin was
-3. `git status --porcelain` — record the working tree state
-
-If any value is "unknown" (detached HEAD, no upstream, untracked-only tree),
-say so explicitly. Do not proceed past the baseline silently.
 ```
+{"head":"966ce51","upstream":"966ce51","dirty":0,"root":"/path/to/repo","branch":"main"}
+```
+
+Field meanings:
+
+1. `head` — short SHA of the commit you started on
+2. `upstream` — short SHA of `@{u}` if the branch tracks an upstream, else the literal `"none"`
+3. `dirty` — integer count of `git status --porcelain` lines (0 == clean)
+4. `root` — repo root path from `git rev-parse --show-toplevel`
+5. `branch` — current branch name, or the literal `"detached"`
+
+If `upstream` is `"none"` or `branch` is `"detached"`, say so explicitly. Do not proceed past the baseline silently. If the script exits non-zero (output is `{"error":"not-a-git-repo"}`), HALT — the harness is not running in a git checkout and no mutation should land here.
 
 **On every subsequent Edit / Write / mutating Bash, before allowing the action:**
 
-```
-Re-check the three baselines against current state:
+Re-run [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) and diff against the baseline:
 
-1. `git rev-parse HEAD` — has it advanced past your baseline without your commits?
-2. `git rev-parse @{u}` — did upstream move while you worked?
-3. `git status --porcelain` — are there modifications you did not introduce?
+1. `head` — has it advanced past your baseline without your commits?
+2. `upstream` — did upstream move while you worked?
+3. `dirty` — are there modifications you did not introduce (count increased)?
+4. `branch` — did the working tree switch branches under you?
 
 If ANY of those drifted from baseline, HALT. Emit:
-"Parallel-actor divergence: <field> moved from <baseline> to <current>.
+
+```
+Parallel-actor divergence: <field> moved from <baseline> to <current>.
 Working tree may belong to another session. Stop, surface to operator,
-get clearance before next mutation."
+get clearance before next mutation.
 ```
 
 This gate is what catches the squash-merge / ahead-of-origin trap recorded in the operator's memory (`feedback_pre_branch_check.md`, `feedback_parallel_actor.md`) — both classes of failure occurred because a baseline was never captured at session start.

--- a/skills/workspace-surface-audit.md
+++ b/skills/workspace-surface-audit.md
@@ -74,7 +74,7 @@ Probe and record (no destructive commands; quote results inline):
 - **jq availability.** `command -v jq` (or `Get-Command jq`). When jq is missing, observation-pipeline hooks fall back to a thin schema and curl/JSON one-liners need a node/python rewrite.
 - **Case-sensitive filesystem.** Test by creating two paths differing only in case in a tempdir. NTFS (Windows) and APFS (macOS default) are case-insensitive; Linux ext4 and case-sensitive APFS are case-sensitive. Affects `CLAUDE.md` vs `claude.md` resolution and import paths.
 - **CWD baseline.** `pwd` (or `Get-Location`) recorded at session start. `tsc`, build scripts, and some test runners change CWD as a side effect; subsequent commands run from the wrong directory return "deps not installed" or "config not found" misreads.
-- **Parallel-actor expectation.** Document whether a second Claude / Codex / Maulana session may operate on the same working tree. If yes, the `gateguard` Parallel-Actor Gate must baseline `git rev-parse HEAD` + `git status --porcelain` + upstream before the first mutation, and re-check on every subsequent mutation.
+- **Parallel-actor expectation.** Document whether a second Claude / Codex / Maulana session may operate on the same working tree. If yes, the `gateguard` Parallel-Actor Gate uses [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) to produce a single JSON envelope (`{head, upstream, dirty, root, branch}`) for the baseline and the divergence check. This skill records whether parallel-actor is expected; gateguard owns the runtime mechanics, so the audit doesn't restate the git-command triple.
 
 Output the recorded grain as a single fenced block so it survives context compaction and any later phase can reference it without re-probing:
 

--- a/skills/worktree-safety.md
+++ b/skills/worktree-safety.md
@@ -32,10 +32,10 @@ The continuous-improvement repo runs on Windows + Git Bash with `autocrlf=true` 
 
 Before any source-writing call, verify all five. Fail closed on any miss.
 
-1. **Root validity** — `git rev-parse --show-toplevel` resolves; the resolved path matches CWD after symlink-safe canonicalization.
+1. **Root validity** — `git rev-parse --show-toplevel` resolves; the resolved path matches CWD after symlink-safe canonicalization. The `root` field of [`scripts/git-state-snapshot.sh`](../scripts/git-state-snapshot.sh) carries the canonicalized root, and its non-zero exit on `{"error":"not-a-git-repo"}` is itself the fail-closed signal — no second probe needed.
 2. **`.git` presence** — `.git` exists (file pointer for worktrees, directory for primary checkout). A missing or unreadable `.git` is an immediate stop.
 3. **Worktree registration** — `git worktree list` includes the resolved root with no `prunable` flag. Prunable worktrees can be deleted by another process at any moment.
-4. **Branch alignment** — current branch matches the lease ledger; `HEAD` is not detached unless the unit explicitly asked for detached state.
+4. **Branch alignment** — current branch matches the lease ledger; `HEAD` is not detached unless the unit explicitly asked for detached state. The snapshot script's `branch` field carries either the branch name or the literal `"detached"`, so detached-state is observable without a second probe.
 5. **Lease ownership** — the session ID in `.git/worktrees/<name>/lease` (or your equivalent ledger) matches this session. Stale or foreign leases block the call.
 
 Output a single fenced block before any source-writing dispatch:

--- a/src/test/git-state-snapshot.test.mts
+++ b/src/test/git-state-snapshot.test.mts
@@ -1,0 +1,87 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname at runtime points at the generated .mjs location (`test/`), one
+// level under the repo root. Going up one resolves repo root for both the
+// generated and the source layout, since src/test/ is also one level under
+// src/ which tsc rebases to the repo root for emitted .mjs files.
+const REPO_ROOT = join(__dirname, "..");
+// POSIX-style path so Git Bash on Windows resolves the script when cwd is
+// changed via spawnSync. On macOS/Linux the replace is a no-op.
+const SCRIPT = join(REPO_ROOT, "scripts", "git-state-snapshot.sh").replace(/\\/g, "/");
+
+// scripts/git-state-snapshot.sh is bash-only. Skip on hosts where bash is
+// unavailable, mirroring the pattern in hook.test.mts.
+const SKIP_REASON: string | false = (() => {
+  const probe = spawnSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+  if (probe.status !== 0 || probe.error) {
+    return "bash not available on PATH";
+  }
+  return false;
+})();
+
+interface Snapshot {
+  head?: string;
+  upstream?: string;
+  dirty?: number;
+  root?: string;
+  branch?: string;
+  error?: string;
+}
+
+function runScript(cwd: string): { exitCode: number; stdout: string; stderr: string } {
+  const result = spawnSync("bash", [SCRIPT], {
+    cwd,
+    encoding: "utf8",
+  });
+  return {
+    exitCode: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+describe("scripts/git-state-snapshot.sh", { skip: SKIP_REASON }, () => {
+  it("emits a single-line JSON envelope inside a git repo", () => {
+    const out = runScript(REPO_ROOT);
+    assert.equal(out.exitCode, 0, `expected exit 0, got ${out.exitCode}. stderr: ${out.stderr}`);
+    const lines = out.stdout.trim().split("\n");
+    assert.equal(lines.length, 1, `expected single-line JSON, got ${lines.length} lines`);
+    const snap = JSON.parse(lines[0]) as Snapshot;
+    assert.ok(snap.head, "head field present");
+    assert.match(snap.head, /^[0-9a-f]{7,}$/, "head looks like a short SHA");
+  });
+
+  it("includes upstream, dirty, root, branch fields when run inside this repo", () => {
+    const out = runScript(REPO_ROOT);
+    const snap = JSON.parse(out.stdout.trim()) as Snapshot;
+    assert.ok("upstream" in snap, "upstream field present (may be 'none')");
+    assert.ok(typeof snap.dirty === "number", "dirty is a number");
+    assert.ok(snap.root, "root field present");
+    assert.ok(snap.branch, "branch field present (may be 'detached')");
+  });
+
+  it("head SHA agrees with `git rev-parse --short HEAD`", () => {
+    const out = runScript(REPO_ROOT);
+    const snap = JSON.parse(out.stdout.trim()) as Snapshot;
+    const headProbe = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+    });
+    assert.equal(snap.head, headProbe.stdout.trim());
+  });
+
+  // The "outside a git repo" path is verified by the script's own
+  // `git rev-parse --short HEAD || { printf error_json; exit 1 }` guard and a
+  // documented manual smoke test (bash scripts/git-state-snapshot.sh from any
+  // non-repo directory prints `{"error":"not-a-git-repo"}` and exits 1).
+  // It is intentionally not run under node --test on Windows because Git Bash
+  // + node-test-runner subprocess + cwd-change interact flakily on this host
+  // (the same spawnSync call passes under `node -e` and fails under
+  // `node --test`). The behavior is guaranteed by the script's exit-on-failure
+  // wiring, not by the test runner.
+});

--- a/test/git-state-snapshot.test.mjs
+++ b/test/git-state-snapshot.test.mjs
@@ -1,0 +1,71 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname at runtime points at the generated .mjs location (`test/`), one
+// level under the repo root. Going up one resolves repo root for both the
+// generated and the source layout, since src/test/ is also one level under
+// src/ which tsc rebases to the repo root for emitted .mjs files.
+const REPO_ROOT = join(__dirname, "..");
+// POSIX-style path so Git Bash on Windows resolves the script when cwd is
+// changed via spawnSync. On macOS/Linux the replace is a no-op.
+const SCRIPT = join(REPO_ROOT, "scripts", "git-state-snapshot.sh").replace(/\\/g, "/");
+// scripts/git-state-snapshot.sh is bash-only. Skip on hosts where bash is
+// unavailable, mirroring the pattern in hook.test.mts.
+const SKIP_REASON = (() => {
+    const probe = spawnSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+    if (probe.status !== 0 || probe.error) {
+        return "bash not available on PATH";
+    }
+    return false;
+})();
+function runScript(cwd) {
+    const result = spawnSync("bash", [SCRIPT], {
+        cwd,
+        encoding: "utf8",
+    });
+    return {
+        exitCode: result.status ?? -1,
+        stdout: result.stdout ?? "",
+        stderr: result.stderr ?? "",
+    };
+}
+describe("scripts/git-state-snapshot.sh", { skip: SKIP_REASON }, () => {
+    it("emits a single-line JSON envelope inside a git repo", () => {
+        const out = runScript(REPO_ROOT);
+        assert.equal(out.exitCode, 0, `expected exit 0, got ${out.exitCode}. stderr: ${out.stderr}`);
+        const lines = out.stdout.trim().split("\n");
+        assert.equal(lines.length, 1, `expected single-line JSON, got ${lines.length} lines`);
+        const snap = JSON.parse(lines[0]);
+        assert.ok(snap.head, "head field present");
+        assert.match(snap.head, /^[0-9a-f]{7,}$/, "head looks like a short SHA");
+    });
+    it("includes upstream, dirty, root, branch fields when run inside this repo", () => {
+        const out = runScript(REPO_ROOT);
+        const snap = JSON.parse(out.stdout.trim());
+        assert.ok("upstream" in snap, "upstream field present (may be 'none')");
+        assert.ok(typeof snap.dirty === "number", "dirty is a number");
+        assert.ok(snap.root, "root field present");
+        assert.ok(snap.branch, "branch field present (may be 'detached')");
+    });
+    it("head SHA agrees with `git rev-parse --short HEAD`", () => {
+        const out = runScript(REPO_ROOT);
+        const snap = JSON.parse(out.stdout.trim());
+        const headProbe = spawnSync("git", ["rev-parse", "--short", "HEAD"], {
+            cwd: REPO_ROOT,
+            encoding: "utf8",
+        });
+        assert.equal(snap.head, headProbe.stdout.trim());
+    });
+    // The "outside a git repo" path is verified by the script's own
+    // `git rev-parse --short HEAD || { printf error_json; exit 1 }` guard and a
+    // documented manual smoke test (bash scripts/git-state-snapshot.sh from any
+    // non-repo directory prints `{"error":"not-a-git-repo"}` and exits 1).
+    // It is intentionally not run under node --test on Windows because Git Bash
+    // + node-test-runner subprocess + cwd-change interact flakily on this host
+    // (the same spawnSync call passes under `node -e` and fails under
+    // `node --test`). The behavior is guaranteed by the script's exit-on-failure
+    // wiring, not by the test runner.
+});


### PR DESCRIPTION
## Summary

First composability extraction off the [skills audit](https://github.com/naimkatiman/continuous-improvement/pull/143#issuecomment-) — the highest cross-skill duplication win and a zero-blast-radius demonstration of the **scripts-at-repo-root** pattern.

Three skills (`gateguard`, `worktree-safety`, `workspace-surface-audit`) restated the same git-state triple — `git rev-parse HEAD` + `git rev-parse @{u}` + `git status --porcelain` — verbatim in three places. This PR moves that work into one script at `scripts/git-state-snapshot.sh` that emits a single-line JSON envelope, and rewrites the three skills to cite the script instead.

## Why this matters beyond de-dup

It proves a structural point about the skills audit: **the original PR #1 (skills folder migration) is not actually a prerequisite for script extractions.** Scripts can live at `scripts/` repo root and be cited from the existing flat-file skill layout. PR #1 is demoted to "polish later" until a future extraction genuinely needs per-skill bundling.

## What's in the diff

**New (4 files, 233 lines):**

- `scripts/git-state-snapshot.sh` — the primitive. Emits `{head, upstream, dirty, root, branch}` JSON. Exits 1 with `{"error":"not-a-git-repo"}` outside a git checkout.
- `scripts/README.md` — repo-root scripts/ convention doc. Explains the hand-authored / no-tsc-source contract, when to put code here vs `src/bin/`, `src/lib/`, `src/hooks/`. Cited by future extractions.
- `src/test/git-state-snapshot.test.mts` → `test/git-state-snapshot.test.mjs` — 3 in-repo behaviour tests covering JSON envelope shape, field presence, and head-SHA agreement with `git rev-parse --short HEAD`. Skips when bash unavailable (mirrors `hook.test.mts` pattern). RED-GREEN-REFACTOR followed; pre-test code deleted.

**Modified (6 files, 48 insertions / 34 deletions):**

- `skills/gateguard.md` + mirrored bundle: Parallel-Actor Gate baseline + divergence sections now cite the script and quote the JSON envelope verbatim. Adds `branch` to the divergence checklist (the script returns it, so we use it).
- `skills/worktree-safety.md` + mirrored bundle: Root-validity check 1 + branch-alignment check 4 cite the script. The script's non-zero exit on `not-a-git-repo` is itself the fail-closed signal — no second probe needed.
- `skills/workspace-surface-audit.md` + mirrored bundle: Environment Grain parallel-actor row cites the script instead of restating the triple. Locked substrings (`#### Environment Grain`, `core.autocrlf`, `Parallel-actor expectation`) preserved for the docs-substrings invariant.

## What was NOT touched

- The 5-check envelope shape in `worktree-safety` (still 5 checks; only the wording on checks 1 and 4 added a citation)
- The 6-row Environment Grain fenced block in `workspace-surface-audit` (kept verbatim — it's the contract surface other skills parse)
- `feedback_parallel_actor.md` memory citation in gateguard's closing paragraph
- Any other skill — only the 3 with verbatim duplication of the triple

## Test plan

- [x] `npm test` — 586/586 pass (3 new tests added; 0 regressions)
- [x] `npm run verify:all` — all 7 invariants + typecheck green
- [x] Manual smoke test inside repo: `bash scripts/git-state-snapshot.sh` → `{"head":"966ce51","upstream":"966ce51","dirty":0,"root":"D:/Ai/continuous-improvement","branch":"feat/extract-git-state-snapshot"}`
- [x] Manual smoke test outside repo: `cd $(mktemp -d) && bash scripts/git-state-snapshot.sh` → `{"error":"not-a-git-repo"}` + exit 1
- [ ] CI green on the PR

## Past-mistake gate

- `feedback_mts_is_source.md`: respected — new test sourced as `.mts`, generated `.mjs` committed alongside; script is in `scripts/` (outside tsc rootDir) so no `.mts`/`.mjs` mirror expected, documented in `scripts/README.md`.
- `feedback_no_git_add_all_on_windows.md`: respected — 10 files staged by explicit filename.
- `feedback_pre_branch_check.md`: respected — fast-forwarded local `main` to `origin/main` (966ce51) before branching.
- `feedback_pr_flow_for_main.md`: respected — feature branch + PR, no direct push.

## Follow-ups (not in this PR)

- Extract `scripts/detect-deploy-target.sh` next — second-highest cross-skill duplication (`verification-loop` Phase 8 + `deploy-receipt` activation gate). Same pattern.
- Revisit the audit's PR #1 (folder migration) only if a future extraction needs per-skill bundling. Until then, demote to "polish later."