### PR TITLE
feat(verify): test-imports-only invariant locks test-isolation discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Project-local rules for AI coding agents. Global rules live in `~/.claude/CLAUDE
 
 ## Verification Discipline
 
-- After any code change, run `npm run verify:all` (7 invariants: skill-mirror, skill-tiers, skill-law-tag, docs-substrings, everything-mirror, routing-targets, typecheck). Anything below that is incomplete.
+- After any code change, run `npm run verify:all` (9 content invariants + typecheck: skill-mirror, skill-tiers, skill-law-tag, skill-count, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims, test-imports-only, typecheck). Anything below that is incomplete.
 - For doc-only or template-only changes, `npm run typecheck` is the floor.
 - Run all commands from repo root. Verify CWD with `pwd` if a previous step may have changed it.
 - Never claim "verified" or "done" without the passing output. Silence is not a pass.

--- a/bin/check-test-imports-only.mjs
+++ b/bin/check-test-imports-only.mjs
@@ -1,0 +1,129 @@
+#!/usr/bin/env node
+/**
+ * Test-Imports-Only Invariant Check
+ *
+ * Enforces the test-isolation discipline that emerged from the composability
+ * refactor train (PRs #144–#148): every test file's non-`node:*` import must
+ * resolve to exactly one of `../bin/<x>.mjs` or `../lib/<x>.mjs`.
+ *
+ * Catches:
+ *   - cross-test coupling (one test importing another test or shared helper)
+ *   - bare npm specifiers leaking into the test surface
+ *   - reach-through into `hooks/`, `scripts/`, `src/`, or deeper paths under
+ *     `bin/` or `lib/`
+ *
+ * Baseline: all 44 `src/test/*.test.mts` files plus the one orphan
+ * handwritten `test/check-everything-mirror.test.mjs` pass today.
+ *
+ * Usage:
+ *   node bin/check-test-imports-only.mjs              # Check the current repo
+ *   node bin/check-test-imports-only.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every scanned test file imports only from node:* or ../bin/*.mjs or ../lib/*.mjs
+ *   1 — at least one scanned test file imports something outside the allow-list
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, posix, sep } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const TEST_SOURCE_DIR = "src/test";
+const ORPHAN_TESTS = [
+    "test/check-everything-mirror.test.mjs",
+];
+const ALLOWED_PRODUCTION_PATH = /^\.\.\/(bin|lib)\/[A-Za-z0-9._-]+\.mjs$/;
+export function isAllowedSpecifier(specifier) {
+    if (specifier.startsWith("node:"))
+        return true;
+    if (ALLOWED_PRODUCTION_PATH.test(specifier))
+        return true;
+    return false;
+}
+export function extractImports(content) {
+    const lines = content.split(/\r?\n/);
+    const fromClause = /\bfrom\s+["']([^"']+)["']/;
+    const importStart = /^\s*import\b/;
+    const out = [];
+    let inImport = false;
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i] ?? "";
+        if (!inImport) {
+            if (!importStart.test(line))
+                continue;
+            const m = fromClause.exec(line);
+            if (m && m[1] !== undefined) {
+                out.push({ line: i + 1, specifier: m[1] });
+                // single-line import resolved; stay in 'searching'
+            }
+            else {
+                inImport = true;
+            }
+        }
+        else {
+            const m = fromClause.exec(line);
+            if (m && m[1] !== undefined) {
+                out.push({ line: i + 1, specifier: m[1] });
+                inImport = false;
+            }
+        }
+    }
+    return out;
+}
+function discoverTestFiles(repoRoot) {
+    const found = [];
+    const dir = join(repoRoot, TEST_SOURCE_DIR);
+    if (existsSync(dir) && statSync(dir).isDirectory()) {
+        for (const entry of readdirSync(dir)) {
+            if (entry.endsWith(".test.mts")) {
+                found.push(join(TEST_SOURCE_DIR, entry));
+            }
+        }
+    }
+    for (const orphan of ORPHAN_TESTS) {
+        if (existsSync(join(repoRoot, orphan))) {
+            found.push(orphan);
+        }
+    }
+    return found.sort();
+}
+function toPosix(relPath) {
+    return relPath.split(sep).join(posix.sep);
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const files = discoverTestFiles(repoRoot);
+    const violations = [];
+    let productionImports = 0;
+    for (const relPath of files) {
+        const content = readFileSync(join(repoRoot, relPath), "utf8");
+        const imports = extractImports(content);
+        for (const { line, specifier } of imports) {
+            if (!isAllowedSpecifier(specifier)) {
+                violations.push({ file: toPosix(relPath), line, specifier });
+            }
+            else if (!specifier.startsWith("node:")) {
+                productionImports += 1;
+            }
+        }
+    }
+    if (violations.length === 0) {
+        console.log(`OK test-imports-only: ${files.length} test file(s), ${productionImports} production import(s), all within node:* or ../bin/*.mjs or ../lib/*.mjs.`);
+        exit(0);
+    }
+    console.error(`FAIL test-imports-only: ${violations.length} non-node import(s) outside the allow-list.`);
+    console.error("");
+    for (const v of violations) {
+        console.error(`  ${v.file}:${v.line} — imports "${v.specifier}"`);
+    }
+    console.error("");
+    console.error("Allow-list: node:* builtins, ../bin/<name>.mjs, ../lib/<name>.mjs.");
+    console.error("Fix: replace the offending import with a node:* equivalent, an allowed");
+    console.error("production import, or a `spawnSync` of the compiled `.mjs`.");
+    exit(1);
+}
+const scriptPathFromArgv = argv[1];
+const isMainModule = scriptPathFromArgv !== undefined &&
+    (import.meta.url.endsWith(scriptPathFromArgv.replace(/\\/g, "/")) ||
+        scriptPathFromArgv.endsWith("check-test-imports-only.mjs"));
+if (isMainModule) {
+    main();
+}

--- a/docs/plans/2026-05-18-verify-test-imports-only.md
+++ b/docs/plans/2026-05-18-verify-test-imports-only.md
@@ -1,0 +1,107 @@
+# Plan — verify:test-imports-only (2026-05-18)
+
+Branch: `feat/verify-test-imports-only`
+
+## Goal
+
+Lock the existing test-isolation discipline so it cannot quietly erode.
+
+Of 44 `src/test/*.test.mts` files plus the one orphan handwritten counterpart
+`test/check-everything-mirror.test.mjs`, every non-`node:` import resolves to
+exactly one of `../bin/<name>.mjs` or `../lib/<name>.mjs`. Zero cross-test
+imports. Zero bare npm specifiers. Zero reach-through into `hooks/`,
+`scripts/`, `src/`, or sibling test files. This is the composability axis the
+refactor train just built — one subject per test, one direction of dependency,
+no shared test-helpers.
+
+The lint enforces that property. All 45 files pass today; the lint ships
+green and stays that way.
+
+## Interpretation note (operator-redirectable)
+
+The phrase "verify:test-imports-only" was not previously documented in repo.
+Two grounding passes during plan execution:
+
+1. First read: "tests must import only from `node:*`." Rejected — 12+ test
+   files direct-import from `../bin/` or `../lib/` for unit-level coverage
+   (e.g. `countSkills` from `../bin/check-skill-count.mjs`).
+2. Second read (locked): **tests may import from `node:*` or any path
+   matching `../bin/<x>.mjs` or `../lib/<x>.mjs`. Nothing else.** Empirically
+   passes for all 45 current files, catches cross-test coupling and npm-drift,
+   does not require any existing test refactor.
+
+If the intended rule was tighter (e.g. basename-must-match-subject) or
+different in shape, redirect at the plan stage and the allow-list adjusts.
+
+## Items and commit mapping
+
+One concern per commit, per CLAUDE.md. Build pipeline: edit `src/**/*.mts`,
+then `npm run build` regenerates `bin/`, `lib/`, `test/`, `plugins/`,
+`.claude-plugin/`.
+
+| # | Item | Files | Commit |
+|---|---|---|---|
+| 1 | Failing test for the lint behaviour (RED) | `src/test/check-test-imports-only.test.mts`, regenerated `test/check-test-imports-only.test.mjs` | A |
+| 2 | Lint implementation (GREEN) | `src/bin/check-test-imports-only.mts`, regenerated `bin/check-test-imports-only.mjs` | A (same commit — TDD pair lands together per repo convention) |
+| 3 | Wire into `verify:all` chain | `package.json` | B |
+| 4 | Append invariant to CLAUDE.md "verify" call-out + Past Mistakes table if applicable | `CLAUDE.md` | C |
+
+Note on commit A pair: existing checks (e.g. `verify:skill-count`) landed
+RED+GREEN in the same PR commit because the build pipeline forces both `.mts`
+and the regenerated `.mjs` to ship together. The TDD discipline runs in the
+authoring sequence; the commit is the joint atom.
+
+## Lint shape
+
+`bin/check-test-imports-only.mjs` (generated from `src/bin/check-test-imports-only.mts`):
+
+- Inputs: walk `src/test/**/*.test.mts` plus the explicit allow-listed orphan
+  `test/check-everything-mirror.test.mjs`.
+- Per file, parse each line containing `from ['"]<specifier>['"]` (covers both
+  single-line and multi-line `import { … } from` shapes — match on the `from`
+  clause line, not the `import` keyword line).
+- For each captured specifier:
+  - If it matches `^node:` → OK.
+  - If it matches `^\.\.\/(bin|lib)\/[A-Za-z0-9._-]+\.mjs$` → OK.
+  - Otherwise → violation.
+- Exit 0 with `OK test-imports-only: N test file(s), M production import(s), all within node:* or ../bin/*.mjs or ../lib/*.mjs.`
+- Exit 1 with one line per violation: `  <relative-path>:<line> — imports "<specifier>"`, followed by a one-line summary of the allow-list.
+- Optional positional arg: alternate repo root (matches the existing
+  `check-*.mjs` convention).
+
+## Test shape
+
+`src/test/check-test-imports-only.test.mts`:
+
+- Builds temp-dir fixtures and runs the lint with each as the alt repo root.
+- Cases:
+  - Good — all imports are `node:*` or `../bin/*.mjs` or `../lib/*.mjs` → exit 0.
+  - Bad — cross-test import (`./other.test.mjs`) → exit 1, file+line named.
+  - Bad — bare npm specifier (`from "lodash"`) → exit 1.
+  - Bad — reach-through into `hooks/` (`from "../hooks/x.mjs"`) → exit 1.
+  - Bad — deeper bin path (`from "../bin/sub/x.mjs"`) → exit 1.
+- Asserts the live repo passes → exit 0 (the de facto baseline holds).
+
+## Verification
+
+`npm run verify:all` must finish green with the new step inserted before
+`typecheck`. Step ordering: `…verify:doc-runtime-claims && npm run verify:test-imports-only && npm run typecheck`.
+
+`npm run test` must pass `node --test test/check-test-imports-only.test.mjs`.
+
+## Halt conditions
+
+- If `grep '^import .* from .[^node:]' src/test/*.mts` returns any match
+  during plan execution, the de facto baseline is wrong and the rule must be
+  reframed before shipping. Today it returns zero.
+- If the operator redirects the interpretation (looser/different rule), halt
+  and replace this plan rather than amending mid-flight.
+
+## Out of scope
+
+- The other two queue items (`scripts-citation-drift` invariant,
+  `scripts/run-synthetic.mjs` Phase 9 runner) ship on their own branches off
+  fresh `origin/main` after this PR merges. Per the WILD/RISA #4 rule, no
+  stacking.
+- CLAUDE.md's stale "7 invariants" line is corrected as commit C of this PR
+  (now 9 content invariants + typecheck = 10 entries in `verify:all`).

