### PR TITLE
ci(verify): include hooks/ in generated-artifact diff check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
           node -e "const pkg = require('./package.json'); const runtime = ['dependencies','optionalDependencies','bundleDependencies'].flatMap((key) => Object.keys(pkg[key] || {})); if (runtime.length) { console.error('ERROR: runtime dependencies must stay empty:', runtime.join(', ')); process.exit(1); }"
 
       - name: Verify generated artifacts are committed
-        run: git diff --exit-code -- .claude-plugin bin test lib plugins
+        run: git diff --exit-code -- .claude-plugin bin hooks test lib plugins
 
       - name: Verify SKILL.md contains all 7 laws
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: npm run build
 
       - name: Verify generated artifacts are committed
-        run: git diff --exit-code -- .claude-plugin bin test lib plugins
+        run: git diff --exit-code -- .claude-plugin bin hooks test lib plugins
 
       - name: Run verify:all
         run: npm run verify:all

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "hooks:stats": "node bin/hook-stats.mjs",
     "test": "npm run build && node --test test/*.test.mjs",
     "lint": "node bin/lint-transcript.mjs --help",
-    "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin test lib plugins",
+    "verify:generated": "npm run build && git diff --exit-code -- .claude-plugin bin hooks test lib plugins",
     "verify:skill-mirror": "node bin/check-skill-mirror.mjs",
     "verify:skill-tiers": "node bin/check-skill-tiers.mjs",
     "verify:skill-law-tag": "node bin/check-skill-law-tag.mjs",

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -455,3 +455,9 @@ None. All 661 tests pass / 0 fail as of this cycle.
 - Local `main` was 1 commit ahead of `origin/main` (`d9109f0 docs(report): record deletion of stale merged branch hourly/2026-06-02-remove-stale-orphan-from-test-imports-check (#172)`). The prior cycle produced the commit but did not push it, leaving the remote behind.
 - Pushed with `git push origin main`. Remote fast-forwarded from `f079c8d` to `d9109f0`.
 - Verified with `git status` (working tree clean, branch up to date with `origin/main`) and `git log --oneline origin/main..main` (empty). No stale branches remain.
+
+## 2026-06-02 — Add `hooks/` to generated-artifact verification
+- The `verify:generated` npm script and both CI workflows (`ci.yml`, `release.yml`) ran `git diff --exit-code -- .claude-plugin bin test lib plugins` to ensure all generated `.mjs` artifacts were committed. However, `hooks/*.mjs` files are also compiled from `src/hooks/*.mts` by `tsc`, just like `bin/`, `lib/`, and `test/`. A direct edit to a `.mjs` file in `hooks/` would survive CI undetected.
+- Added `hooks` to the path list in all three locations: `package.json` (`verify:generated` script), `.github/workflows/ci.yml` ("Verify generated artifacts are committed" step), and `.github/workflows/release.yml` (same step name).
+- Verified with `npm run verify:generated` (passes, zero diff) and `npm run verify:all` (all 11 content invariants + typecheck pass). `npm test` confirms 661 pass / 0 fail.
+- Branch: `hourly/2026-06-02-add-hooks-to-verify-generated`.


### PR DESCRIPTION
Adds `hooks/` to the generated-artifact verification path in `verify:generated`, CI, and release workflows, matching the treatment of `bin/`, `lib/", and `test/`.