### PR TITLE
docs(audit): anchor audit #8 closure to commit hash b4f2eaf

### DIFF
--- a/docs/audits/2026-06-03-new-feature-audit.md
+++ b/docs/audits/2026-06-03-new-feature-audit.md
@@ -56,7 +56,7 @@ surgical fix — left to the PR #154 owner.
 | 3 | MED | goal-state | `window:0`/negative collapses to default 30. Defensible as invalid→default; decide clamp vs reject. **CLOSED `6207648`.** |
 | 4 | LOW | goal-state | `.includes` keyword match hits `test` inside `latest`. Intentional fuzzy heuristic. |
 | 6 | MED | recall-index | `tokenize` is ASCII-only (drops CJK/Cyrillic/accents). Broad i18n change; same pattern in goal-state. **CLOSED `d2001ac`.** |
-| 8 | MED | skill-distill | NaN timestamps suppress the time-gap trajectory split. Degrades draft mining only. **CLOSED in working tree.** |
+| 8 | MED | skill-distill | NaN timestamps suppress the time-gap trajectory split. Degrades draft mining only. **CLOSED `b4f2eaf`.** |
 | 9 | MED | skill-distill | Empty verify output counts as success. NOT a clean fix — silent-success commands (`tsc --noEmit`) legitimately emit nothing; needs a data-model decision. |
 | 10 | LOW | skill-distill | `occurrences` counts overlapping windows, not distinct runs; `minSessions` is the real guard. Add a contract-pinning test. **CLOSED `c19e9f3`.** |
 | 13 | LOW | mcp | `getRecentObservations(_, 0)` does `slice(-0)` = full read; output stays bounded downstream. Clamp `limit<=0`. **CLOSED `08cdbae`.** |

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -5,6 +5,11 @@
 - Updated both the `<title>` and the visible date line to "June 7, 2026" / "2026-06-07" so the card matches the current reporting period. Updated the report header from "2026-06-06" to "2026-06-07".
 - Verified with `npm run verify:all` (all 11 content invariants + typecheck pass, 752 pass / 0 fail). Working tree remains clean.
 
+## 2026-06-07 — Anchor audit #8 closure to commit hash in audit doc
+- `docs/audits/2026-06-03-new-feature-audit.md` row #8 still read **CLOSED in working tree** even though the fix was committed two days ago as `b4f2eaf` and is now in `main`. This left the audit trail ambiguous compared to other closed rows that cite exact commit hashes.
+- Replaced **CLOSED in working tree** with **CLOSED `b4f2eaf`** so the audit log matches the canonical commit reference pattern used by every other closed item.
+- Verified with `npm run verify:all` (all 11 content invariants + typecheck pass, 752 pass / 0 fail). Working tree has a single doc-only diff.
+
 ## 2026-06-07 — Reorganize misplaced report entries into chronological order
 - Five daily-improvement entries were accidentally appended after the "Project Snapshot" / "Remaining Failures" sections instead of being inserted in reverse-chronological order: the June 6 PR #188 audit-doc deferral fix, the June 1 `bin/refresh-third-party.mjs` TypeScript source migration, and three June 2 entries (push local main, add `hooks/` to generated-artifact verification, merge PR #173). This broke the report's reverse-chronological flow and placed newer June entries after older May entries.
 - Moved the June 6 entry to join the other June 6 entries before the June 3 block; moved the three June 2 entries to join the other June 2 entries before the June 1 block; moved the June 1 entry to join the other June 1 entries before the May block. Added a missing blank line between the last June 2 entry and the first June 1 entry.


### PR DESCRIPTION
Replaces the ambiguous **CLOSED in working tree** annotation for audit item #8 with **CLOSED `b4f2eaf`** so the audit log matches the canonical commit reference pattern used by every other closed item. The fix was committed two days ago and is already in main.