### PR TITLE
fix(lint): include llms.txt in skill-count drift check and update stale count

### DIFF
--- a/bin/check-skill-count.mjs
+++ b/bin/check-skill-count.mjs
@@ -23,6 +23,7 @@
  *   - .claude-plugin/marketplace.json
  *   - plugins/continuous-improvement/.claude-plugin/plugin.json
  *   - package.json
+ *   - llms.txt
  *
  * Usage:
  *   node bin/check-skill-count.mjs              # Check the current repo
@@ -40,6 +41,7 @@ const CHECKED_FILES = [
     ".claude-plugin/marketplace.json",
     "plugins/continuous-improvement/.claude-plugin/plugin.json",
     "package.json",
+    "llms.txt",
 ];
 export function countSkills(repoRoot) {
     const skillsDir = join(repoRoot, BUNDLE_SKILLS_DIR);

--- a/llms.txt
+++ b/llms.txt
@@ -1,6 +1,6 @@
 # continuous-improvement
 
-> Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 13 enforcement skills, gating hooks, and the Mulahazah auto-leveling instinct engine.
+> Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 20 bundled skills, gating hooks, and the Mulahazah auto-leveling instinct engine.
 
 ## What This Is
 

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -2,6 +2,15 @@
 
 Fixed 13 test failures caused by Windows platform incompatibilities in test infrastructure.
 
+## 2026-05-24 — `llms.txt` added to `verify:skill-count` lint
+- The skill-count lint (`src/bin/check-skill-count.mts`) was only checking `.claude-plugin/marketplace.json`, `plugins/continuous-improvement/.claude-plugin/plugin.json`, and `package.json`.
+- Added `llms.txt` to the checked-files list so the "N bundled skills" phrase in that user-facing summary can never drift again.
+- Rebuilt (`npm run build`) to regenerate `bin/check-skill-count.mjs` and verified with `npm run verify:all`; full repo gate stayed green (661 pass / 0 fail).
+
+## 2026-05-24 — `llms.txt` stale skill count
+- `llms.txt` still described the project as having "13 enforcement skills"; updated to "20 bundled skills" to match the current `package.json`, `README.md`, and `skills/superpowers.md` reality.
+- Verified with `npm run verify:all`; full repo gate stayed green (661 pass / 0 fail).
+
 ## 2026-05-23 — Plugin bundle `mcp-server.mjs` executable-bit regression fix
 - The in-progress `package.json` build-script chmod step was only setting `+x` on files in `bin/` but missed `plugins/continuous-improvement/bin/mcp-server.mjs`, so after `npm run build` the plugin copy lost its executable bit (regression from HEAD where it was 755).
 - Added `plugins/continuous-improvement/bin/mcp-server.mjs` to the build-script chmod list so the plugin bundle stays executable after every rebuild.

--- a/src/bin/check-skill-count.mts
+++ b/src/bin/check-skill-count.mts
@@ -24,6 +24,7 @@
  *   - .claude-plugin/marketplace.json
  *   - plugins/continuous-improvement/.claude-plugin/plugin.json
  *   - package.json
+ *   - llms.txt
  *
  * Usage:
  *   node bin/check-skill-count.mjs              # Check the current repo
@@ -43,6 +44,7 @@ const CHECKED_FILES: ReadonlyArray<string> = [
   ".claude-plugin/marketplace.json",
   "plugins/continuous-improvement/.claude-plugin/plugin.json",
   "package.json",
+  "llms.txt",
 ];
 
 export function countSkills(repoRoot: string): number {


### PR DESCRIPTION
- Adds `llms.txt` to the skill-count lint so the bundled-skills phrase can never drift again.
- Updates the stale `13 enforcement skills` tagline in `llms.txt` to `20 bundled skills`.
- Records both fixes in `reports/daily-improvement.md`.

Verified: `npm run verify:all` green (661 pass / 0 fail).