### PR TITLE
fix(manifests): align skill-discovery filter with tier-lint

### DIFF
--- a/bin/generate-plugin-manifests.mjs
+++ b/bin/generate-plugin-manifests.mjs
@@ -35,7 +35,7 @@ async function writeBundledSkills() {
     const sourceSkillsDir = join(REPO_ROOT, "skills");
     const targetSkillsDir = join(PLUGIN_BUNDLE_DIR, "skills");
     const companionSkills = (await readdir(sourceSkillsDir))
-        .filter((file) => /^[a-z][a-z0-9-]*\.md$/.test(file))
+        .filter((file) => file.endsWith(".md") && file !== "README.md")
         .sort();
     await mkdir(targetSkillsDir, { recursive: true });
     await copyFileTo(join(REPO_ROOT, "SKILL.md"), join(targetSkillsDir, PACKAGE_NAME, "SKILL.md"));

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,5 +1,10 @@
 # Daily Improvement Report — 2026-06-03
 
+## 2026-06-03 — Align manifest generator skill-discovery filter with tier-lint
+- `src/bin/generate-plugin-manifests.mts` used `/^[a-z][a-z0-9-]*\.md$/` to discover companion skills for the plugin bundle, while `check-skill-tiers` (and its mirror `check-skill-law-tag`) accepted any `.md` file except `README.md`. This meant a future skill with an uppercase, underscore, or leading-digit name would pass `verify:all` but be silently omitted from the generated bundle.
+- Replaced the strict regex with the same loose filter `file.endsWith(".md") && file !== "README.md"` so the manifest generator aligns with the tier-lint discovery logic. The current repo has no non-kebab-case skill files, so the generated bundle is unchanged.
+- Verified with `npm run build` (manifests regenerated cleanly), `npm test` (750 pass / 0 fail), and `npm run verify:all` (all 11 content invariants + typecheck pass). Commit `c09bc10` on branch `hourly/2026-06-03-align-manifest-skill-discovery`.
+
 ## 2026-06-03 — Fast-forward main and delete stale merged branch
 - PR #182 (`hourly/2026-06-03-changelog-3-10-0-entry`) was squash-merged to `main` at commit `afe9718`, but the local feature branch `hourly/2026-06-03-changelog-3-10-0-entry` was still present and checked out. Squash merges create a new commit, so `git branch --merged` does not detect them, leaving stale branches behind. Additionally, `origin/main` had moved forward with three more merged PRs (#178 goal-monitor boundary fixes, #183 goal-drift Stop hook, #184 README goal-drift docs), so local `main` was behind the remote.
 - Checked out `main`, fast-forwarded to `origin/main` (commit `5cf4f83`), and deleted the local feature branch with `git branch -D hourly/2026-06-03-changelog-3-10-0-entry`. The remote branch was already deleted by the squash-merge `--delete-branch` default, so `git push origin --delete` was not needed; the local remote-tracking ref was pruned with `git remote prune origin`.

--- a/src/bin/generate-plugin-manifests.mts
+++ b/src/bin/generate-plugin-manifests.mts
@@ -66,7 +66,7 @@ async function writeBundledSkills(): Promise<void> {
   const sourceSkillsDir = join(REPO_ROOT, "skills");
   const targetSkillsDir = join(PLUGIN_BUNDLE_DIR, "skills");
   const companionSkills = (await readdir(sourceSkillsDir))
-    .filter((file) => /^[a-z][a-z0-9-]*\.md$/.test(file))
+    .filter((file) => file.endsWith(".md") && file !== "README.md")
     .sort();
 
   await mkdir(targetSkillsDir, { recursive: true });


### PR DESCRIPTION
- `src/bin/generate-plugin-manifests.mts` used `/^[a-z][a-z0-9-]*\.md$/` to discover companion skills for the plugin bundle, while `check-skill-tiers` (and its mirror `check-skill-law-tag`) accepted any `.md` file except `README.md`. This meant a future skill with an uppercase, underscore, or leading-digit name would pass `verify:all` but be silently omitted from the generated bundle.

- Replaced the strict regex with the same loose filter `file.endsWith(".md") && file !== "README.md"` so the manifest generator aligns with the tier-lint discovery logic. The current repo has no non-kebab-case skill files, so the generated bundle is unchanged.

- Verified with `npm run build` (manifests regenerated cleanly), `npm test` (750 pass / 0 fail), and `npm run verify:all` (all 11 content invariants + typecheck pass).