### PR TITLE
feat(scripts): deploy-seam primitives — detect-deploy-target.sh + get-deployed-sha.sh (audit composability #2)

### DIFF
--- a/plugins/continuous-improvement/skills/deploy-receipt/SKILL.md
+++ b/plugins/continuous-improvement/skills/deploy-receipt/SKILL.md
@@ -21,14 +21,7 @@ This skill defines the receipt that closes that gap, without modifying the vendo
 Activate when ALL of the following are true:
 
 1. A merge into the deploy branch (typically `main` or `master`) has just landed
-2. The repo declares an auto-deploy target — detect via any of:
-   - `railway.toml`, `railway.json`, or `RAILWAY_*` env vars in `.env.example`
-   - `wrangler.toml` / `wrangler.jsonc` (Cloudflare Workers)
-   - `vercel.json` or `.vercel/` directory
-   - `netlify.toml`
-   - `fly.toml`
-   - `app.yaml` (App Engine), `apprunner.yaml` (App Runner)
-   - GitHub Actions workflow with `deploy:` job triggered on push to the deploy branch
+2. [`scripts/detect-deploy-target.sh`](../scripts/detect-deploy-target.sh) returns a value other than `none` at the repo root. The script encodes the full file-marker table — `railway.toml` / `railway.json` → `railway`, `wrangler.toml` / `wrangler.jsonc` → `cloudflare`, `vercel.json` / `.vercel/` → `vercel`, `netlify.toml` → `netlify`, `fly.toml` → `fly`, `app.yaml` → `appengine`, `apprunner.yaml` → `apprunner`, `.github/workflows/*.yml` with a `deploy:` job → `gha-deploy`. First match wins, in that order. The script is the source of truth; the file list above is documentation
 3. `finishing-a-development-branch` has reported "merged" — not "PR opened", not "review pending"
 
 Do NOT activate when:
@@ -52,17 +45,19 @@ The skill is provider-aware but never hardcodes a specific API key or token shap
 
 ### Route A — Provider CLI (preferred when authenticated)
 
-The CLI is the highest-fidelity source.
+The CLI is the highest-fidelity source. Run [`scripts/get-deployed-sha.sh <provider>`](../scripts/get-deployed-sha.sh) — the script owns the per-provider pipeline (CLI + jq filter) and prints just the SHA on stdout. Inspect the pipeline shape without executing via `bash scripts/get-deployed-sha.sh --show-command <provider>`.
 
-| Provider | Command shape | Receipt extraction |
-|---|---|---|
-| Railway | `railway status --json` | `.deployments[0].meta.commitHash` |
-| Cloudflare Workers | `wrangler deployments list --json` | `[0].metadata.deployment_trigger.metadata.commit_hash` |
-| Vercel | `vercel inspect <url> --json` | `.gitSource.sha` |
-| Netlify | `netlify api listSiteDeploys --data='{"site_id":"<id>"}'` | `[0].commit_ref` |
-| Fly.io | `fly releases --json` | `[0].commit_sha` |
+Provider-to-pipeline map (cited from the script, not redefined here):
 
-If the CLI is not installed or not authenticated in this session, fall through to Route B. Do NOT prompt the operator to install the CLI mid-session — that is a drive-by.
+| Provider value | CLI |
+|---|---|
+| `railway` | `railway` |
+| `cloudflare` | `wrangler` |
+| `vercel` | `vercel` |
+| `netlify` | `netlify` |
+| `fly` | `fly` |
+
+Exit codes from the script: `0` on success (SHA printed), `2` on missing/unknown provider (usage error), `3` when the required CLI is not installed locally — that is the fall-through signal to Route B, not a hard failure. Do NOT prompt the operator to install the CLI mid-session — that is a drive-by.
 
 ### Route B — GitHub Deployments API (works for any provider that posts back)
 

--- a/plugins/continuous-improvement/skills/verification-loop/SKILL.md
+++ b/plugins/continuous-improvement/skills/verification-loop/SKILL.md
@@ -143,7 +143,11 @@ If either is `No`, the verification report goes back to the operator with the ex
 
 ### Phase 8: Deploy Receipt (auto-deploy projects only)
 
-For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or whose sniff path detects an auto-deploy target (Railway, Cloudflare Workers, Vercel, Netlify, Fly.io) — the verify is not complete until the deployed SHA matches the merge SHA and a healthcheck returns 200. Hand off to the `deploy-receipt` skill (Law 4 deploy-seam companion landed in PR #83) and treat its `Receipt status: COMPLETE` as the gate.
+For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or whose sniff path detects an auto-deploy target — the verify is not complete until the deployed SHA matches the merge SHA and a healthcheck returns 200. Hand off to the `deploy-receipt` skill (Law 4 deploy-seam companion landed in PR #83) and treat its `Receipt status: COMPLETE` as the gate.
+
+**Detection.** Run [`scripts/detect-deploy-target.sh`](../scripts/detect-deploy-target.sh) at the repo root. Output is one of `railway` / `cloudflare` / `vercel` / `netlify` / `fly` / `appengine` / `apprunner` / `gha-deploy` / `none`. Anything except `none` triggers handoff to `deploy-receipt`; `none` means Phase 8 is skipped (no deploy seam exists).
+
+**SHA extraction.** For the detected provider, [`scripts/get-deployed-sha.sh <provider>`](../scripts/get-deployed-sha.sh) returns the currently-deployed SHA via the provider CLI; `--show-command <provider>` prints the pipeline shape without executing (useful for dry-runs and citation). `deploy-receipt` owns the receipt's other components (health endpoint, build artifact, on-incomplete modes) and Route B/C fallbacks.
 
 INCOMPLETE receipts move to "Immediate operator action" in the close, never to "ready". Library-only / package-published repos skip this phase entirely (no deploy seam exists).
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -14,6 +14,8 @@ This directory holds small, hand-authored scripts that skills (and hooks) cite i
 | Script | Purpose | Cited by |
 |---|---|---|
 | `git-state-snapshot.sh` | JSON envelope `{head, upstream, dirty, root, branch}` for the current git working tree | `skills/gateguard.md` (Parallel-Actor Gate), `skills/worktree-safety.md` (Root + branch), `skills/workspace-surface-audit.md` (Environment Grain — parallel-actor row) |
+| `detect-deploy-target.sh` | Detect the auto-deploy provider for the repo at the current working directory (or first arg). Prints one of `railway`/`cloudflare`/`vercel`/`netlify`/`fly`/`appengine`/`apprunner`/`gha-deploy`/`none`. Always exits 0. | `skills/verification-loop.md` (Phase 8 deploy-receipt handoff), `skills/deploy-receipt.md` (When to Activate gate) |
+| `get-deployed-sha.sh` | Per-provider deployed-SHA extraction. Default mode runs the CLI; `--show-command <provider>` prints the pipeline shape without executing (useful for citation, dry-run, tests). | `skills/verification-loop.md` (Phase 8), `skills/deploy-receipt.md` (Route A — provider CLI extraction) |
 
 When a new script lands here, add a row to this table in the same PR and cite the script from at least one skill — otherwise the script is dead code on arrival.
 

--- a/scripts/detect-deploy-target.sh
+++ b/scripts/detect-deploy-target.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# scripts/detect-deploy-target.sh
+#
+# Detect the auto-deploy provider for the repo rooted at the current working
+# directory (or the first argument, if supplied). Composability primitive used
+# by skills and hooks that need to know "does this repo auto-deploy, and if so
+# from where?" without each restating the file-marker table.
+#
+# Output: one of
+#   railway | cloudflare | vercel | netlify | fly | appengine | apprunner |
+#   gha-deploy | none
+#
+# Resolution priority (first match wins):
+#   1. railway.toml | railway.json                              → railway
+#   2. wrangler.toml | wrangler.jsonc                           → cloudflare
+#   3. vercel.json | .vercel/                                   → vercel
+#   4. netlify.toml                                             → netlify
+#   5. fly.toml                                                 → fly
+#   6. app.yaml                                                 → appengine
+#   7. apprunner.yaml                                           → apprunner
+#   8. .github/workflows/*.{yml,yaml} containing "deploy:" job  → gha-deploy
+#   9. nothing matched                                          → none
+#
+# Always exits 0. `none` is a valid result, not an error condition.
+#
+# Cited by:
+#   - skills/verification-loop.md Phase 8 (deploy-receipt handoff trigger)
+#   - skills/deploy-receipt.md "When to Activate" gate
+
+set -u
+
+ROOT="${1:-$PWD}"
+
+emit() {
+  printf '%s\n' "$1"
+  exit 0
+}
+
+# Order is the contract — earlier rows shadow later ones when multiple
+# markers exist in the same repo.
+[ -f "$ROOT/railway.toml" ]    && emit railway
+[ -f "$ROOT/railway.json" ]    && emit railway
+[ -f "$ROOT/wrangler.toml" ]   && emit cloudflare
+[ -f "$ROOT/wrangler.jsonc" ]  && emit cloudflare
+[ -f "$ROOT/vercel.json" ]     && emit vercel
+[ -d "$ROOT/.vercel" ]         && emit vercel
+[ -f "$ROOT/netlify.toml" ]    && emit netlify
+[ -f "$ROOT/fly.toml" ]        && emit fly
+[ -f "$ROOT/app.yaml" ]        && emit appengine
+[ -f "$ROOT/apprunner.yaml" ]  && emit apprunner
+
+# GitHub Actions deploy workflow: scan .github/workflows/*.{yml,yaml} for a
+# job whose key is literally `deploy:`. Cheap and conservative — false
+# positives (a non-deploy job named "deploy") are unlikely; false negatives
+# (a deploy job named something else) require the repo to declare the
+# provider via one of the file markers above instead.
+if [ -d "$ROOT/.github/workflows" ]; then
+  if grep -lE '^[[:space:]]*deploy:[[:space:]]*$' \
+        "$ROOT/.github/workflows/"*.yml \
+        "$ROOT/.github/workflows/"*.yaml 2>/dev/null \
+      | head -n 1 | grep -q .; then
+    emit gha-deploy
+  fi
+fi
+
+emit none

--- a/scripts/get-deployed-sha.sh
+++ b/scripts/get-deployed-sha.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# scripts/get-deployed-sha.sh
+#
+# Print the currently-deployed commit SHA for an auto-deploy provider, or
+# print the CLI command shape (with `--show-command`) without executing it.
+# Composability primitive that owns the per-provider CLI knowledge so skills
+# can cite one path instead of restating the 5-provider extraction table.
+#
+# Usage:
+#   bash scripts/get-deployed-sha.sh <provider>
+#   bash scripts/get-deployed-sha.sh --show-command <provider>
+#
+# Providers: railway | cloudflare | vercel | netlify | fly
+#
+# Default mode: runs the provider CLI, pipes through jq, prints the SHA on
+# stdout. Requires the CLI to be installed and authenticated; exits 3 with a
+# clear error if the CLI is missing.
+#
+# --show-command mode: prints the command pipeline that would run, without
+# executing it. Useful for skill citations, dry-runs, and tests that should
+# not require live CLI auth.
+#
+# Exit codes:
+#   0 — SHA printed (default mode) or command printed (--show-command mode)
+#   2 — missing or unknown provider (usage error)
+#   3 — required CLI not installed (default mode only)
+#   non-zero — CLI failure (passed through)
+#
+# Cited by:
+#   - skills/verification-loop.md Phase 8 (deploy-receipt handoff trigger)
+#   - skills/deploy-receipt.md Route A (provider CLI extraction)
+
+set -u
+
+SHOW_COMMAND=false
+PROVIDER=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --show-command)
+      SHOW_COMMAND=true
+      shift
+      ;;
+    -h|--help)
+      sed -n '2,/^$/p' "$0" >&2
+      exit 0
+      ;;
+    *)
+      if [ -z "$PROVIDER" ]; then
+        PROVIDER="$1"
+      else
+        printf 'usage: get-deployed-sha.sh [--show-command] <provider>\n' >&2
+        exit 2
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [ -z "$PROVIDER" ]; then
+  printf 'usage: get-deployed-sha.sh [--show-command] <provider>\n' >&2
+  exit 2
+fi
+
+# Single source of truth for the per-provider command pipeline. Each value is
+# the literal pipeline that would run; the jq filter extracts the SHA.
+case "$PROVIDER" in
+  railway)
+    CMD='railway status --json | jq -r .deployments[0].meta.commitHash'
+    CLI=railway
+    ;;
+  cloudflare)
+    CMD='wrangler deployments list --json | jq -r .[0].metadata.deployment_trigger.metadata.commit_hash'
+    CLI=wrangler
+    ;;
+  vercel)
+    CMD='vercel inspect "$(vercel ls --json | jq -r .[0].url)" --json | jq -r .gitSource.sha'
+    CLI=vercel
+    ;;
+  netlify)
+    CMD='netlify api listSiteDeploys --data="{\"site_id\":\"$NETLIFY_SITE_ID\"}" | jq -r .[0].commit_ref'
+    CLI=netlify
+    ;;
+  fly)
+    CMD='fly releases --json | jq -r .[0].commit_sha'
+    CLI=fly
+    ;;
+  *)
+    printf 'unknown or unsupported provider: %s\n' "$PROVIDER" >&2
+    printf 'supported: railway | cloudflare | vercel | netlify | fly\n' >&2
+    exit 2
+    ;;
+esac
+
+if [ "$SHOW_COMMAND" = "true" ]; then
+  printf '%s\n' "$CMD"
+  exit 0
+fi
+
+if ! command -v "$CLI" >/dev/null 2>&1; then
+  printf 'required CLI "%s" not installed for provider "%s"\n' "$CLI" "$PROVIDER" >&2
+  exit 3
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  printf 'required CLI "jq" not installed\n' >&2
+  exit 3
+fi
+
+# Execute the pipeline. eval is intentional — the per-provider CMD contains
+# pipes and command substitution that need shell interpretation. CMDs are
+# sourced from the literal table above, not user input.
+eval "$CMD"