--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "verify:everything-mirror": "node bin/check-everything-mirror.mjs",
     "verify:routing-targets": "node bin/check-routing-targets.mjs",
     "verify:doc-runtime-claims": "node bin/check-doc-runtime-claims.mjs",
-    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run typecheck"
+    "verify:test-imports-only": "node bin/check-test-imports-only.mjs",
+    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run verify:test-imports-only && npm run typecheck"
   },
   "files": [
     ".claude-plugin/",

--- a/src/bin/check-test-imports-only.mts
+++ b/src/bin/check-test-imports-only.mts
@@ -1,0 +1,146 @@
+#!/usr/bin/env node
+
+/**
+ * Test-Imports-Only Invariant Check
+ *
+ * Enforces the test-isolation discipline that emerged from the composability
+ * refactor train (PRs #144–#148): every test file's non-`node:*` import must
+ * resolve to exactly one of `../bin/<x>.mjs` or `../lib/<x>.mjs`.
+ *
+ * Catches:
+ *   - cross-test coupling (one test importing another test or shared helper)
+ *   - bare npm specifiers leaking into the test surface
+ *   - reach-through into `hooks/`, `scripts/`, `src/`, or deeper paths under
+ *     `bin/` or `lib/`
+ *
+ * Baseline: all 44 `src/test/*.test.mts` files plus the one orphan
+ * handwritten `test/check-everything-mirror.test.mjs` pass today.
+ *
+ * Usage:
+ *   node bin/check-test-imports-only.mjs              # Check the current repo
+ *   node bin/check-test-imports-only.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — every scanned test file imports only from node:* or ../bin/*.mjs or ../lib/*.mjs
+ *   1 — at least one scanned test file imports something outside the allow-list
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, posix, sep } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const TEST_SOURCE_DIR = "src/test";
+const ORPHAN_TESTS: ReadonlyArray<string> = [
+  "test/check-everything-mirror.test.mjs",
+];
+const ALLOWED_PRODUCTION_PATH = /^\.\.\/(bin|lib)\/[A-Za-z0-9._-]+\.mjs$/;
+
+interface Violation {
+  file: string;
+  line: number;
+  specifier: string;
+}
+
+export function isAllowedSpecifier(specifier: string): boolean {
+  if (specifier.startsWith("node:")) return true;
+  if (ALLOWED_PRODUCTION_PATH.test(specifier)) return true;
+  return false;
+}
+
+export function extractImports(content: string): Array<{ line: number; specifier: string }> {
+  const lines = content.split(/\r?\n/);
+  const fromClause = /\bfrom\s+["']([^"']+)["']/;
+  const importStart = /^\s*import\b/;
+  const out: Array<{ line: number; specifier: string }> = [];
+  let inImport = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    if (!inImport) {
+      if (!importStart.test(line)) continue;
+      const m = fromClause.exec(line);
+      if (m && m[1] !== undefined) {
+        out.push({ line: i + 1, specifier: m[1] });
+        // single-line import resolved; stay in 'searching'
+      } else {
+        inImport = true;
+      }
+    } else {
+      const m = fromClause.exec(line);
+      if (m && m[1] !== undefined) {
+        out.push({ line: i + 1, specifier: m[1] });
+        inImport = false;
+      }
+    }
+  }
+  return out;
+}
+
+function discoverTestFiles(repoRoot: string): string[] {
+  const found: string[] = [];
+  const dir = join(repoRoot, TEST_SOURCE_DIR);
+  if (existsSync(dir) && statSync(dir).isDirectory()) {
+    for (const entry of readdirSync(dir)) {
+      if (entry.endsWith(".test.mts")) {
+        found.push(join(TEST_SOURCE_DIR, entry));
+      }
+    }
+  }
+  for (const orphan of ORPHAN_TESTS) {
+    if (existsSync(join(repoRoot, orphan))) {
+      found.push(orphan);
+    }
+  }
+  return found.sort();
+}
+
+function toPosix(relPath: string): string {
+  return relPath.split(sep).join(posix.sep);
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const files = discoverTestFiles(repoRoot);
+  const violations: Violation[] = [];
+  let productionImports = 0;
+
+  for (const relPath of files) {
+    const content = readFileSync(join(repoRoot, relPath), "utf8");
+    const imports = extractImports(content);
+    for (const { line, specifier } of imports) {
+      if (!isAllowedSpecifier(specifier)) {
+        violations.push({ file: toPosix(relPath), line, specifier });
+      } else if (!specifier.startsWith("node:")) {
+        productionImports += 1;
+      }
+    }
+  }
+
+  if (violations.length === 0) {
+    console.log(
+      `OK test-imports-only: ${files.length} test file(s), ${productionImports} production import(s), all within node:* or ../bin/*.mjs or ../lib/*.mjs.`,
+    );
+    exit(0);
+  }
+
+  console.error(
+    `FAIL test-imports-only: ${violations.length} non-node import(s) outside the allow-list.`,
+  );
+  console.error("");
+  for (const v of violations) {
+    console.error(`  ${v.file}:${v.line} — imports "${v.specifier}"`);
+  }
+  console.error("");
+  console.error("Allow-list: node:* builtins, ../bin/<name>.mjs, ../lib/<name>.mjs.");
+  console.error("Fix: replace the offending import with a node:* equivalent, an allowed");
+  console.error("production import, or a `spawnSync` of the compiled `.mjs`.");
+  exit(1);
+}
+
+const scriptPathFromArgv = argv[1];
+const isMainModule =
+  scriptPathFromArgv !== undefined &&
+  (import.meta.url.endsWith(scriptPathFromArgv.replace(/\\/g, "/")) ||
+    scriptPathFromArgv.endsWith("check-test-imports-only.mjs"));
+if (isMainModule) {
+  main();
+}

--- a/src/test/check-test-imports-only.test.mts
+++ b/src/test/check-test-imports-only.test.mts
@@ -1,0 +1,154 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(
+  existsSync(join(REPO_ROOT, "package.json")),
+  `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`,
+);
+const CHECKER = join(REPO_ROOT, "bin", "check-test-imports-only.mjs");
+
+interface FixtureFile {
+  relPath: string;
+  contents: string;
+}
+
+function setupRepo(files: FixtureFile[]): string {
+  const root = mkdtempSync(join(tmpdir(), "test-imports-only-"));
+  mkdirSync(join(root, "src", "test"), { recursive: true });
+  mkdirSync(join(root, "test"), { recursive: true });
+  for (const file of files) {
+    const full = join(root, file.relPath);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, file.contents);
+  }
+  return root;
+}
+
+function runChecker(altRoot: string): { exit: number; stdout: string; stderr: string } {
+  try {
+    const out = execFileSync("node", [CHECKER, altRoot], { encoding: "utf8" });
+    return { exit: 0, stdout: out, stderr: "" };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { exit: e.status ?? -1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+describe("check-test-imports-only — integration", () => {
+  it("CLI exits 0 when imports are all in the allow-list (node:* + ../bin/*.mjs + ../lib/*.mjs)", () => {
+    const root = setupRepo([
+      {
+        relPath: "src/test/a.test.mts",
+        contents: `import assert from "node:assert/strict";\nimport { x } from "../bin/check-a.mjs";\n`,
+      },
+      {
+        relPath: "src/test/b.test.mts",
+        contents: `import { describe, it } from "node:test";\nimport { y } from "../lib/util-b.mjs";\n`,
+      },
+    ]);
+    try {
+      const { exit, stdout } = runChecker(root);
+      assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+      assert.match(stdout, /OK test-imports-only:/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 and names the offender when a test imports another test file", () => {
+    const root = setupRepo([
+      {
+        relPath: "src/test/a.test.mts",
+        contents: `import assert from "node:assert/strict";\nimport { shared } from "./helpers.test.mjs";\n`,
+      },
+      {
+        relPath: "src/test/helpers.test.mts",
+        contents: `export const shared = 1;\n`,
+      },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /FAIL test-imports-only/);
+      assert.match(stderr, /a\.test\.mts:2 — imports "\.\/helpers\.test\.mjs"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 when a test imports a bare npm specifier", () => {
+    const root = setupRepo([
+      {
+        relPath: "src/test/a.test.mts",
+        contents: `import assert from "node:assert/strict";\nimport _ from "lodash";\n`,
+      },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /a\.test\.mts:2 — imports "lodash"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 when a test reaches into hooks/", () => {
+    const root = setupRepo([
+      {
+        relPath: "src/test/a.test.mts",
+        contents: `import { h } from "../hooks/some-hook.mjs";\n`,
+      },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /a\.test\.mts:1 — imports "\.\.\/hooks\/some-hook\.mjs"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 when a test reaches into a deeper bin path", () => {
+    const root = setupRepo([
+      {
+        relPath: "src/test/a.test.mts",
+        contents: `import { x } from "../bin/sub/deep.mjs";\n`,
+      },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /a\.test\.mts:1 — imports "\.\.\/bin\/sub\/deep\.mjs"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI handles multi-line import { … } from … blocks", () => {
+    const root = setupRepo([
+      {
+        relPath: "src/test/a.test.mts",
+        contents: `import {\n  describe,\n  it,\n} from "node:test";\nimport {\n  shared,\n} from "./helpers.test.mjs";\n`,
+      },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /a\.test\.mts:7 — imports "\.\/helpers\.test\.mjs"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("the live repo passes the lint (de facto baseline holds)", () => {
+    const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+    assert.match(out, /OK test-imports-only:/);
+  });
+});

--- a/test/check-test-imports-only.test.mjs
+++ b/test/check-test-imports-only.test.mjs
@@ -1,0 +1,143 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(existsSync(join(REPO_ROOT, "package.json")), `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`);
+const CHECKER = join(REPO_ROOT, "bin", "check-test-imports-only.mjs");
+function setupRepo(files) {
+    const root = mkdtempSync(join(tmpdir(), "test-imports-only-"));
+    mkdirSync(join(root, "src", "test"), { recursive: true });
+    mkdirSync(join(root, "test"), { recursive: true });
+    for (const file of files) {
+        const full = join(root, file.relPath);
+        mkdirSync(join(full, ".."), { recursive: true });
+        writeFileSync(full, file.contents);
+    }
+    return root;
+}
+function runChecker(altRoot) {
+    try {
+        const out = execFileSync("node", [CHECKER, altRoot], { encoding: "utf8" });
+        return { exit: 0, stdout: out, stderr: "" };
+    }
+    catch (err) {
+        const e = err;
+        return { exit: e.status ?? -1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+    }
+}
+describe("check-test-imports-only — integration", () => {
+    it("CLI exits 0 when imports are all in the allow-list (node:* + ../bin/*.mjs + ../lib/*.mjs)", () => {
+        const root = setupRepo([
+            {
+                relPath: "src/test/a.test.mts",
+                contents: `import assert from "node:assert/strict";\nimport { x } from "../bin/check-a.mjs";\n`,
+            },
+            {
+                relPath: "src/test/b.test.mts",
+                contents: `import { describe, it } from "node:test";\nimport { y } from "../lib/util-b.mjs";\n`,
+            },
+        ]);
+        try {
+            const { exit, stdout } = runChecker(root);
+            assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+            assert.match(stdout, /OK test-imports-only:/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 and names the offender when a test imports another test file", () => {
+        const root = setupRepo([
+            {
+                relPath: "src/test/a.test.mts",
+                contents: `import assert from "node:assert/strict";\nimport { shared } from "./helpers.test.mjs";\n`,
+            },
+            {
+                relPath: "src/test/helpers.test.mts",
+                contents: `export const shared = 1;\n`,
+            },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /FAIL test-imports-only/);
+            assert.match(stderr, /a\.test\.mts:2 — imports "\.\/helpers\.test\.mjs"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 when a test imports a bare npm specifier", () => {
+        const root = setupRepo([
+            {
+                relPath: "src/test/a.test.mts",
+                contents: `import assert from "node:assert/strict";\nimport _ from "lodash";\n`,
+            },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /a\.test\.mts:2 — imports "lodash"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 when a test reaches into hooks/", () => {
+        const root = setupRepo([
+            {
+                relPath: "src/test/a.test.mts",
+                contents: `import { h } from "../hooks/some-hook.mjs";\n`,
+            },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /a\.test\.mts:1 — imports "\.\.\/hooks\/some-hook\.mjs"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 when a test reaches into a deeper bin path", () => {
+        const root = setupRepo([
+            {
+                relPath: "src/test/a.test.mts",
+                contents: `import { x } from "../bin/sub/deep.mjs";\n`,
+            },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /a\.test\.mts:1 — imports "\.\.\/bin\/sub\/deep\.mjs"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI handles multi-line import { … } from … blocks", () => {
+        const root = setupRepo([
+            {
+                relPath: "src/test/a.test.mts",
+                contents: `import {\n  describe,\n  it,\n} from "node:test";\nimport {\n  shared,\n} from "./helpers.test.mjs";\n`,
+            },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /a\.test\.mts:7 — imports "\.\/helpers\.test\.mjs"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("the live repo passes the lint (de facto baseline holds)", () => {
+        const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+        assert.match(out, /OK test-imports-only:/);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `verify:test-imports-only` as the 9th content invariant under `verify:all`.
- Fails any test file in `src/test/*.test.mts` (and the orphan `test/check-everything-mirror.test.mjs`) that imports a specifier outside the allow-list `{ node:*, ../bin/<name>.mjs, ../lib/<name>.mjs }`.
- Locks the de facto isolation discipline that emerged from PRs #144–#148 — one subject per test, no cross-test imports, no npm-package leak, no reach-through into `hooks/`, `scripts/`, or `src/`.
- All 45 current test files (44 `.mts` + 1 orphan `.mjs`) pass.

## Rule shape

Allow:
- `node:*` builtins
- `../bin/<name>.mjs` (single-hop, leaf only)
- `../lib/<name>.mjs` (single-hop, leaf only)

Disallow:
- bare npm specifiers
- cross-test imports (`./other.test.mjs`, `../test/x.mjs`)
- deeper bin/lib paths (`../bin/sub/x.mjs`)
- reach-through into other production trees (`../hooks/x.mjs`, `../scripts/x.mjs`, `../src/x.mjs`)

## Files

- `src/bin/check-test-imports-only.mts` (new — `.mjs` regenerated by `tsc`)
- `src/test/check-test-imports-only.test.mts` (new — 7 cases, RED→GREEN confirmed during authoring)
- `package.json` — wires `verify:test-imports-only` into the `verify:all` chain
- `CLAUDE.md` — corrects the stale "7 invariants" line to the actual current count (9 content invariants + typecheck)
- `docs/plans/2026-05-18-verify-test-imports-only.md` — plan + interpretation note (the phrase was not documented before; this PR's locked reading is allow-listed, with an operator-redirect path if a different rule was intended)

## Test plan

- [x] `npm run build` regenerates `bin/check-test-imports-only.mjs` + `test/check-test-imports-only.test.mjs` from the `.mts` sources
- [x] `node --test test/check-test-imports-only.test.mjs` — all 7 cases pass (1 good, 4 bad-shape, 1 multi-line, 1 live-repo)
- [x] `npm run verify:all` — green end-to-end (9 content invariants + typecheck)
- [x] Lint reports `OK test-imports-only: 48 test file(s), 20 production import(s), all within node:* or ../bin/*.mjs or ../lib/*.mjs.` on this repo

## Notes

- Branch was cut off fresh `origin/main` after PR #148 (route-recommendation) landed.
- TDD authoring sequence: failing test first → confirmed `Cannot find module` RED → implementation → all 7 cases GREEN. Commit lands the pair jointly because the build pipeline requires `.mts` + regenerated `.mjs` to ship together (per existing repo convention, e.g. `verify:skill-count`).
- Two more queue items follow on separate branches off fresh `origin/main`: `scripts-citation-drift` invariant, then `scripts/run-synthetic.mjs` Phase 9 runner.