### PR TITLE
fix(gateguard): block reason points at the clearance path that works on Claude Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+### Fixed
+
+- **GateGuard block reason now points at a clearance path that works on Claude Code** — the runtime hook told the agent to retry with `_gateguard_facts_presented: true`, but Claude Code's strict tool schema (`additionalProperties: false`) rejects that extra param with `InputValidationError` before the hook runs, leaving the first Edit/Write per file unclearable through the file tools. The block reason and the skill's "Honor system" note now lead with the portable route — record clearance in the session state file via a non-destructive Bash write — and keep the inline flag as a secondary path for harnesses that forward unknown tool params. No behavior change to the gate itself.
+
 ---
 
 ## [3.10.0] — 2026-06-03

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -9,8 +9,10 @@
  * Three-stage gate per skills/gateguard.md:
  * - DENY  : first mutating tool call per file, with fact-list reason
  * - FORCE : agent presents facts (model-side; out of band)
- * - ALLOW : retry once `_gateguard_facts_presented: true` is set or the
- *           per-file marker is recorded in session state
+ * - ALLOW : retry once the per-file marker is recorded in session state
+ *           (harness-portable, written out of band via Bash), or
+ *           `_gateguard_facts_presented: true` is set where the harness
+ *           forwards unknown tool params
  *
  * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
  * unconditionally. Destructive Bash gates EVERY call, not just first.