--- a/skills/deploy-receipt.md
+++ b/skills/deploy-receipt.md
@@ -21,14 +21,7 @@ This skill defines the receipt that closes that gap, without modifying the vendo
 Activate when ALL of the following are true:
 
 1. A merge into the deploy branch (typically `main` or `master`) has just landed
-2. The repo declares an auto-deploy target — detect via any of:
-   - `railway.toml`, `railway.json`, or `RAILWAY_*` env vars in `.env.example`
-   - `wrangler.toml` / `wrangler.jsonc` (Cloudflare Workers)
-   - `vercel.json` or `.vercel/` directory
-   - `netlify.toml`
-   - `fly.toml`
-   - `app.yaml` (App Engine), `apprunner.yaml` (App Runner)
-   - GitHub Actions workflow with `deploy:` job triggered on push to the deploy branch
+2. [`scripts/detect-deploy-target.sh`](../scripts/detect-deploy-target.sh) returns a value other than `none` at the repo root. The script encodes the full file-marker table — `railway.toml` / `railway.json` → `railway`, `wrangler.toml` / `wrangler.jsonc` → `cloudflare`, `vercel.json` / `.vercel/` → `vercel`, `netlify.toml` → `netlify`, `fly.toml` → `fly`, `app.yaml` → `appengine`, `apprunner.yaml` → `apprunner`, `.github/workflows/*.yml` with a `deploy:` job → `gha-deploy`. First match wins, in that order. The script is the source of truth; the file list above is documentation
 3. `finishing-a-development-branch` has reported "merged" — not "PR opened", not "review pending"
 
 Do NOT activate when:
