### PR TITLE
docs(report): update stale dates to June 7

### DIFF
--- a/reports/assets/update-card.html
+++ b/reports/assets/update-card.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Daily Improvement Report — 2026-06-06</title>
+<title>Daily Improvement Report — 2026-06-07</title>
 <script src="https://unpkg.com/lucide@latest"></script>
 <style>
   * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -161,7 +161,7 @@
     <i data-lucide="trending-up" style="color:#58a6ff" width="22" height="22"></i>
     <h1>Daily Improvement</h1>
   </div>
-  <div class="date">June 6, 2026 — continuous-improvement v3.10.0</div>
+  <div class="date">June 7, 2026 — continuous-improvement v3.10.0</div>
 
   <div class="stats">
     <div class="stat">

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,4 +1,9 @@
-# Daily Improvement Report — 2026-06-06
+# Daily Improvement Report — 2026-06-07
+
+## 2026-06-07 — Update stale report dates to June 7
+- The HTML summary card at `reports/assets/update-card.html` still showed "June 6, 2026" / "2026-06-06" in the `<title>` and visible date line, and the daily report header was still "2026-06-06". With the date boundary crossed to June 7, these assets needed to reflect the current reporting period.
+- Updated both the `<title>` and the visible date line to "June 7, 2026" / "2026-06-07" so the card matches the current reporting period. Updated the report header from "2026-06-06" to "2026-06-07".
+- Verified with `npm run verify:all` (all 11 content invariants + typecheck pass, 752 pass / 0 fail). Working tree remains clean.
 
 ## 2026-06-06 — Push local main to origin
 - Local `main` was 1 commit ahead of `origin/main` (`792fdb7 docs(report): sync test counts 750→752 and record daily improvement entry`). The prior cycle produced the commit but did not push it, leaving the remote behind.


### PR DESCRIPTION
Rollover daily report header and update-card date from June 6 to June 7. Doc-only change; verify:all passes.