### PR TITLE
docs(report): update stale dates to 2026-06-01

### DIFF
--- a/reports/assets/update-card.html
+++ b/reports/assets/update-card.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Daily Improvement Report — 2026-05-31</title>
+<title>Daily Improvement Report — 2026-06-01</title>
 <script src="https://unpkg.com/lucide@latest"></script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -161,7 +161,7 @@
     <i data-lucide="trending-up" style="color:#58a6ff" width="22" height="22"></i>
     <h1>Daily Improvement</h1>
   </div>
-  <div class="date">May 31, 2026 — continuous-improvement v3.9.2</div>
+  <div class="date">June 1, 2026 — continuous-improvement v3.9.2</div>
 
   <div class="stats">
     <div class="stat">

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,4 +1,9 @@
-# Daily Improvement Report — 2026-05-31
+# Daily Improvement Report — 2026-06-01
+
+## 2026-06-01 — Update stale report dates to June 1
+- The HTML summary card at `reports/assets/update-card.html` still showed "May 31, 2026" / "2026-05-31" in the `<title>` and visible date line, despite the daily report already containing a 2026-06-01 entry.
+- Updated both the `<title>` and the visible date line to "June 1, 2026" / "2026-06-01" so the card matches the current reporting period. Also updated the report header from "2026-05-31" to "2026-06-01".
+- Verified with `npm run verify:all`; the full repo gate stayed green (all 11 content invariants + typecheck pass). The card is a standalone generated asset, so no mirror update was needed.
 
 ## 2026-06-01 — Merge PR #159 and prune stale remote-tracking ref
 - PR #159 (`hourly/2026-05-31-delete-stale-merged-branches`) was open with all checks green (lint-transcript + test matrix on Node 18/20/22). It contained two commits: the second sweep of stale merged remote branches (8 branches deleted) and the build-script fix to persist execute permissions on `scripts/*.mjs` and `synthetic-checks/*.mjs`.


### PR DESCRIPTION
Updates the HTML summary card and daily report header from May 31 to June 1. Verified with npm run verify:all (all 11 content invariants + typecheck pass).