### PR TITLE
feat(verify): scripts-citation-drift invariant locks 3-way inventory contract

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Project-local rules for AI coding agents. Global rules live in `~/.claude/CLAUDE
 
 ## Verification Discipline
 
-- After any code change, run `npm run verify:all` (9 content invariants + typecheck: skill-mirror, skill-tiers, skill-law-tag, skill-count, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims, test-imports-only, typecheck). Anything below that is incomplete.
+- After any code change, run `npm run verify:all` (10 content invariants + typecheck: skill-mirror, skill-tiers, skill-law-tag, skill-count, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims, test-imports-only, scripts-citation-drift, typecheck). Anything below that is incomplete.
 - For doc-only or template-only changes, `npm run typecheck` is the floor.
 - Run all commands from repo root. Verify CWD with `pwd` if a previous step may have changed it.
 - Never claim "verified" or "done" without the passing output. Silence is not a pass.

--- a/bin/check-scripts-citation-drift.mjs
+++ b/bin/check-scripts-citation-drift.mjs
@@ -1,0 +1,210 @@
+#!/usr/bin/env node
+/**
+ * Scripts-Citation-Drift Invariant Check
+ *
+ * Locks the inventory-citation contract stated in scripts/README.md:
+ *
+ *   "When a new script lands here, add a row to this table in the same PR
+ *    and cite the script from at least one skill — otherwise the script is
+ *    dead code on arrival."
+ *
+ * Three sides of the contract are enforced as one invariant:
+ *
+ *   Side A — every file in scripts/ (excluding README.md) must appear in the
+ *            Inventory table's Script column.
+ *   Side B — for every Inventory row, every `skills/<name>.md` token in the
+ *            Cited by cell must reference a file whose body contains the
+ *            literal substring `scripts/<script-filename>` for at least one
+ *            of the row's scripts.
+ *   Side C — every skills/*.md that mentions `scripts/<filename>` for an
+ *            inventoried script must appear in that script's row's Cited by
+ *            cell.
+ *
+ * Origin: ongoing composability refactor (PRs #144–#148, #149) extracts
+ * shared primitives into scripts/. Without enforcement, the inventory and
+ * citations drift the first time a script lands without README + skill
+ * plumbing. The lint locks the contract in CI on every PR.
+ *
+ * Usage:
+ *   node bin/check-scripts-citation-drift.mjs              # Check the current repo
+ *   node bin/check-scripts-citation-drift.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — all three sides reconciled
+ *   1 — at least one drift on at least one side
+ */
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, posix, sep } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const SCRIPTS_DIR = "scripts";
+const SCRIPTS_README = "scripts/README.md";
+const SKILLS_DIR = "skills";
+const TABLE_HEADER_LINE = "| Script | Purpose | Cited by |";
+export function parseInventoryTable(readmeContent) {
+    const lines = readmeContent.split(/\r?\n/);
+    const headerIdx = lines.findIndex((l) => l.trim() === TABLE_HEADER_LINE);
+    if (headerIdx === -1)
+        return [];
+    const rows = [];
+    for (let i = headerIdx + 2; i < lines.length; i++) {
+        const line = lines[i] ?? "";
+        const trimmed = line.trim();
+        if (!trimmed.startsWith("|"))
+            break;
+        if (trimmed === "")
+            break;
+        const cells = trimmed.split("|").slice(1, -1).map((c) => c.trim());
+        if (cells.length < 3)
+            continue;
+        const scriptCell = cells[0] ?? "";
+        const citedByCell = cells[2] ?? "";
+        const scripts = [...scriptCell.matchAll(/`([^`]+)`/g)].map((m) => m[1] ?? "");
+        const skills = [...citedByCell.matchAll(/`(skills\/[^`]+)`/g)].map((m) => m[1] ?? "");
+        rows.push({ scripts, skills, raw: trimmed });
+    }
+    return rows;
+}
+function listScriptFiles(repoRoot) {
+    const dir = join(repoRoot, SCRIPTS_DIR);
+    if (!existsSync(dir) || !statSync(dir).isDirectory())
+        return [];
+    return readdirSync(dir)
+        .filter((entry) => {
+        if (entry === "README.md")
+            return false;
+        try {
+            return statSync(join(dir, entry)).isFile();
+        }
+        catch {
+            return false;
+        }
+    })
+        .sort();
+}
+function listSkillFiles(repoRoot) {
+    const dir = join(repoRoot, SKILLS_DIR);
+    if (!existsSync(dir) || !statSync(dir).isDirectory())
+        return [];
+    return readdirSync(dir)
+        .filter((entry) => entry.endsWith(".md"))
+        .map((entry) => `${SKILLS_DIR}/${entry}`)
+        .sort();
+}
+function toPosix(relPath) {
+    return relPath.split(sep).join(posix.sep);
+}
+export function checkRepo(repoRoot) {
+    const sideA = [];
+    const sideB = [];
+    const sideC = [];
+    const scriptFiles = listScriptFiles(repoRoot);
+    const readmePath = join(repoRoot, SCRIPTS_README);
+    const readmeContent = existsSync(readmePath) ? readFileSync(readmePath, "utf8") : "";
+    const rows = parseInventoryTable(readmeContent);
+    const inventoryScripts = new Set();
+    for (const row of rows) {
+        for (const s of row.scripts)
+            inventoryScripts.add(s);
+    }
+    for (const file of scriptFiles) {
+        if (!inventoryScripts.has(file)) {
+            sideA.push(file);
+        }
+    }
+    let citationCount = 0;
+    const rowsByScript = new Map();
+    for (const row of rows) {
+        for (const s of row.scripts) {
+            if (!rowsByScript.has(s))
+                rowsByScript.set(s, row);
+        }
+    }
+    for (const row of rows) {
+        for (const skillPath of row.skills) {
+            citationCount += 1;
+            const fullSkill = join(repoRoot, skillPath);
+            let skillBody = "";
+            try {
+                skillBody = readFileSync(fullSkill, "utf8");
+            }
+            catch {
+                sideB.push(`${skillPath} — file does not exist (referenced by row "${row.scripts.join(", ")}")`);
+                continue;
+            }
+            const anyCited = row.scripts.some((script) => skillBody.includes(`scripts/${script}`));
+            if (!anyCited) {
+                const claimedScripts = row.scripts.map((s) => `scripts/${s}`).join(" or ");
+                sideB.push(`${skillPath} does not contain "${claimedScripts}" (claimed by row "${row.scripts.join(" + ")}")`);
+            }
+        }
+    }
+    const skillFiles = listSkillFiles(repoRoot);
+    for (const skillPath of skillFiles) {
+        let body = "";
+        try {
+            body = readFileSync(join(repoRoot, skillPath), "utf8");
+        }
+        catch {
+            continue;
+        }
+        for (const inventoryScript of inventoryScripts) {
+            const needle = `scripts/${inventoryScript}`;
+            if (!body.includes(needle))
+                continue;
+            const row = rowsByScript.get(inventoryScript);
+            if (!row)
+                continue;
+            if (!row.skills.includes(skillPath)) {
+                sideC.push(`${skillPath} cites "${needle}" but is not listed in that script's Cited by cell`);
+            }
+        }
+    }
+    return {
+        sideA,
+        sideB,
+        sideC,
+        scriptCount: scriptFiles.length,
+        citationCount,
+    };
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const result = checkRepo(repoRoot);
+    const totalViolations = result.sideA.length + result.sideB.length + result.sideC.length;
+    if (totalViolations === 0) {
+        console.log(`OK scripts-citation-drift: ${result.scriptCount} script(s), ${result.citationCount} skill citation(s), all three sides reconciled.`);
+        exit(0);
+    }
+    console.error(`FAIL scripts-citation-drift: ${totalViolations} drift(s) across the inventory-citation contract.`);
+    if (result.sideA.length > 0) {
+        console.error("");
+        console.error("Side A — script files missing from scripts/README.md inventory table:");
+        for (const v of result.sideA) {
+            console.error(`  ${toPosix(v)}`);
+        }
+    }
+    if (result.sideB.length > 0) {
+        console.error("");
+        console.error("Side B — inventory rows claim a citation the skill body does not contain:");
+        for (const v of result.sideB) {
+            console.error(`  ${toPosix(v)}`);
+        }
+    }
+    if (result.sideC.length > 0) {
+        console.error("");
+        console.error("Side C — skill cites a real inventoried script but is not listed in that script's Cited by cell:");
+        for (const v of result.sideC) {
+            console.error(`  ${toPosix(v)}`);
+        }
+    }
+    console.error("");
+    console.error("Fix: update scripts/README.md inventory (Side A/C) or correct the skill citation (Side B).");
+    exit(1);
+}
+const scriptPathFromArgv = argv[1];
+const isMainModule = scriptPathFromArgv !== undefined &&
+    (import.meta.url.endsWith(scriptPathFromArgv.replace(/\\/g, "/")) ||
+        scriptPathFromArgv.endsWith("check-scripts-citation-drift.mjs"));
+if (isMainModule) {
+    main();
+}