@@ -52,17 +45,19 @@ The skill is provider-aware but never hardcodes a specific API key or token shap
 
 ### Route A — Provider CLI (preferred when authenticated)
 
-The CLI is the highest-fidelity source.
+The CLI is the highest-fidelity source. Run [`scripts/get-deployed-sha.sh <provider>`](../scripts/get-deployed-sha.sh) — the script owns the per-provider pipeline (CLI + jq filter) and prints just the SHA on stdout. Inspect the pipeline shape without executing via `bash scripts/get-deployed-sha.sh --show-command <provider>`.
 
-| Provider | Command shape | Receipt extraction |
-|---|---|---|
-| Railway | `railway status --json` | `.deployments[0].meta.commitHash` |
-| Cloudflare Workers | `wrangler deployments list --json` | `[0].metadata.deployment_trigger.metadata.commit_hash` |
-| Vercel | `vercel inspect <url> --json` | `.gitSource.sha` |
-| Netlify | `netlify api listSiteDeploys --data='{"site_id":"<id>"}'` | `[0].commit_ref` |
-| Fly.io | `fly releases --json` | `[0].commit_sha` |
+Provider-to-pipeline map (cited from the script, not redefined here):
 
-If the CLI is not installed or not authenticated in this session, fall through to Route B. Do NOT prompt the operator to install the CLI mid-session — that is a drive-by.
+| Provider value | CLI |
+|---|---|
+| `railway` | `railway` |
+| `cloudflare` | `wrangler` |
+| `vercel` | `vercel` |
+| `netlify` | `netlify` |
+| `fly` | `fly` |
+
+Exit codes from the script: `0` on success (SHA printed), `2` on missing/unknown provider (usage error), `3` when the required CLI is not installed locally — that is the fall-through signal to Route B, not a hard failure. Do NOT prompt the operator to install the CLI mid-session — that is a drive-by.
 
 ### Route B — GitHub Deployments API (works for any provider that posts back)
 