@@ -25,6 +27,7 @@
  * path.
  */
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { MAX_CLEARED_FILES, isCapReached, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
@@ -105,7 +108,7 @@ function formatFileTarget(filePaths) {
         return nonEmpty[0];
     return `${nonEmpty.length} files (${nonEmpty.join(", ")})`;
 }
-function buildMutatingFileReason(toolName, filePaths) {
+function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
@@ -115,8 +118,13 @@ function buildMutatingFileReason(toolName, filePaths) {
         "  3. If this file reads/writes data files, show field names, structure, and date format",
         "  4. Quote the user's current instruction verbatim",
         "",
-        "After presenting the facts, retry with `_gateguard_facts_presented: true` in tool_input,",
-        "or with the same file_path after a previous clearance has been recorded for this session.",
+        "Then clear the gate and retry the same call. Two clearance paths:",
+        `  A. Portable (works on every harness): append each path above to "cleared_files" in`,
+        `     ${stateFilePath} with a non-destructive Bash write, then retry. Bash is not gated`,
+        "     unless the command itself is destructive.",
+        "  B. Inline: retry with `_gateguard_facts_presented: true` in tool_input. This only works",
+        "     where the harness forwards unknown tool params; Claude Code's strict tool schema",
+        "     rejects it with InputValidationError, so use path A on Claude Code.",
     ].join("\n");
 }
 function buildDestructiveBashReason(command) {
@@ -172,6 +180,7 @@ function main() {
     }
     // mutating-file
     const sessionDir = resolveSessionDir();
+    const stateFilePath = join(sessionDir, "gateguard-session.json");
     const state = loadState(sessionDir);
     const filePaths = extractFilePaths(toolInput);
     const filePath = firstUnclearedFilePath(toolInput, state.cleared_files);
@@ -179,7 +188,7 @@ function main() {
     const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => path in state.cleared_files);
     const newFileCount = countDistinctNewFilePaths(filePaths, state.cleared_files);
     if (!factsFlagged && !alreadyCleared) {
-        emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath]) });
+        emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath], stateFilePath) });
         return;
     }
     if (factsFlagged && !alreadyCleared) {

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -9,8 +9,10 @@
  * Three-stage gate per skills/gateguard.md:
  * - DENY  : first mutating tool call per file, with fact-list reason
  * - FORCE : agent presents facts (model-side; out of band)
- * - ALLOW : retry once `_gateguard_facts_presented: true` is set or the
- *           per-file marker is recorded in session state
+ * - ALLOW : retry once the per-file marker is recorded in session state
+ *           (harness-portable, written out of band via Bash), or
+ *           `_gateguard_facts_presented: true` is set where the harness
+ *           forwards unknown tool params
  *
  * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
  * unconditionally. Destructive Bash gates EVERY call, not just first.
@@ -25,6 +27,7 @@
  * path.
  */
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import { MAX_CLEARED_FILES, isCapReached, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
@@ -105,7 +108,7 @@ function formatFileTarget(filePaths) {
         return nonEmpty[0];
     return `${nonEmpty.length} files (${nonEmpty.join(", ")})`;
 }
-function buildMutatingFileReason(toolName, filePaths) {
+function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
@@ -115,8 +118,13 @@ function buildMutatingFileReason(toolName, filePaths) {
         "  3. If this file reads/writes data files, show field names, structure, and date format",
         "  4. Quote the user's current instruction verbatim",
         "",
-        "After presenting the facts, retry with `_gateguard_facts_presented: true` in tool_input,",
-        "or with the same file_path after a previous clearance has been recorded for this session.",
+        "Then clear the gate and retry the same call. Two clearance paths:",
+        `  A. Portable (works on every harness): append each path above to "cleared_files" in`,
+        `     ${stateFilePath} with a non-destructive Bash write, then retry. Bash is not gated`,
+        "     unless the command itself is destructive.",
+        "  B. Inline: retry with `_gateguard_facts_presented: true` in tool_input. This only works",
+        "     where the harness forwards unknown tool params; Claude Code's strict tool schema",
+        "     rejects it with InputValidationError, so use path A on Claude Code.",
     ].join("\n");
 }
 function buildDestructiveBashReason(command) {
@@ -172,6 +180,7 @@ function main() {
     }
     // mutating-file
     const sessionDir = resolveSessionDir();
+    const stateFilePath = join(sessionDir, "gateguard-session.json");
     const state = loadState(sessionDir);
     const filePaths = extractFilePaths(toolInput);
     const filePath = firstUnclearedFilePath(toolInput, state.cleared_files);
@@ -179,7 +188,7 @@ function main() {
     const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => path in state.cleared_files);
     const newFileCount = countDistinctNewFilePaths(filePaths, state.cleared_files);
     if (!factsFlagged && !alreadyCleared) {
-        emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath]) });
+        emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath], stateFilePath) });
         return;
     }
     if (factsFlagged && !alreadyCleared) {

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -142,7 +142,7 @@ Smoke-test the runtime gate after install: ask Claude to write a throwaway file 
 
 ### V1 honest limitations (not mitigated, documented)
 
-- **Honor system.** Once the agent flips `_gateguard_facts_presented: true` in `tool_input`, the hook can't verify the investigation actually happened. The 50-file cap bounds damage from stuck loops or rogue agents.
+- **Honor system.** Clearance is recorded either by retrying with `_gateguard_facts_presented: true` in `tool_input` (only on harnesses that forward unknown tool params) or by appending the file path to `cleared_files` in the session state file with a non-destructive Bash write. Claude Code's strict tool schema (`additionalProperties: false`) rejects the inline flag with `InputValidationError`, so on Claude Code the state-file path is the working route. Either way the hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
 - **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
 - **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
 

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -142,7 +142,7 @@ Smoke-test the runtime gate after install: ask Claude to write a throwaway file 
 
 ### V1 honest limitations (not mitigated, documented)
 
-- **Honor system.** Once the agent flips `_gateguard_facts_presented: true` in `tool_input`, the hook can't verify the investigation actually happened. The 50-file cap bounds damage from stuck loops or rogue agents.
+- **Honor system.** Clearance is recorded either by retrying with `_gateguard_facts_presented: true` in `tool_input` (only on harnesses that forward unknown tool params) or by appending the file path to `cleared_files` in the session state file with a non-destructive Bash write. Claude Code's strict tool schema (`additionalProperties: false`) rejects the inline flag with `InputValidationError`, so on Claude Code the state-file path is the working route. Either way the hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
 - **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
 - **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
 

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -9,8 +9,10 @@
  * Three-stage gate per skills/gateguard.md:
  * - DENY  : first mutating tool call per file, with fact-list reason
  * - FORCE : agent presents facts (model-side; out of band)
- * - ALLOW : retry once `_gateguard_facts_presented: true` is set or the
- *           per-file marker is recorded in session state
+ * - ALLOW : retry once the per-file marker is recorded in session state
+ *           (harness-portable, written out of band via Bash), or
+ *           `_gateguard_facts_presented: true` is set where the harness
+ *           forwards unknown tool params
  *
  * Read-only and exploratory tools (Read, Grep, Glob, routine Bash) bypass
  * unconditionally. Destructive Bash gates EVERY call, not just first.
@@ -26,6 +28,7 @@
  */
 
 import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   MAX_CLEARED_FILES,
   isCapReached,
@@ -137,7 +140,7 @@ function formatFileTarget(filePaths: string[]): string {
   return `${nonEmpty.length} files (${nonEmpty.join(", ")})`;
 }
 
-function buildMutatingFileReason(toolName: string, filePaths: string[]): string {
+function buildMutatingFileReason(toolName: string, filePaths: string[], stateFilePath: string): string {
   const target = formatFileTarget(filePaths);
   return [
     `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
@@ -147,8 +150,13 @@ function buildMutatingFileReason(toolName: string, filePaths: string[]): string 
     "  3. If this file reads/writes data files, show field names, structure, and date format",
     "  4. Quote the user's current instruction verbatim",
     "",
-    "After presenting the facts, retry with `_gateguard_facts_presented: true` in tool_input,",
-    "or with the same file_path after a previous clearance has been recorded for this session.",
+    "Then clear the gate and retry the same call. Two clearance paths:",
+    `  A. Portable (works on every harness): append each path above to "cleared_files" in`,
+    `     ${stateFilePath} with a non-destructive Bash write, then retry. Bash is not gated`,
+    "     unless the command itself is destructive.",
+    "  B. Inline: retry with `_gateguard_facts_presented: true` in tool_input. This only works",
+    "     where the harness forwards unknown tool params; Claude Code's strict tool schema",
+    "     rejects it with InputValidationError, so use path A on Claude Code.",
   ].join("\n");
 }
 
@@ -209,6 +217,7 @@ function main(): void {
 
   // mutating-file
   const sessionDir = resolveSessionDir();
+  const stateFilePath = join(sessionDir, "gateguard-session.json");
   const state = loadState(sessionDir);
   const filePaths = extractFilePaths(toolInput);
   const filePath = firstUnclearedFilePath(toolInput, state.cleared_files);
@@ -217,7 +226,7 @@ function main(): void {
   const newFileCount = countDistinctNewFilePaths(filePaths, state.cleared_files);
 
   if (!factsFlagged && !alreadyCleared) {
-    emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath]) });
+    emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath], stateFilePath) });
     return;
   }
 


### PR DESCRIPTION
## Problem

The GateGuard runtime PreToolUse hook blocks the first `Edit`/`Write` per file and tells the agent to clear the gate by retrying with `_gateguard_facts_presented: true` in `tool_input`. **On Claude Code that instruction is impossible to follow:** the Write/Edit tool schema is `additionalProperties: false`, so the harness rejects the extra param with `InputValidationError` *before* the hook ever runs. The first mutation per file is therefore unclearable through the file tools — the gate's own block message points at a dead end.

Reproduced live this session:

```
InputValidationError: An unexpected parameter `_gateguard_facts_presented` was provided
```

A sibling project session (GoldTraders) hit the same wall and had to discover the undocumented marker-file workaround on its own.

## Fix

Text/doc only — **no change to the gate's clearance logic.**

- `src/hooks/gateguard.mts` — `buildMutatingFileReason` now takes the resolved `stateFilePath` and leads with the portable clearance route: append the path to `cleared_files` in the printed session-state file via a non-destructive Bash write, then retry. The inline `_gateguard_facts_presented` flag is kept as a secondary path "for harnesses that forward unknown tool params," with the `InputValidationError` caveat named explicitly. The block reason now prints the exact state-file path.
- `skills/gateguard.md` + plugin-bundle `SKILL.md` mirror — the "Honor system" limitation note now documents both clearance paths and the strict-schema reality.
- `CHANGELOG.md` — `[Unreleased] → Fixed` entry.

The `_gateguard_facts_presented` mechanism is intentionally retained: it still works on harnesses that pass unknown tool params through, and the test suite drives clearance through it.

## Verification

- `npm run build` — regenerates both `.mjs` hook copies + manifests; clean.
- `npm run verify:all` — 11 invariants + typecheck green (everything-mirror 53/53, skill-mirror, doc-runtime-claims, typecheck).
- `node --test test/gateguard-hook.test.mjs` — **14/14 pass** (unchanged).
- Smoke: new block reason renders the portable path with the exact state-file path interpolated; marker-based clearance still returns `allow`.

## Test plan

- [x] Build regenerates `.mjs` from `.mts` (no hand-edited generated files)
- [x] `verify:all` green
- [x] gateguard hook tests green
- [x] New block-reason text verified by direct hook invocation
- [ ] CI green on Linux runner