--- a/docs/plans/2026-05-18-verify-scripts-citation-drift.md
+++ b/docs/plans/2026-05-18-verify-scripts-citation-drift.md
@@ -1,0 +1,107 @@
+# Plan — verify:scripts-citation-drift (2026-05-18)
+
+Branch: `feat/verify-scripts-citation-drift`
+
+## Goal
+
+Lock the inventory-citation contract in [scripts/README.md](../../scripts/README.md):
+
+> "When a new script lands here, add a row to this table in the same PR and
+> cite the script from at least one skill — otherwise the script is dead code
+> on arrival."
+
+Today the contract holds organically (7 scripts, 6 citing skills, every row
+in the inventory table maps to a real citation, every citation is back-listed
+in its script's row). Without enforcement, the contract erodes the first time
+a script lands without README and skill plumbing — a real risk during the
+ongoing composability refactor. The lint locks all three sides:
+
+| Side | Catches |
+|---|---|
+| A — script ↔ README row | new script lands without inventory row |
+| B — README row ↔ real citation | inventory claims a skill cites a script the skill no longer mentions |
+| C — skill mention ↔ README row | skill body adds a citation without the inventory row catching up |
+
+## Promotion note (operator-redirectable)
+
+The original queue framing was `hooks/scripts-citation-drift.mjs` (a runtime
+PreToolUse hook). The locked promotion (from the /superpowers WILD #2 of this
+session, accepted by the operator with "continue with item 2") is to ship
+this as `bin/check-scripts-citation-drift.mjs` (a `npm run verify:*`
+invariant) instead. Reason: invariants fire in CI on every PR; hooks fire
+only on the host where a dev is already paying attention, and the
+inventory-citation contract is a release-gate concern, not a tool-use concern.
+
+## Items and commit mapping
+
+One concern per commit. Build pipeline: edit `src/**/*.mts`, then
+`npm run build` regenerates `bin/`, `lib/`, `test/`, `plugins/`,
+`.claude-plugin/` manifests.
+
+| # | Item | Files | Commit |
+|---|---|---|---|
+| 1 | Failing test for the lint behaviour (RED) | `src/test/check-scripts-citation-drift.test.mts`, regenerated `test/check-scripts-citation-drift.test.mjs` | A |
+| 2 | Lint implementation (GREEN) | `src/bin/check-scripts-citation-drift.mts`, regenerated `bin/check-scripts-citation-drift.mjs` | A (paired with the test per repo convention) |
+| 3 | Wire into `verify:all` chain | `package.json` | A |
+| 4 | Bump CLAUDE.md count to 10 content invariants + typecheck | `CLAUDE.md` | A |
+
+Single commit total — same shape as PR #149 (the test-imports-only invariant).
+
+## Lint shape
+
+`bin/check-scripts-citation-drift.mjs` (generated from `src/bin/check-scripts-citation-drift.mts`):
+
+- Inputs: walk `<repo>/scripts/` for files other than `README.md`; parse
+  `<repo>/scripts/README.md` Inventory table; read every file referenced in a
+  table row's "Cited by" cell.
+- Half A: every file in `scripts/` (excluding `README.md`) must appear inside
+  at least one backticked token in the Script column of the table.
+- Half B: for every row, every `\`skills/<name>.md\`` token inside the Cited
+  by column must reference a file whose body contains the literal string
+  `scripts/<script-filename>` for at least one of the row's scripts.
+- Half C: every `skills/*.md` file that contains the literal substring
+  `scripts/<filename>` (for any `<filename>` listed in the inventory) must
+  appear in that script's row's Cited by cell.
+- Exit 0 with `OK scripts-citation-drift: N script(s), M skill citation(s), all three sides reconciled.`
+- Exit 1 with one line per violation, grouped by side (A/B/C), naming files.
+- Optional positional arg: alternate repo root (matches the existing
+  `check-*.mjs` convention).
+
+## Test shape
+
+`src/test/check-scripts-citation-drift.test.mts`:
+
+- Six cases — one per side-pass, one per side-fail (A pass/fail, B fail, C
+  fail), one for `README.md` is the only `.md` in `scripts/` so it stays
+  excluded, and one for the live repo (baseline holds).
+- Each fixture builds a temp dir with `scripts/<files>` + a minimal
+  `scripts/README.md` containing the Inventory table + `skills/<files>.md`.
+- Runs the lint with that temp dir as the alt repo root.
+
+## Verification
+
+- `npm run build` regenerates the `.mjs` siblings.
+- `node --test test/check-scripts-citation-drift.test.mjs` — all cases pass.
+- `npm run verify:all` — green end-to-end with the new step inserted after
+  `verify:test-imports-only` and before `typecheck`.
+
+## Halt conditions
+
+- If running the lint against the live repo before implementation reveals an
+  existing drift that I overlooked during baselining, halt and surface it —
+  do not let the lint ship with a hidden allow-list.
+- If the operator redirects the promotion (wants it as a runtime hook
+  instead of an invariant), halt and replace this plan rather than amending
+  mid-flight.
+
+## Out of scope
+
+- Reverse coverage for *non-inventoried* scripts (e.g. a skill mentions a
+  fictional `scripts/ghost.mjs` that does not exist). Half C only checks
+  citations of *real* inventoried scripts; phantom mentions would be a
+  separate doc-drift invariant.
+- Citation strength — a skill that mentions a script once in a footnote and
+  a skill that depends heavily on the script both count equally. Out of
+  scope for this PR.
+- The Phase 9 runner (`scripts/run-synthetic.mjs`) ships on its own branch
+  off fresh `origin/main` after this PR merges, per the WILD/RISA #4 rule.

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "verify:routing-targets": "node bin/check-routing-targets.mjs",
     "verify:doc-runtime-claims": "node bin/check-doc-runtime-claims.mjs",
     "verify:test-imports-only": "node bin/check-test-imports-only.mjs",
-    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run verify:test-imports-only && npm run typecheck"
+    "verify:scripts-citation-drift": "node bin/check-scripts-citation-drift.mjs",
+    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run verify:test-imports-only && npm run verify:scripts-citation-drift && npm run typecheck"
   },
   "files": [
     ".claude-plugin/",

--- a/src/bin/check-scripts-citation-drift.mts
+++ b/src/bin/check-scripts-citation-drift.mts
@@ -1,0 +1,231 @@
+#!/usr/bin/env node
+
+/**
+ * Scripts-Citation-Drift Invariant Check
+ *
+ * Locks the inventory-citation contract stated in scripts/README.md:
+ *
+ *   "When a new script lands here, add a row to this table in the same PR
+ *    and cite the script from at least one skill — otherwise the script is
+ *    dead code on arrival."
+ *
+ * Three sides of the contract are enforced as one invariant:
+ *
+ *   Side A — every file in scripts/ (excluding README.md) must appear in the
+ *            Inventory table's Script column.
+ *   Side B — for every Inventory row, every `skills/<name>.md` token in the
+ *            Cited by cell must reference a file whose body contains the
+ *            literal substring `scripts/<script-filename>` for at least one
+ *            of the row's scripts.
+ *   Side C — every skills/*.md that mentions `scripts/<filename>` for an
+ *            inventoried script must appear in that script's row's Cited by
+ *            cell.
+ *
+ * Origin: ongoing composability refactor (PRs #144–#148, #149) extracts
+ * shared primitives into scripts/. Without enforcement, the inventory and
+ * citations drift the first time a script lands without README + skill
+ * plumbing. The lint locks the contract in CI on every PR.
+ *
+ * Usage:
+ *   node bin/check-scripts-citation-drift.mjs              # Check the current repo
+ *   node bin/check-scripts-citation-drift.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — all three sides reconciled
+ *   1 — at least one drift on at least one side
+ */
+
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { join, posix, sep } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const SCRIPTS_DIR = "scripts";
+const SCRIPTS_README = "scripts/README.md";
+const SKILLS_DIR = "skills";
+const TABLE_HEADER_LINE = "| Script | Purpose | Cited by |";
+
+interface InventoryRow {
+  scripts: string[];
+  skills: string[];
+  raw: string;
+}
+
+export function parseInventoryTable(readmeContent: string): InventoryRow[] {
+  const lines = readmeContent.split(/\r?\n/);
+  const headerIdx = lines.findIndex((l) => l.trim() === TABLE_HEADER_LINE);
+  if (headerIdx === -1) return [];
+  const rows: InventoryRow[] = [];
+  for (let i = headerIdx + 2; i < lines.length; i++) {
+    const line = lines[i] ?? "";
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("|")) break;
+    if (trimmed === "") break;
+    const cells = trimmed.split("|").slice(1, -1).map((c) => c.trim());
+    if (cells.length < 3) continue;
+    const scriptCell = cells[0] ?? "";
+    const citedByCell = cells[2] ?? "";
+    const scripts = [...scriptCell.matchAll(/`([^`]+)`/g)].map((m) => m[1] ?? "");
+    const skills = [...citedByCell.matchAll(/`(skills\/[^`]+)`/g)].map((m) => m[1] ?? "");
+    rows.push({ scripts, skills, raw: trimmed });
+  }
+  return rows;
+}
+
+function listScriptFiles(repoRoot: string): string[] {
+  const dir = join(repoRoot, SCRIPTS_DIR);
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return [];
+  return readdirSync(dir)
+    .filter((entry) => {
+      if (entry === "README.md") return false;
+      try {
+        return statSync(join(dir, entry)).isFile();
+      } catch {
+        return false;
+      }
+    })
+    .sort();
+}
+
+function listSkillFiles(repoRoot: string): string[] {
+  const dir = join(repoRoot, SKILLS_DIR);
+  if (!existsSync(dir) || !statSync(dir).isDirectory()) return [];
+  return readdirSync(dir)
+    .filter((entry) => entry.endsWith(".md"))
+    .map((entry) => `${SKILLS_DIR}/${entry}`)
+    .sort();
+}
+
+function toPosix(relPath: string): string {
+  return relPath.split(sep).join(posix.sep);
+}
+
+interface CheckResult {
+  sideA: string[];
+  sideB: string[];
+  sideC: string[];
+  scriptCount: number;
+  citationCount: number;
+}
+
+export function checkRepo(repoRoot: string): CheckResult {
+  const sideA: string[] = [];
+  const sideB: string[] = [];
+  const sideC: string[] = [];
+
+  const scriptFiles = listScriptFiles(repoRoot);
+  const readmePath = join(repoRoot, SCRIPTS_README);
+  const readmeContent = existsSync(readmePath) ? readFileSync(readmePath, "utf8") : "";
+  const rows = parseInventoryTable(readmeContent);
+
+  const inventoryScripts = new Set<string>();
+  for (const row of rows) {
+    for (const s of row.scripts) inventoryScripts.add(s);
+  }
+  for (const file of scriptFiles) {
+    if (!inventoryScripts.has(file)) {
+      sideA.push(file);
+    }
+  }
+
+  let citationCount = 0;
+  const rowsByScript = new Map<string, InventoryRow>();
+  for (const row of rows) {
+    for (const s of row.scripts) {
+      if (!rowsByScript.has(s)) rowsByScript.set(s, row);
+    }
+  }
+
+  for (const row of rows) {
+    for (const skillPath of row.skills) {
+      citationCount += 1;
+      const fullSkill = join(repoRoot, skillPath);
+      let skillBody = "";
+      try {
+        skillBody = readFileSync(fullSkill, "utf8");
+      } catch {
+        sideB.push(`${skillPath} — file does not exist (referenced by row "${row.scripts.join(", ")}")`);
+        continue;
+      }
+      const anyCited = row.scripts.some((script) => skillBody.includes(`scripts/${script}`));
+      if (!anyCited) {
+        const claimedScripts = row.scripts.map((s) => `scripts/${s}`).join(" or ");
+        sideB.push(`${skillPath} does not contain "${claimedScripts}" (claimed by row "${row.scripts.join(" + ")}")`);
+      }
+    }
+  }
+
+  const skillFiles = listSkillFiles(repoRoot);
+  for (const skillPath of skillFiles) {
+    let body = "";
+    try {
+      body = readFileSync(join(repoRoot, skillPath), "utf8");
+    } catch {
+      continue;
+    }
+    for (const inventoryScript of inventoryScripts) {
+      const needle = `scripts/${inventoryScript}`;
+      if (!body.includes(needle)) continue;
+      const row = rowsByScript.get(inventoryScript);
+      if (!row) continue;
+      if (!row.skills.includes(skillPath)) {
+        sideC.push(`${skillPath} cites "${needle}" but is not listed in that script's Cited by cell`);
+      }
+    }
+  }
+
+  return {
+    sideA,
+    sideB,
+    sideC,
+    scriptCount: scriptFiles.length,
+    citationCount,
+  };
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const result = checkRepo(repoRoot);
+  const totalViolations = result.sideA.length + result.sideB.length + result.sideC.length;
+
+  if (totalViolations === 0) {
+    console.log(
+      `OK scripts-citation-drift: ${result.scriptCount} script(s), ${result.citationCount} skill citation(s), all three sides reconciled.`,
+    );
+    exit(0);
+  }
+
+  console.error(`FAIL scripts-citation-drift: ${totalViolations} drift(s) across the inventory-citation contract.`);
+  if (result.sideA.length > 0) {
+    console.error("");
+    console.error("Side A — script files missing from scripts/README.md inventory table:");
+    for (const v of result.sideA) {
+      console.error(`  ${toPosix(v)}`);
+    }
+  }
+  if (result.sideB.length > 0) {
+    console.error("");
+    console.error("Side B — inventory rows claim a citation the skill body does not contain:");
+    for (const v of result.sideB) {
+      console.error(`  ${toPosix(v)}`);
+    }
+  }
+  if (result.sideC.length > 0) {
+    console.error("");
+    console.error("Side C — skill cites a real inventoried script but is not listed in that script's Cited by cell:");
+    for (const v of result.sideC) {
+      console.error(`  ${toPosix(v)}`);
+    }
+  }
+  console.error("");
+  console.error("Fix: update scripts/README.md inventory (Side A/C) or correct the skill citation (Side B).");
+  exit(1);
+}
+
+const scriptPathFromArgv = argv[1];
+const isMainModule =
+  scriptPathFromArgv !== undefined &&
+  (import.meta.url.endsWith(scriptPathFromArgv.replace(/\\/g, "/")) ||
+    scriptPathFromArgv.endsWith("check-scripts-citation-drift.mjs"));
+if (isMainModule) {
+  main();
+}