--- a/skills/verification-loop.md
+++ b/skills/verification-loop.md
@@ -143,7 +143,11 @@ If either is `No`, the verification report goes back to the operator with the ex
 
 ### Phase 8: Deploy Receipt (auto-deploy projects only)
 
-For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or whose sniff path detects an auto-deploy target (Railway, Cloudflare Workers, Vercel, Netlify, Fly.io) — the verify is not complete until the deployed SHA matches the merge SHA and a healthcheck returns 200. Hand off to the `deploy-receipt` skill (Law 4 deploy-seam companion landed in PR #83) and treat its `Receipt status: COMPLETE` as the gate.
+For repos whose `verify-ladder.json` declares a `deploy_receipt` field — or whose sniff path detects an auto-deploy target — the verify is not complete until the deployed SHA matches the merge SHA and a healthcheck returns 200. Hand off to the `deploy-receipt` skill (Law 4 deploy-seam companion landed in PR #83) and treat its `Receipt status: COMPLETE` as the gate.
+
+**Detection.** Run [`scripts/detect-deploy-target.sh`](../scripts/detect-deploy-target.sh) at the repo root. Output is one of `railway` / `cloudflare` / `vercel` / `netlify` / `fly` / `appengine` / `apprunner` / `gha-deploy` / `none`. Anything except `none` triggers handoff to `deploy-receipt`; `none` means Phase 8 is skipped (no deploy seam exists).
+
+**SHA extraction.** For the detected provider, [`scripts/get-deployed-sha.sh <provider>`](../scripts/get-deployed-sha.sh) returns the currently-deployed SHA via the provider CLI; `--show-command <provider>` prints the pipeline shape without executing (useful for dry-runs and citation). `deploy-receipt` owns the receipt's other components (health endpoint, build artifact, on-incomplete modes) and Route B/C fallbacks.
 
 INCOMPLETE receipts move to "Immediate operator action" in the close, never to "ready". Library-only / package-published repos skip this phase entirely (no deploy seam exists).
 

--- a/src/test/detect-deploy-target.test.mts
+++ b/src/test/detect-deploy-target.test.mts
@@ -1,0 +1,140 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname at runtime points at the generated .mjs location (`test/`), one
+// level under the repo root. Going up one resolves repo root for both the
+// generated and the source layout.
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(
+  existsSync(join(REPO_ROOT, "package.json")),
+  `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`,
+);
+const SCRIPT = join(REPO_ROOT, "scripts", "detect-deploy-target.sh").replace(/\\/g, "/");
+
+const SKIP_REASON: string | false = (() => {
+  const probe = spawnSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+  if (probe.status !== 0 || probe.error) return "bash not available on PATH";
+  return false;
+})();
+
+function runScript(cwd: string): { exitCode: number; stdout: string; stderr: string } {
+  const result = spawnSync("bash", [SCRIPT], { cwd, encoding: "utf8" });
+  return {
+    exitCode: result.status ?? -1,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
+function makeTempRepo(): string {
+  return mkdtempSync(join(tmpdir(), "detect-deploy-target-test-"));
+}
+
+describe("scripts/detect-deploy-target.sh", { skip: SKIP_REASON }, () => {
+  it("returns 'none' in an empty directory", () => {
+    const tmp = makeTempRepo();
+    try {
+      const out = runScript(tmp);
+      assert.equal(out.exitCode, 0);
+      assert.equal(out.stdout, "none");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects railway via railway.toml", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "railway.toml"), "");
+      assert.equal(runScript(tmp).stdout, "railway");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects cloudflare via wrangler.toml", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "wrangler.toml"), "");
+      assert.equal(runScript(tmp).stdout, "cloudflare");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects cloudflare via wrangler.jsonc", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "wrangler.jsonc"), "{}");
+      assert.equal(runScript(tmp).stdout, "cloudflare");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects vercel via vercel.json", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "vercel.json"), "{}");
+      assert.equal(runScript(tmp).stdout, "vercel");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects netlify via netlify.toml", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "netlify.toml"), "");
+      assert.equal(runScript(tmp).stdout, "netlify");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects fly via fly.toml", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "fly.toml"), "");
+      assert.equal(runScript(tmp).stdout, "fly");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("prefers railway over later providers when multiple markers exist", () => {
+    const tmp = makeTempRepo();
+    try {
+      writeFileSync(join(tmp, "railway.toml"), "");
+      writeFileSync(join(tmp, "vercel.json"), "{}");
+      writeFileSync(join(tmp, "fly.toml"), "");
+      assert.equal(
+        runScript(tmp).stdout,
+        "railway",
+        "first-match-wins order: railway > cloudflare > vercel > netlify > fly",
+      );
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
+  it("detects gha-deploy when a .github workflow contains a deploy: job", () => {
+    const tmp = makeTempRepo();
+    try {
+      mkdirSync(join(tmp, ".github", "workflows"), { recursive: true });
+      writeFileSync(
+        join(tmp, ".github", "workflows", "release.yml"),
+        "name: release\non:\n  push:\n    branches: [main]\njobs:\n  deploy:\n    runs-on: ubuntu-latest\n    steps: []\n",
+      );
+      assert.equal(runScript(tmp).stdout, "gha-deploy");
+    } finally {
+      rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test/get-deployed-sha.test.mts
+++ b/src/test/get-deployed-sha.test.mts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(
+  existsSync(join(REPO_ROOT, "package.json")),
+  `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`,
+);
+const SCRIPT = join(REPO_ROOT, "scripts", "get-deployed-sha.sh").replace(/\\/g, "/");
+
+const SKIP_REASON: string | false = (() => {
+  const probe = spawnSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+  if (probe.status !== 0 || probe.error) return "bash not available on PATH";
+  return false;
+})();
+
+function runScript(args: string[]): { exitCode: number; stdout: string; stderr: string } {
+  const result = spawnSync("bash", [SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    encoding: "utf8",
+  });
+  return {
+    exitCode: result.status ?? -1,
+    stdout: (result.stdout ?? "").trim(),
+    stderr: (result.stderr ?? "").trim(),
+  };
+}
+
+describe("scripts/get-deployed-sha.sh", { skip: SKIP_REASON }, () => {
+  it("exits non-zero with a clear error when no provider is given", () => {
+    const out = runScript([]);
+    assert.notEqual(out.exitCode, 0);
+    assert.match(out.stderr, /usage|provider/i);
+  });
+
+  it("exits non-zero on an unknown provider", () => {
+    const out = runScript(["--show-command", "made-up-provider"]);
+    assert.notEqual(out.exitCode, 0);
+    assert.match(out.stderr, /unknown|unsupported/i);
+  });
+
+  it("--show-command railway prints the railway CLI shape", () => {
+    const out = runScript(["--show-command", "railway"]);
+    assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+    assert.match(out.stdout, /railway status --json/);
+    assert.match(out.stdout, /commitHash/);
+  });
+
+  it("--show-command cloudflare prints the wrangler CLI shape", () => {
+    const out = runScript(["--show-command", "cloudflare"]);
+    assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+    assert.match(out.stdout, /wrangler deployments list --json/);
+    assert.match(out.stdout, /commit_hash/);
+  });
+
+  it("--show-command vercel prints the vercel CLI shape", () => {
+    const out = runScript(["--show-command", "vercel"]);
+    assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+    assert.match(out.stdout, /vercel inspect/);
+    assert.match(out.stdout, /gitSource\.sha/);
+  });
+
+  it("--show-command netlify prints the netlify CLI shape", () => {
+    const out = runScript(["--show-command", "netlify"]);
+    assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+    assert.match(out.stdout, /netlify api listSiteDeploys/);
+    assert.match(out.stdout, /commit_ref/);
+  });
+
+  it("--show-command fly prints the fly CLI shape", () => {
+    const out = runScript(["--show-command", "fly"]);
+    assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+    assert.match(out.stdout, /fly releases --json/);
+    assert.match(out.stdout, /commit_sha/);
+  });
+});

--- a/test/detect-deploy-target.test.mjs
+++ b/test/detect-deploy-target.test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+// __dirname at runtime points at the generated .mjs location (`test/`), one
+// level under the repo root. Going up one resolves repo root for both the
+// generated and the source layout.
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(existsSync(join(REPO_ROOT, "package.json")), `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`);
+const SCRIPT = join(REPO_ROOT, "scripts", "detect-deploy-target.sh").replace(/\\/g, "/");
+const SKIP_REASON = (() => {
+    const probe = spawnSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+    if (probe.status !== 0 || probe.error)
+        return "bash not available on PATH";
+    return false;
+})();
+function runScript(cwd) {
+    const result = spawnSync("bash", [SCRIPT], { cwd, encoding: "utf8" });
+    return {
+        exitCode: result.status ?? -1,
+        stdout: (result.stdout ?? "").trim(),
+        stderr: (result.stderr ?? "").trim(),
+    };
+}
+function makeTempRepo() {
+    return mkdtempSync(join(tmpdir(), "detect-deploy-target-test-"));
+}
+describe("scripts/detect-deploy-target.sh", { skip: SKIP_REASON }, () => {
+    it("returns 'none' in an empty directory", () => {
+        const tmp = makeTempRepo();
+        try {
+            const out = runScript(tmp);
+            assert.equal(out.exitCode, 0);
+            assert.equal(out.stdout, "none");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects railway via railway.toml", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "railway.toml"), "");
+            assert.equal(runScript(tmp).stdout, "railway");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects cloudflare via wrangler.toml", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "wrangler.toml"), "");
+            assert.equal(runScript(tmp).stdout, "cloudflare");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects cloudflare via wrangler.jsonc", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "wrangler.jsonc"), "{}");
+            assert.equal(runScript(tmp).stdout, "cloudflare");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects vercel via vercel.json", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "vercel.json"), "{}");
+            assert.equal(runScript(tmp).stdout, "vercel");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects netlify via netlify.toml", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "netlify.toml"), "");
+            assert.equal(runScript(tmp).stdout, "netlify");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects fly via fly.toml", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "fly.toml"), "");
+            assert.equal(runScript(tmp).stdout, "fly");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("prefers railway over later providers when multiple markers exist", () => {
+        const tmp = makeTempRepo();
+        try {
+            writeFileSync(join(tmp, "railway.toml"), "");
+            writeFileSync(join(tmp, "vercel.json"), "{}");
+            writeFileSync(join(tmp, "fly.toml"), "");
+            assert.equal(runScript(tmp).stdout, "railway", "first-match-wins order: railway > cloudflare > vercel > netlify > fly");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+    it("detects gha-deploy when a .github workflow contains a deploy: job", () => {
+        const tmp = makeTempRepo();
+        try {
+            mkdirSync(join(tmp, ".github", "workflows"), { recursive: true });
+            writeFileSync(join(tmp, ".github", "workflows", "release.yml"), "name: release\non:\n  push:\n    branches: [main]\njobs:\n  deploy:\n    runs-on: ubuntu-latest\n    steps: []\n");
+            assert.equal(runScript(tmp).stdout, "gha-deploy");
+        }
+        finally {
+            rmSync(tmp, { recursive: true, force: true });
+        }
+    });
+});

--- a/test/get-deployed-sha.test.mjs
+++ b/test/get-deployed-sha.test.mjs
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(existsSync(join(REPO_ROOT, "package.json")), `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`);
+const SCRIPT = join(REPO_ROOT, "scripts", "get-deployed-sha.sh").replace(/\\/g, "/");
+const SKIP_REASON = (() => {
+    const probe = spawnSync("bash", ["-c", "exit 0"], { stdio: "ignore" });
+    if (probe.status !== 0 || probe.error)
+        return "bash not available on PATH";
+    return false;
+})();
+function runScript(args) {
+    const result = spawnSync("bash", [SCRIPT, ...args], {
+        cwd: REPO_ROOT,
+        encoding: "utf8",
+    });
+    return {
+        exitCode: result.status ?? -1,
+        stdout: (result.stdout ?? "").trim(),
+        stderr: (result.stderr ?? "").trim(),
+    };
+}
+describe("scripts/get-deployed-sha.sh", { skip: SKIP_REASON }, () => {
+    it("exits non-zero with a clear error when no provider is given", () => {
+        const out = runScript([]);
+        assert.notEqual(out.exitCode, 0);
+        assert.match(out.stderr, /usage|provider/i);
+    });
+    it("exits non-zero on an unknown provider", () => {
+        const out = runScript(["--show-command", "made-up-provider"]);
+        assert.notEqual(out.exitCode, 0);
+        assert.match(out.stderr, /unknown|unsupported/i);
+    });
+    it("--show-command railway prints the railway CLI shape", () => {
+        const out = runScript(["--show-command", "railway"]);
+        assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+        assert.match(out.stdout, /railway status --json/);
+        assert.match(out.stdout, /commitHash/);
+    });
+    it("--show-command cloudflare prints the wrangler CLI shape", () => {
+        const out = runScript(["--show-command", "cloudflare"]);
+        assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+        assert.match(out.stdout, /wrangler deployments list --json/);
+        assert.match(out.stdout, /commit_hash/);
+    });
+    it("--show-command vercel prints the vercel CLI shape", () => {
+        const out = runScript(["--show-command", "vercel"]);
+        assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+        assert.match(out.stdout, /vercel inspect/);
+        assert.match(out.stdout, /gitSource\.sha/);
+    });
+    it("--show-command netlify prints the netlify CLI shape", () => {
+        const out = runScript(["--show-command", "netlify"]);
+        assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+        assert.match(out.stdout, /netlify api listSiteDeploys/);
+        assert.match(out.stdout, /commit_ref/);
+    });
+    it("--show-command fly prints the fly CLI shape", () => {
+        const out = runScript(["--show-command", "fly"]);
+        assert.equal(out.exitCode, 0, `stderr: ${out.stderr}`);
+        assert.match(out.stdout, /fly releases --json/);
+        assert.match(out.stdout, /commit_sha/);
+    });
+});


### PR DESCRIPTION
## Summary

Second composability extraction off the skills audit. `verification-loop` Phase 8 and `deploy-receipt` "When to Activate" both restated the same file-marker table for auto-deploy detection; `deploy-receipt` Route A restated the 5-provider deployed-SHA extraction pipeline. This PR moves both into scripts at repo root and rewrites the two skills to cite them.

Pairs with PR #144 (`git-state-snapshot.sh`). Three extractions now live in `scripts/`; the audit's original PR #1 (folder migration) stays demoted to "polish later" — no extraction has needed per-skill bundling.

## New scripts

### `scripts/detect-deploy-target.sh`

Prints one of `railway`, `cloudflare`, `vercel`, `netlify`, `fly`, `appengine`, `apprunner`, `gha-deploy`, `none` based on file markers at the repo root. First match wins. Always exits 0 — `none` is a valid result, not an error.

```
$ bash scripts/detect-deploy-target.sh
none
$ touch /tmp/r/railway.toml && bash scripts/detect-deploy-target.sh /tmp/r
railway
```

### `scripts/get-deployed-sha.sh`

Per-provider deployed-SHA extraction. Owns the CLI + jq pipeline knowledge so skills cite one path instead of restating the 5-row table.

```
$ bash scripts/get-deployed-sha.sh --show-command railway
railway status --json | jq -r .deployments[0].meta.commitHash

$ bash scripts/get-deployed-sha.sh railway     # default: actually runs the pipeline
abc1234
```

Exit codes: `0` (SHA / command printed), `2` (missing or unknown provider), `3` (required CLI not installed locally — fall-through signal to Route B).

## Skills updated

- **`skills/verification-loop.md` Phase 8** — gains "Detection" + "SHA extraction" subsections that cite the two scripts. The provider list moves into the script as the source of truth.
- **`skills/deploy-receipt.md` "When to Activate" gate** — cites `detect-deploy-target.sh`. The file-marker bullet list is demoted to documentation mirroring the script.
- **`skills/deploy-receipt.md` Route A** — cites `get-deployed-sha.sh`. The 5-row CLI/jq table replaced with a 5-row provider-to-CLI map plus the script's exit-code contract.

Locked substrings preserved (`#### Environment Grain`, `core.autocrlf`, `Parallel-actor expectation` in `workspace-surface-audit` — untouched).

## What's NOT touched

- Routes B (GitHub Deployments API) and C (version endpoint curl) in `deploy-receipt` — those are protocol-level, not per-provider CLI work; they stay inline.
- Mode B (`open-hotfix-pr`) in `deploy-receipt` — separate concern.
- Phase 9 synthetic-checks runner in `verification-loop` — different shape; that runner is its own future extraction candidate (`scripts/run-synthetic.mjs`).

## Test plan

- [x] `npm test` — 602/602 pass (16 new tests; 586 → 602; 0 regressions)
- [x] `npm run verify:all` — 7 invariants + typecheck green
- [x] Manual smoke: `detect-deploy-target.sh` in this repo returns `none` (no provider markers); same in an empty tempdir
- [x] Manual smoke: `get-deployed-sha.sh --show-command railway` prints the expected pipeline shape; unknown provider exits 2 with clear stderr; no provider arg exits 2 with usage message
- [ ] CI green on the PR

## Past-mistake gate

- `feedback_mts_is_source.md`: respected — new tests sourced as `.mts`, generated `.mjs` committed alongside; scripts in `scripts/` (outside tsc rootDir) need no source mirror, documented in `scripts/README.md`.
- `feedback_no_git_add_all_on_windows.md`: respected — 11 files staged by explicit filename.
- `feedback_pre_branch_check.md`: respected — fast-forwarded local `main` to `origin/main` (1a14709) before branching.
- `feedback_pr_flow_for_main.md`: respected — feature branch + PR, no direct push.
- Sentinel-file REPO_ROOT sanity check (rule added during git-state-snapshot extraction) — present in both new test files.

## Follow-ups (not in this PR)

- Extract `scripts/resolve-verify-ladder.mjs` next — `verification-loop` Phase 0 sniff logic. Likely a `.mts`/`.mjs` rather than `.sh` because the sniff involves parsing `package.json` scripts and per-language manifests.
- Decide explicitly whether PR #1 (folder migration) stays demoted permanently. Three extractions now live in `scripts/` and none has needed per-skill bundling.