### PR TITLE
docs(report): record closure of superseded PR #179 in favor of #178

### DIFF
--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,5 +1,10 @@
 # Daily Improvement Report — 2026-06-03
 
+## 2026-06-03 — Close superseded PR #179 in favor of PR #178
+- PR #179 (`hourly/2026-06-03-unicode-tokenize-audit-6`) was opened with the Unicode-aware regex fix for goal-state and recall-index (audit #6). While it was open, PR #178 (`fix/goal-monitor-boundary-edges`) was found to contain the same Unicode tokenizer fix (`d2001ac`) plus additional boundary hardening: window:0/negative rejection (`6207648`), limit:0 clamping (`08cdbae`), regression tests, and updated deferred documentation.
+- Closed PR #179 with a superseded comment to avoid merge conflicts on the same source lines; the broader fix set will reach `main` through #178. Deleted the local feature branch after switching back to `main`.
+- Verified with `npm run verify:all` (all 11 content invariants + typecheck pass) and `git branch -a` (no stale `hourly/*` branches remain). Working tree clean.
+
 ## 2026-06-03 — Push rebased local main to origin
 - Local `main` was 2 commits ahead of `origin/main` (`821139d` docs(contributing) and `c9eac5d` docs(report)), but `origin/main` had also moved forward with 3 new commits from merged PRs #154, #175, and #176. A direct push was rejected (non-fast-forward).
 - Fetched remote state, rebased the 2 local docs commits onto the new `origin/main`, and pushed the result. The rebase applied cleanly because the local changes (`CONTRIBUTING.md` and `reports/daily-improvement.md`) did not overlap with the upstream changes (new skills, hooks, and tests under `src/` and `skills/`).


### PR DESCRIPTION
Closes PR #179 (Unicode tokenizer fix) as superseded by the broader boundary-hardening PR #178. No code changes.