--- a/src/test/check-scripts-citation-drift.test.mts
+++ b/src/test/check-scripts-citation-drift.test.mts
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(
+  existsSync(join(REPO_ROOT, "package.json")),
+  `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`,
+);
+const CHECKER = join(REPO_ROOT, "bin", "check-scripts-citation-drift.mjs");
+
+interface FixtureFile {
+  relPath: string;
+  contents: string;
+}
+
+function setupRepo(files: FixtureFile[]): string {
+  const root = mkdtempSync(join(tmpdir(), "scripts-citation-drift-"));
+  for (const file of files) {
+    const full = join(root, file.relPath);
+    mkdirSync(join(full, ".."), { recursive: true });
+    writeFileSync(full, file.contents);
+  }
+  return root;
+}
+
+function runChecker(altRoot: string): { exit: number; stdout: string; stderr: string } {
+  try {
+    const out = execFileSync("node", [CHECKER, altRoot], { encoding: "utf8" });
+    return { exit: 0, stdout: out, stderr: "" };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { exit: e.status ?? -1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+  }
+}
+
+const INVENTORY_HEADER = `# scripts/\n\n## Inventory\n\n| Script | Purpose | Cited by |\n|---|---|---|\n`;
+
+describe("check-scripts-citation-drift — integration", () => {
+  it("CLI exits 0 when every script is inventoried and every citation reconciles both ways", () => {
+    const root = setupRepo([
+      { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+      { relPath: "scripts/beta.mjs", contents: "// beta\n" },
+      {
+        relPath: "scripts/README.md",
+        contents:
+          INVENTORY_HEADER +
+          "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n" +
+          "| `beta.mjs` | Beta primitive | `skills/dos.md` (Section B), `skills/uno.md` (Section A) |\n",
+      },
+      { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh` and also `scripts/beta.mjs` in Section A.\n" },
+      { relPath: "skills/dos.md", contents: "# dos\n\nUses `scripts/beta.mjs` in Section B.\n" },
+    ]);
+    try {
+      const { exit, stdout } = runChecker(root);
+      assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+      assert.match(stdout, /OK scripts-citation-drift:/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("Side A — CLI exits 1 when a script file is missing from the inventory table", () => {
+    const root = setupRepo([
+      { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+      { relPath: "scripts/orphan.mjs", contents: "// orphan, not in inventory\n" },
+      {
+        relPath: "scripts/README.md",
+        contents:
+          INVENTORY_HEADER +
+          "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n",
+      },
+      { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh`.\n" },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /Side A/);
+      assert.match(stderr, /orphan\.mjs/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("Side B — CLI exits 1 when the README claims a skill cites a script but the skill body does not", () => {
+    const root = setupRepo([
+      { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+      {
+        relPath: "scripts/README.md",
+        contents:
+          INVENTORY_HEADER +
+          "| `alpha.sh` | Alpha primitive | `skills/liar.md` (Section A) |\n",
+      },
+      { relPath: "skills/liar.md", contents: "# liar\n\nDoes not actually mention any script path.\n" },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /Side B/);
+      assert.match(stderr, /liar\.md.*does not contain "scripts\/alpha\.sh"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("Side C — CLI exits 1 when a skill cites a real script that the inventory row does not list it under", () => {
+    const root = setupRepo([
+      { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+      {
+        relPath: "scripts/README.md",
+        contents:
+          INVENTORY_HEADER +
+          "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n",
+      },
+      { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh`.\n" },
+      { relPath: "skills/ghost.md", contents: "# ghost\n\nAlso uses `scripts/alpha.sh`, but README has not been updated.\n" },
+    ]);
+    try {
+      const { exit, stderr } = runChecker(root);
+      assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+      assert.match(stderr, /Side C/);
+      assert.match(stderr, /ghost\.md.*cites "scripts\/alpha\.sh".*not listed/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("excludes scripts/README.md from the Side A inventory requirement", () => {
+    const root = setupRepo([
+      { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+      {
+        relPath: "scripts/README.md",
+        contents:
+          INVENTORY_HEADER +
+          "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n",
+      },
+      { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh`.\n" },
+    ]);
+    try {
+      const { exit } = runChecker(root);
+      assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("supports multi-file inventory rows (e.g. `route-recommendation.mjs` + `route-recommendation.routes.json`)", () => {
+    const root = setupRepo([
+      { relPath: "scripts/foo.mjs", contents: "// foo\n" },
+      { relPath: "scripts/foo.data.json", contents: "{}\n" },
+      {
+        relPath: "scripts/README.md",
+        contents:
+          INVENTORY_HEADER +
+          "| `foo.mjs` + `foo.data.json` | Foo primitive | `skills/uno.md` (Section A) |\n",
+      },
+      { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/foo.mjs` which reads `scripts/foo.data.json`.\n" },
+    ]);
+    try {
+      const { exit } = runChecker(root);
+      assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("the live repo passes the lint (baseline holds — all 3 sides reconciled)", () => {
+    const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+    assert.match(out, /OK scripts-citation-drift:/);
+  });
+});

--- a/test/check-scripts-citation-drift.test.mjs
+++ b/test/check-scripts-citation-drift.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+assert.ok(existsSync(join(REPO_ROOT, "package.json")), `REPO_ROOT sanity check failed — ${REPO_ROOT}/package.json not found`);
+const CHECKER = join(REPO_ROOT, "bin", "check-scripts-citation-drift.mjs");
+function setupRepo(files) {
+    const root = mkdtempSync(join(tmpdir(), "scripts-citation-drift-"));
+    for (const file of files) {
+        const full = join(root, file.relPath);
+        mkdirSync(join(full, ".."), { recursive: true });
+        writeFileSync(full, file.contents);
+    }
+    return root;
+}
+function runChecker(altRoot) {
+    try {
+        const out = execFileSync("node", [CHECKER, altRoot], { encoding: "utf8" });
+        return { exit: 0, stdout: out, stderr: "" };
+    }
+    catch (err) {
+        const e = err;
+        return { exit: e.status ?? -1, stdout: e.stdout ?? "", stderr: e.stderr ?? "" };
+    }
+}
+const INVENTORY_HEADER = `# scripts/\n\n## Inventory\n\n| Script | Purpose | Cited by |\n|---|---|---|\n`;
+describe("check-scripts-citation-drift — integration", () => {
+    it("CLI exits 0 when every script is inventoried and every citation reconciles both ways", () => {
+        const root = setupRepo([
+            { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+            { relPath: "scripts/beta.mjs", contents: "// beta\n" },
+            {
+                relPath: "scripts/README.md",
+                contents: INVENTORY_HEADER +
+                    "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n" +
+                    "| `beta.mjs` | Beta primitive | `skills/dos.md` (Section B), `skills/uno.md` (Section A) |\n",
+            },
+            { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh` and also `scripts/beta.mjs` in Section A.\n" },
+            { relPath: "skills/dos.md", contents: "# dos\n\nUses `scripts/beta.mjs` in Section B.\n" },
+        ]);
+        try {
+            const { exit, stdout } = runChecker(root);
+            assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+            assert.match(stdout, /OK scripts-citation-drift:/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("Side A — CLI exits 1 when a script file is missing from the inventory table", () => {
+        const root = setupRepo([
+            { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+            { relPath: "scripts/orphan.mjs", contents: "// orphan, not in inventory\n" },
+            {
+                relPath: "scripts/README.md",
+                contents: INVENTORY_HEADER +
+                    "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n",
+            },
+            { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh`.\n" },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /Side A/);
+            assert.match(stderr, /orphan\.mjs/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("Side B — CLI exits 1 when the README claims a skill cites a script but the skill body does not", () => {
+        const root = setupRepo([
+            { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+            {
+                relPath: "scripts/README.md",
+                contents: INVENTORY_HEADER +
+                    "| `alpha.sh` | Alpha primitive | `skills/liar.md` (Section A) |\n",
+            },
+            { relPath: "skills/liar.md", contents: "# liar\n\nDoes not actually mention any script path.\n" },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /Side B/);
+            assert.match(stderr, /liar\.md.*does not contain "scripts\/alpha\.sh"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("Side C — CLI exits 1 when a skill cites a real script that the inventory row does not list it under", () => {
+        const root = setupRepo([
+            { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+            {
+                relPath: "scripts/README.md",
+                contents: INVENTORY_HEADER +
+                    "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n",
+            },
+            { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh`.\n" },
+            { relPath: "skills/ghost.md", contents: "# ghost\n\nAlso uses `scripts/alpha.sh`, but README has not been updated.\n" },
+        ]);
+        try {
+            const { exit, stderr } = runChecker(root);
+            assert.equal(exit, 1, `expected exit 1, got ${exit}`);
+            assert.match(stderr, /Side C/);
+            assert.match(stderr, /ghost\.md.*cites "scripts\/alpha\.sh".*not listed/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("excludes scripts/README.md from the Side A inventory requirement", () => {
+        const root = setupRepo([
+            { relPath: "scripts/alpha.sh", contents: "#!/usr/bin/env bash\n" },
+            {
+                relPath: "scripts/README.md",
+                contents: INVENTORY_HEADER +
+                    "| `alpha.sh` | Alpha primitive | `skills/uno.md` (Section A) |\n",
+            },
+            { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/alpha.sh`.\n" },
+        ]);
+        try {
+            const { exit } = runChecker(root);
+            assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("supports multi-file inventory rows (e.g. `route-recommendation.mjs` + `route-recommendation.routes.json`)", () => {
+        const root = setupRepo([
+            { relPath: "scripts/foo.mjs", contents: "// foo\n" },
+            { relPath: "scripts/foo.data.json", contents: "{}\n" },
+            {
+                relPath: "scripts/README.md",
+                contents: INVENTORY_HEADER +
+                    "| `foo.mjs` + `foo.data.json` | Foo primitive | `skills/uno.md` (Section A) |\n",
+            },
+            { relPath: "skills/uno.md", contents: "# uno\n\nUses `scripts/foo.mjs` which reads `scripts/foo.data.json`.\n" },
+        ]);
+        try {
+            const { exit } = runChecker(root);
+            assert.equal(exit, 0, `expected exit 0, got ${exit}`);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("the live repo passes the lint (baseline holds — all 3 sides reconciled)", () => {
+        const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+        assert.match(out, /OK scripts-citation-drift:/);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds `verify:scripts-citation-drift` as the 10th content invariant under `verify:all`.
- Locks the inventory-citation contract documented in [scripts/README.md](../scripts/README.md): *"When a new script lands here, add a row to this table in the same PR and cite the script from at least one skill — otherwise the script is dead code on arrival."*
- Three sides, one invariant:

| Side | Catches |
|---|---|
| **A** | a script file in `scripts/` is missing from the README's Inventory table |
| **B** | an Inventory row claims `skills/<x>.md` cites a script, but the skill body does not contain `scripts/<filename>` |
| **C** | a `skills/*.md` mentions `scripts/<filename>` for an inventoried script, but is not listed in that script's Cited by cell |

- Baseline: 7 scripts, 10 skill citations, all three sides reconciled at fresh `origin/main` (803eab3 — PR #149).

## Promotion note

The original queue framing was `hooks/scripts-citation-drift.mjs` (a runtime PreToolUse hook). This PR ships it instead as `bin/check-scripts-citation-drift.mjs` — a `npm run verify:*` invariant that fires in CI on every PR. Rationale: the inventory-citation contract is a release-gate concern, not a tool-use concern. Operator authorized the promotion with "continue with item 2 from fresh origin/main."

## Files

- `src/bin/check-scripts-citation-drift.mts` (new — `.mjs` regenerated by `tsc`)
- `src/test/check-scripts-citation-drift.test.mts` (new — 7 cases including Side A/B/C fail paths, multi-file row support, and live-repo baseline)
- `package.json` — wires the new invariant into the `verify:all` chain
- `CLAUDE.md` — bumps verify count from 9 → 10 content invariants
- `docs/plans/2026-05-18-verify-scripts-citation-drift.md` — plan + promotion note

## Test plan

- [x] `npm run build` regenerates `bin/check-scripts-citation-drift.mjs` + `test/check-scripts-citation-drift.test.mjs` from `.mts` sources
- [x] `node --test test/check-scripts-citation-drift.test.mjs` — all 7 cases pass
- [x] `npm run verify:all` — green end-to-end (10 content invariants + typecheck)
- [x] Lint reports `OK scripts-citation-drift: 7 script(s), 10 skill citation(s), all three sides reconciled.` on this repo

## Notes

- Branch cut off `origin/main` at 803eab3 (fresh after PR #149 merged).
- TDD authoring sequence: failing test confirmed `Cannot find module` RED → implementation → all 7 cases GREEN.
- Item 3 follows on its own branch off fresh `origin/main` after this PR merges: `scripts/run-synthetic.mjs` (Phase 9 runner). That one routes through subagent-driven-development per the original /superpowers commitment — design surface large enough to warrant the two-stage spec + quality review.