### PR TITLE
feat(gateguard): canonical clearance + in-harness clearance action (ci_gateguard_clear + CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **In-harness GateGuard clearance: `ci_gateguard_clear` + `bin/gateguard-clear.mjs`** — after presenting the facts, clear the gate with the `ci_gateguard_clear` MCP tool (available in beginner *and* expert mode, since the gate fires for every install) or the `gateguard-clear.mjs` CLI over the hook-allowed Bash route, instead of hand-writing the session-state JSON. Both take one or more file paths and record clearance through the shared canonical writer; the CLI accepts `--state <gateguard-session.json>` to target the exact file the block reason prints.
+
 ### Changed
 
 - **Landing page rebuilt as a Blueprint spec-sheet on the `continuous-improvement.dev` domain** — `docs/landing/index.html` is now a warm-paper editorial spec-sheet (OKLCH palette, one safety-vermilion accent, Space Grotesk + JetBrains Mono, asymmetric hero, the 7 Laws rendered as numbered clauses, enforcement zig-zag), replacing the previous dark/purple/emoji page. The 7-Law copy is pulled verbatim from `commands/discipline.md`. A `docs/landing/CNAME` plus updated `homepage`, canonical URL, and README link point the GitHub Pages site at the `continuous-improvement.dev` custom domain.
@@ -13,6 +17,7 @@ All notable changes to this skill are documented here.
 ### Fixed
 
 - **GateGuard block reason now points at a clearance path that works on Claude Code** — the runtime hook told the agent to retry with `_gateguard_facts_presented: true`, but Claude Code's strict tool schema (`additionalProperties: false`) rejects that extra param with `InputValidationError` before the hook runs, leaving the first Edit/Write per file unclearable through the file tools. The block reason and the skill's "Honor system" note now lead with the portable route — record clearance in the session state file via a non-destructive Bash write — and keep the inline flag as a secondary path for harnesses that forward unknown tool params. No behavior change to the gate itself.
+- **GateGuard clearance now matches regardless of path form** — the hook and every clearance helper canonicalize the project root and per-file keys (lowercase drive letter, `\`→`/`, strip trailing slash), so a clearance recorded by one process (e.g. the MCP server, which resolves the root via git-toplevel `D:/…`) is seen by the hook (which resolves via `CLAUDE_PROJECT_DIR` `d:/…`). This removes the drive-case / separator mismatch that previously forced seeding every path variant across candidate session dirs by hand. `lib/gateguard-state.mjs` is now bundled into `plugins/continuous-improvement/` (the bundled hook and `mcp-server.mjs` both import it).
 
 ---
 

--- a/bin/gateguard-clear.mjs
+++ b/bin/gateguard-clear.mjs
@@ -31,6 +31,10 @@ function main() {
             files.push(arg);
         }
     }
+    if (argv.includes("--state") && stateFile === "") {
+        process.stderr.write("--state requires a <gateguard-session.json> path argument\n");
+        process.exit(2);
+    }
     if (files.length === 0) {
         process.stderr.write("usage: gateguard-clear <file_path> [<file_path>...] [--state <gateguard-session.json>]\n");
         process.exit(2);

--- a/bin/gateguard-clear.mjs
+++ b/bin/gateguard-clear.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * gateguard-clear — record GateGuard clearance for files from the Bash route.
+ *
+ * The GateGuard PreToolUse hook blocks the first Edit/Write per file and prints
+ * the session-state path in its block reason. After presenting the required
+ * facts, run this to clear the gate so the retry is allowed. Bash is not gated
+ * (unless the command is destructive), so this surface always works — including
+ * where the ci_gateguard_clear MCP tool is not connected.
+ *
+ * Usage:
+ *   node bin/gateguard-clear.mjs <file_path> [<file_path>...] [--state <path>]
+ *
+ * Default resolves the session dir canonically, the same way the hook does.
+ * --state <path> writes that exact gateguard-session.json — the path the block
+ * reason prints — bypassing resolution for any residual env mismatch.
+ */
+import { dirname, join } from "node:path";
+import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
+function main() {
+    const argv = process.argv.slice(2);
+    const files = [];
+    let stateFile = "";
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === "--state") {
+            stateFile = argv[i + 1] ?? "";
+            i += 1;
+        }
+        else {
+            files.push(arg);
+        }
+    }
+    if (files.length === 0) {
+        process.stderr.write("usage: gateguard-clear <file_path> [<file_path>...] [--state <gateguard-session.json>]\n");
+        process.exit(2);
+    }
+    // clearFiles writes <sessionDir>/gateguard-session.json. With --state the
+    // caller hands us the full state-file path the block reason printed, so the
+    // session dir is its parent.
+    const sessionDir = stateFile ? dirname(stateFile) : resolveSessionDir();
+    const { cleared, skippedForCap } = clearFiles(sessionDir, files);
+    process.stdout.write(`Cleared ${cleared.length}: ${cleared.length > 0 ? cleared.join(", ") : "(none — already cleared)"}\n`);
+    if (skippedForCap.length > 0) {
+        process.stdout.write(`Skipped — session cap of ${MAX_CLEARED_FILES} reached: ${skippedForCap.join(", ")}\n`);
+    }
+    process.stdout.write(`State: ${join(sessionDir, "gateguard-session.json")}\n`);
+}
+main();

--- a/bin/generate-plugin-manifests.mjs
+++ b/bin/generate-plugin-manifests.mjs
@@ -145,6 +145,7 @@ async function writePluginBundle() {
         copyFileTo(join(REPO_ROOT, "bin", "mcp-server.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "mcp-server.mjs")),
         copyFileTo(join(REPO_ROOT, "bin", "observe.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "observe.mjs")),
         copyFileTo(join(REPO_ROOT, "bin", "backfill.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "backfill.mjs")),
+        copyFileTo(join(REPO_ROOT, "bin", "gateguard-clear.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "gateguard-clear.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "gateguard-state.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "gateguard-state.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "plugin-metadata.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "resolve-home-dir.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "resolve-home-dir.mjs")),

--- a/bin/generate-plugin-manifests.mjs
+++ b/bin/generate-plugin-manifests.mjs
@@ -145,6 +145,7 @@ async function writePluginBundle() {
         copyFileTo(join(REPO_ROOT, "bin", "mcp-server.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "mcp-server.mjs")),
         copyFileTo(join(REPO_ROOT, "bin", "observe.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "observe.mjs")),
         copyFileTo(join(REPO_ROOT, "bin", "backfill.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "backfill.mjs")),
+        copyFileTo(join(REPO_ROOT, "lib", "gateguard-state.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "gateguard-state.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "plugin-metadata.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "resolve-home-dir.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "resolve-home-dir.mjs")),
         copyFileTo(join(REPO_ROOT, "lib", "observe-event.mjs"), join(PLUGIN_BUNDLE_DIR, "lib", "observe-event.mjs")),

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -21,6 +21,7 @@ import { PACKAGE_NAME, VERSION, getToolDefinitions, isPluginMode, } from "../lib
 import { formatDriftReport, parseGoalFromPlan, scoreObservations, } from "../lib/goal-state.mjs";
 import { buildIndex, formatRecallHits, parseSince, query as queryRecall, } from "../lib/recall-index.mjs";
 import { draftFromCandidate, extractTrajectories, findCandidates, formatCandidates, serializeDraft, } from "../lib/skill-distill.mjs";
+import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 function getHomeDir() {
     return process.env.HOME || process.env.USERPROFILE || homedir();
 }
@@ -504,6 +505,33 @@ function handleTool(name, params) {
                 "  (or just `1. None — goal met, stop.` if the original goal is fully resolved)",
             ].join("\n");
             return text(reflection);
+        }
+        case "ci_gateguard_clear": {
+            // Beginner-available on purpose: the GateGuard hook fires for every
+            // install, so the clearance action must too. Resolves the session dir via
+            // gateguard-state (canonical), the same way the hook does, so the marker
+            // lands where the hook looks regardless of how each process spelled the
+            // project root.
+            const rawList = Array.isArray(params.file_paths) ? params.file_paths : [];
+            const listPaths = rawList.filter((value) => typeof value === "string" && value.length > 0);
+            const single = getString(params.file_path).trim();
+            const paths = single ? [...listPaths, single] : listPaths;
+            if (paths.length === 0) {
+                return error("file_paths is required — pass the file path(s) named in the GateGuard block reason, e.g. { file_paths: [\"src/x.ts\"] }.");
+            }
+            const sessionDir = resolveSessionDir();
+            const { cleared, skippedForCap } = clearFiles(sessionDir, paths);
+            const lines = [
+                "## GateGuard clearance",
+                "",
+                `**State file:** ${join(sessionDir, "gateguard-session.json")}`,
+                `**Cleared (${cleared.length}):** ${cleared.length > 0 ? cleared.join(", ") : "(none — already cleared)"}`,
+            ];
+            if (skippedForCap.length > 0) {
+                lines.push(`**Skipped — session cap of ${MAX_CLEARED_FILES} reached (${skippedForCap.length}):** ${skippedForCap.join(", ")}`, "Start a new session to reset the gate.");
+            }
+            lines.push("", "Retry the Edit/Write now — it will pass.");
+            return text(lines.join("\n"));
         }
         case "ci_reinforce": {
             if (MODE !== "expert") {

--- a/docs/plans/2026-06-07-gateguard-canonical-clearance.md
+++ b/docs/plans/2026-06-07-gateguard-canonical-clearance.md
@@ -1,0 +1,149 @@
+# Plan — Canonical GateGuard clearance + in-harness clearance action
+
+- Date: 2026-06-07
+- Status: Spec approved (design sign-off given); implementation NOT started
+- Owner: gateguard
+- Follows: PR #193 (block reason now prints the exact state-file path and stops instructing the impossible inline flag). This plan removes the remaining fragility.
+- Scope decision (confirmed): root-cause canonicalization **plus** a clearance action.
+- Surface decision (confirmed): **both** an MCP tool (`ci_gateguard_clear`) and a Bash CLI (`bin/gateguard-clear.mjs`).
+
+## Problem (root cause)
+
+GateGuard's per-session clearance state is addressed two ways, both sensitive to path *form*:
+
+1. **Session dir** = `~/.claude/instincts/<hash>/`, `hash = sha256(projectRoot).slice(0,12)`.
+2. **Per-file keys** = the raw `tool_input.file_path` string under `cleared_files`.
+
+`projectRoot` is resolved differently by different processes:
+
+- The hook (`src/lib/gateguard-state.mts::resolveSessionDir`) uses `CLAUDE_PROJECT_DIR` first — on this host that was `d:/Ai/continuous-improvement` (lowercase drive) → `86cc9a542a7a`.
+- The MCP server (`src/bin/mcp-server.mts::getProjectHash`) uses `git rev-parse --show-toplevel` — which returned `D:/Ai/continuous-improvement` (uppercase drive) → `38c17ae973a4`.
+
+Different string → different hash → **different dir**. Likewise file keys differ by drive-letter case and separator (`d:\x`, `D:/x`, …). A clearance written by one process is invisible to the hook, which is why clearing the gate today requires shotgun-seeding every path variant across several candidate dirs by hand (observed live while shipping PR #193).
+
+## Goals / non-goals
+
+Goals:
+- The hook and every clearance helper resolve the **same** session dir and match the **same** file key, regardless of drive-letter case, separator, or which env var supplied the root.
+- A first-class, in-harness way to clear the gate after presenting facts — usable in beginner mode (the gate fires for all users) and without the MCP server connected.
+- No change to the gate's *intent*: first mutation per file still blocks; clearance is still honor-system; the 50-file cap still bounds damage.
+
+Non-goals:
+- Verifying that investigation actually happened (still honor-system; out of scope).
+- Removing the `_gateguard_facts_presented` inline flag (kept for harnesses that forward unknown tool params; tests depend on it).
+- Persisting clearance across sessions (still ephemeral).
+
+## Design
+
+### 1. One shared canonicalizer (`src/lib/gateguard-state.mts`)
+
+Add two pure, total functions (never throw):
+
+- `canonicalizeProjectRoot(p: string): string` — if `p` matches `^[A-Za-z]:` lowercase the drive letter; convert `\` → `/`; strip a trailing `/`. POSIX/relative paths pass through unchanged.
+- `canonicalizeFileKey(p: string): string` — same normalization, applied to every file path before it is stored or looked up. Relative keys (e.g. `scratch.txt`, used throughout the existing tests) contain no drive letter and no `\`, so they are a **no-op** — existing tests keep matching.
+
+Wire them in:
+- `resolveSessionDir()` hashes `canonicalizeProjectRoot(projectRoot)` (applied to both the `CLAUDE_PROJECT_DIR` and the git-toplevel branches).
+- `markFileCleared(state, filePath)` stores under `canonicalizeFileKey(filePath)`.
+- New `isFileCleared(state, filePath): boolean` → `canonicalizeFileKey(filePath) in state.cleared_files`. Single lookup shared by the hook and any helper.
+- New `clearFiles(sessionDir, filePaths: string[]): { cleared: string[]; skippedForCap: string[] }` — load → for each canonical key not already present, add if under `MAX_CLEARED_FILES`, else push to `skippedForCap` → save only if something changed. The one writer shared by the MCP tool and the CLI.
+
+### 2. Hook (`src/hooks/gateguard.mts`)
+
+- Replace the inline `path in state.cleared_files` checks in `alreadyCleared` / `firstUnclearedFilePath` with `isFileCleared(...)` so lookups are canonical.
+- Block reason: keep the printed state-file path (PR #193); add one line naming the clearance action, e.g. `Clear it: ci_gateguard_clear {file_paths:["<path>"]}  —or—  node "${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" "<path>"`.
+- No change to routing, destructive-bash, or cap logic.
+
+### 3. MCP tool `ci_gateguard_clear` (`src/bin/mcp-server.mts` + `src/lib/plugin-metadata.mts`)
+
+- Definition added to `BEGINNER_TOOL_ENTRIES` (so it appears in **both** beginner and expert catalogs — the gate fires for all users).
+- Schema: `{ file_paths: string[] }` (required; accept a single string too by coercing). Returns which paths were cleared, which were skipped for the cap, and the resolved state-file path for transparency.
+- Handler resolves the dir via gateguard-state's `resolveSessionDir()` — **not** the server's own `getProjectHash()` — so it agrees with the hook. Reuses `clearFiles`.
+- Not expert-gated (unlike most `ci_*` tools).
+
+### 4. CLI `bin/gateguard-clear.mjs` (`src/bin/gateguard-clear.mts`, new)
+
+- `node bin/gateguard-clear.mjs <file_path> [<file_path>...] [--state <path>]`.
+- Default: resolve via `resolveSessionDir()` (canonical) and `clearFiles`.
+- `--state <path>`: write that exact state file (the path the block reason prints) — zero resolution, belt-and-suspenders for any residual env mismatch.
+- Runs via the hook-allowed Bash route (Bash is gated only on destructive patterns). Prints cleared/skipped summary; exit 0 on success, non-zero on usage error.
+- `tsconfig` (`rootDir: src`, `outDir: .`) maps `src/bin/gateguard-clear.mts` → `bin/gateguard-clear.mjs`; the everything-mirror build copies it to `plugins/continuous-improvement/bin/gateguard-clear.mjs`.
+
+### Data flow
+
+Gate blocks first Write/Edit → reason prints the state path + clearance command → agent presents facts → calls `ci_gateguard_clear` (MCP) or runs the CLI (Bash) → shared `clearFiles(resolveSessionDir(), …)` writes canonical markers in the canonical dir → agent retries → hook canonicalizes the incoming path via `isFileCleared`, matches, allows.
+
+### Error handling
+
+- Empty / non-array `file_paths` → usage error (tool returns `isError`, CLI exits non-zero).
+- Cap reached → paths reported under `skippedForCap`; message mirrors `buildCapReachedReason`.
+- `--state` path unwritable → error.
+- Canonicalizers are pure/total; relative + POSIX paths are no-ops.
+
+### Migration / backward-compat
+
+Canonicalizing the hash changes the session dir once for any project whose `CLAUDE_PROJECT_DIR`/git-toplevel was not already canonical. Existing markers in the old dir are orphaned → at worst a one-time re-block per file in an active session (clearances are ephemeral; no persistent data). The variant keys seeded by hand during PR #193 become moot, harmless. No schema change to `gateguard-session.json`.
+
+## Public API surface (new/changed exports)
+
+`src/lib/gateguard-state.mts`:
+- `+ canonicalizeProjectRoot(p): string`
+- `+ canonicalizeFileKey(p): string`
+- `+ isFileCleared(state, filePath): boolean`
+- `+ clearFiles(sessionDir, filePaths): { cleared, skippedForCap }`
+- `~ resolveSessionDir` / `markFileCleared` now canonical (no signature change)
+
+`src/lib/plugin-metadata.mts`:
+- `+ ci_gateguard_clear` entry in `BEGINNER_TOOL_ENTRIES`
+
+`src/bin/mcp-server.mts`:
+- `+ case "ci_gateguard_clear"` using `resolveSessionDir` + `clearFiles`
+
+`src/bin/gateguard-clear.mts` (new) → `bin/gateguard-clear.mjs`
+
+## Phased implementation plan (TDD, one concern per commit per layer)
+
+**Phase 0 — confirm the three risks (no code).**
+- Read `src/test/mcp-server.test.mts`: exact per-mode tool-count assertions + `tools/list` membership shape.
+- `grep` docs/README for tool-count strings the `verify:docs-substrings` lint pins (beginner "3 tools" / expert counts).
+- Decide single vs array param final shape from how other tools coerce.
+
+**Phase 1 — lib canonicalization (RED→GREEN).**
+- `src/test/gateguard-state.test.mts` (extend or add): unit tests for both canonicalizers (drive-case, `\`→`/`, trailing slash, relative no-op, POSIX no-op); `resolveSessionDir` canonical; `markFileCleared` stores canonical; `isFileCleared` matches across forms; `clearFiles` writes + respects cap.
+- Implement in `gateguard-state.mts`. Build + run suite.
+
+**Phase 2 — hook uses canonical lookup (RED→GREEN).**
+- Extend `src/test/gateguard-hook.test.mts`: a file cleared as `D:/x` is allowed when the hook receives `d:\x`; existing relative-path tests stay green. Add block-reason assertion naming the clearance action.
+- Update `src/hooks/gateguard.mts`. Build.
+
+**Phase 3 — MCP tool (RED→GREEN).**
+- Extend `src/test/mcp-server.test.mts`: `ci_gateguard_clear` present in beginner + expert `tools/list`; clears markers in `resolveSessionDir()` dir; returns cleared/skipped; cap behavior; bump the per-mode count assertions (beginner 3→4, expert 17→18 — verify in Phase 0).
+- Add the entry to `plugin-metadata.mts` and the handler to `mcp-server.mts`. Build (regenerates manifests).
+
+**Phase 4 — CLI (RED→GREEN).**
+- New `src/test/gateguard-clear.test.mts`: clears via `resolveSessionDir`; `--state` override writes the named file; multi-path; cap; usage error. (Spawn the built `.mjs` like the hook test does.)
+- Add `src/bin/gateguard-clear.mts`. Build (emits `bin/gateguard-clear.mjs` + bundle mirror).
+
+**Phase 5 — docs + changelog (mirror-safe).**
+- Both skill `.md` copies (`skills/gateguard.md` + `plugins/.../SKILL.md`, byte-identical): document the clearance action and the canonical-key behavior; update the "Honor system" note.
+- Any docs/README tool-count strings flagged in Phase 0.
+- `CHANGELOG.md` `[Unreleased]`.
+
+## Verification
+
+- `npm run build` after every `.mts` edit (rebuild-before-stage; `.mjs` are generated).
+- `npm run verify:all` green: skill-mirror, everything-mirror (new `bin/*.mjs` + bundle copy), routing-targets, doc-runtime-claims, docs-substrings (tool counts), typecheck.
+- Full test suite green; specifically the gateguard-state, gateguard-hook, mcp-server, and new gateguard-clear suites.
+- Manual: trip the live gate, run `ci_gateguard_clear` and the CLI, confirm retry is allowed without hand-seeding any dir.
+
+## Rollout / deploy
+
+- Ship via a feature branch + PR off `origin/main` (never direct to main).
+- Global host deploy (per the PR #193 pattern): after merge, refresh the plugin so the cache picks up the new `gateguard.mjs`, `mcp-server.mjs`, and `bin/gateguard-clear.mjs`. Because the cache only refreshes on a version bump, decide at PR time whether to cut a patch version or hot-patch the cache for immediate effect.
+
+## Risks & open questions
+
+- **Tool-count assertions** (Phase 0) — `mcp-server.test.mts` and `verify:docs-substrings` pin counts; both must move together or the gate fails.
+- **MCP server env** — if the server process lacks `CLAUDE_PROJECT_DIR`, its git-toplevel branch must still canonicalize to the hook's dir; the `--state` override and canonicalization both de-risk this, but Phase 3 should assert the resolved dir equals the hook's for the same project.
+- **Param shape** — `file_paths: string[]` vs single `file_path`; coerce a lone string to a one-element array to be forgiving.
+- **Cap semantics on partial clear** — clearing a MultiEdit batch that straddles the cap clears some and reports the rest; the agent must see which were skipped (already in the return shape).

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -88,14 +88,10 @@ function extractFilePaths(toolInput) {
         return [toolInput.command];
     return [];
 }
+// The call site only reads this inside the block branch, where at least one
+// path is uncleared; an all-cleared batch returns "" and is never consumed.
 function firstUnclearedFilePath(toolInput, state) {
-    const filePaths = extractFilePaths(toolInput);
-    const uncleared = filePaths.find((path) => !isFileCleared(state, path));
-    if (uncleared)
-        return uncleared;
-    if (filePaths.length > 0)
-        return filePaths[0];
-    return "";
+    return extractFilePaths(toolInput).find((path) => !isFileCleared(state, path)) ?? "";
 }
 function countDistinctNewFilePaths(filePaths, state) {
     return new Set(filePaths.filter((path) => !isFileCleared(state, path)).map((path) => canonicalizeFileKey(path))).size;
@@ -112,7 +108,7 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
     const pathList = filePaths.filter((p) => p !== "");
     const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
-    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => `"${p}"`).join(" ");
+    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(" ");
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
         "",

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -28,7 +28,7 @@
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { MAX_CLEARED_FILES, isCapReached, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, isCapReached, isFileCleared, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
     Grep: "allow",
@@ -88,17 +88,17 @@ function extractFilePaths(toolInput) {
         return [toolInput.command];
     return [];
 }
-function firstUnclearedFilePath(toolInput, clearedFiles) {
+function firstUnclearedFilePath(toolInput, state) {
     const filePaths = extractFilePaths(toolInput);
-    const uncleared = filePaths.find((path) => !(path in clearedFiles));
+    const uncleared = filePaths.find((path) => !isFileCleared(state, path));
     if (uncleared)
         return uncleared;
     if (filePaths.length > 0)
         return filePaths[0];
     return "";
 }
-function countDistinctNewFilePaths(filePaths, clearedFiles) {
-    return new Set(filePaths.filter((path) => !(path in clearedFiles))).size;
+function countDistinctNewFilePaths(filePaths, state) {
+    return new Set(filePaths.filter((path) => !isFileCleared(state, path)).map((path) => canonicalizeFileKey(path))).size;
 }
 function formatFileTarget(filePaths) {
     const nonEmpty = filePaths.filter((path) => path !== "");
@@ -110,6 +110,9 @@ function formatFileTarget(filePaths) {
 }
 function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
+    const pathList = filePaths.filter((p) => p !== "");
+    const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
+    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => `"${p}"`).join(" ");
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
         "",
@@ -118,13 +121,13 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "  3. If this file reads/writes data files, show field names, structure, and date format",
         "  4. Quote the user's current instruction verbatim",
         "",
-        "Then clear the gate and retry the same call. Two clearance paths:",
-        `  A. Portable (works on every harness): append each path above to "cleared_files" in`,
-        `     ${stateFilePath} with a non-destructive Bash write, then retry. Bash is not gated`,
-        "     unless the command itself is destructive.",
-        "  B. Inline: retry with `_gateguard_facts_presented: true` in tool_input. This only works",
-        "     where the harness forwards unknown tool params; Claude Code's strict tool schema",
-        "     rejects it with InputValidationError, so use path A on Claude Code.",
+        "Then clear the gate and retry the same call. Any one of:",
+        `  A. MCP tool:  ci_gateguard_clear  {file_paths: [${jsonArray}]}`,
+        `  B. CLI (Bash, never gated): node "\${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" ${cliArgs}`,
+        `  C. Manual: append each path to "cleared_files" in ${stateFilePath} via a non-destructive Bash write.`,
+        "  Clearance matches regardless of drive-letter case or path separator.",
+        "  (On harnesses that forward unknown tool params you may instead retry with",
+        "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A/B/C.)",
     ].join("\n");
 }
 function buildDestructiveBashReason(command) {
@@ -183,10 +186,10 @@ function main() {
     const stateFilePath = join(sessionDir, "gateguard-session.json");
     const state = loadState(sessionDir);
     const filePaths = extractFilePaths(toolInput);
-    const filePath = firstUnclearedFilePath(toolInput, state.cleared_files);
+    const filePath = firstUnclearedFilePath(toolInput, state);
     const factsFlagged = toolInput._gateguard_facts_presented === true;
-    const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => path in state.cleared_files);
-    const newFileCount = countDistinctNewFilePaths(filePaths, state.cleared_files);
+    const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => isFileCleared(state, path));
+    const newFileCount = countDistinctNewFilePaths(filePaths, state);
     if (!factsFlagged && !alreadyCleared) {
         emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath], stateFilePath) });
         return;

--- a/lib/gateguard-state.mjs
+++ b/lib/gateguard-state.mjs
@@ -29,7 +29,7 @@ export function resolveSessionDir() {
         return fromEnv;
     const home = process.env.HOME || process.env.USERPROFILE || homedir();
     const projectRoot = resolveProjectRoot();
-    const projectHash = createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+    const projectHash = createHash("sha256").update(canonicalizeProjectRoot(projectRoot)).digest("hex").slice(0, 12);
     return join(home, ".claude", "instincts", projectHash);
 }
 function resolveProjectRoot() {
@@ -79,7 +79,59 @@ export function markFileCleared(state, filePath) {
         ...state,
         cleared_files: {
             ...state.cleared_files,
-            [filePath]: { cleared_at: new Date().toISOString() },
+            [canonicalizeFileKey(filePath)]: { cleared_at: new Date().toISOString() },
         },
     };
+}
+// Canonicalize a path so the hook and any clearance helper agree regardless of
+// which process resolved it. Two processes can supply the same directory in
+// different forms — CLAUDE_PROJECT_DIR gives `d:/...` (lowercase drive) while
+// `git rev-parse --show-toplevel` gives `D:/...` (uppercase) — and tool inputs
+// vary by separator. Normalizing the drive-letter case and separators (only;
+// directory/file-name case is preserved) makes the hash and the per-file key
+// stable. Relative and POSIX paths have no drive letter or backslash, so they
+// pass through unchanged and existing relative-key state keeps matching.
+function canonicalizePath(p) {
+    let out = p.replace(/\\/g, "/");
+    if (/^[A-Za-z]:/.test(out)) {
+        out = out.charAt(0).toLowerCase() + out.slice(1);
+    }
+    if (out.length > 1 && out.endsWith("/")) {
+        out = out.slice(0, -1);
+    }
+    return out;
+}
+export function canonicalizeProjectRoot(p) {
+    return canonicalizePath(p);
+}
+export function canonicalizeFileKey(p) {
+    return canonicalizePath(p);
+}
+export function isFileCleared(state, filePath) {
+    return canonicalizeFileKey(filePath) in state.cleared_files;
+}
+// Shared clearance writer used by the MCP tool and the CLI. Loads, marks each
+// not-yet-cleared canonical key (respecting MAX_CLEARED_FILES), and saves once.
+// Idempotent across path forms; returns what it cleared and what it skipped for
+// the cap so callers can report partial results on a MultiEdit-sized batch.
+export function clearFiles(sessionDir, filePaths) {
+    const cleared = [];
+    const skippedForCap = [];
+    let state = loadState(sessionDir);
+    for (const filePath of filePaths) {
+        const key = canonicalizeFileKey(filePath);
+        if (key in state.cleared_files) {
+            continue; // already cleared — idempotent, no cap charge
+        }
+        if (Object.keys(state.cleared_files).length >= MAX_CLEARED_FILES) {
+            skippedForCap.push(filePath);
+            continue;
+        }
+        state = markFileCleared(state, filePath);
+        cleared.push(key);
+    }
+    if (cleared.length > 0) {
+        saveState(sessionDir, state);
+    }
+    return { cleared, skippedForCap };
 }

--- a/lib/gateguard-state.mjs
+++ b/lib/gateguard-state.mjs
@@ -96,7 +96,7 @@ function canonicalizePath(p) {
     if (/^[A-Za-z]:/.test(out)) {
         out = out.charAt(0).toLowerCase() + out.slice(1);
     }
-    if (out.length > 1 && out.endsWith("/")) {
+    while (out.length > 1 && out.endsWith("/")) {
         out = out.slice(0, -1);
     }
     return out;

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -127,6 +127,26 @@ const BEGINNER_TOOL_ENTRIES = [
             required: ["summary"],
         },
     },
+    {
+        name: "ci_gateguard_clear",
+        description: "Clear the GateGuard gate for one or more files after presenting the required facts (importers, affected APIs, data schema, the user's instruction). Records canonical per-file clearance in the session state the hook reads, so the next Edit/Write to those paths is allowed. Clearance matches regardless of drive-letter case or path separator. Available in beginner mode because the gate fires for every install.",
+        manifestWhat: "Clear the GateGuard gate for files after presenting facts",
+        inputSchema: {
+            type: "object",
+            properties: {
+                file_paths: {
+                    type: "array",
+                    description: "File paths to clear — the paths named in the GateGuard block reason",
+                    items: { type: "string" },
+                },
+                file_path: {
+                    type: "string",
+                    description: "A single file path to clear (alternative to file_paths)",
+                },
+            },
+            required: [],
+        },
+    },
 ];
 const EXPERT_TOOL_ENTRIES = [
     {

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -15,6 +15,10 @@
     {
       "name": "ci_reflect",
       "what": "Reflect on what you did this session"
+    },
+    {
+      "name": "ci_gateguard_clear",
+      "what": "Clear the GateGuard gate for files after presenting facts"
     }
   ],
   "setup": {

--- a/plugins/continuous-improvement/bin/gateguard-clear.mjs
+++ b/plugins/continuous-improvement/bin/gateguard-clear.mjs
@@ -31,6 +31,10 @@ function main() {
             files.push(arg);
         }
     }
+    if (argv.includes("--state") && stateFile === "") {
+        process.stderr.write("--state requires a <gateguard-session.json> path argument\n");
+        process.exit(2);
+    }
     if (files.length === 0) {
         process.stderr.write("usage: gateguard-clear <file_path> [<file_path>...] [--state <gateguard-session.json>]\n");
         process.exit(2);

--- a/plugins/continuous-improvement/bin/gateguard-clear.mjs
+++ b/plugins/continuous-improvement/bin/gateguard-clear.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * gateguard-clear — record GateGuard clearance for files from the Bash route.
+ *
+ * The GateGuard PreToolUse hook blocks the first Edit/Write per file and prints
+ * the session-state path in its block reason. After presenting the required
+ * facts, run this to clear the gate so the retry is allowed. Bash is not gated
+ * (unless the command is destructive), so this surface always works — including
+ * where the ci_gateguard_clear MCP tool is not connected.
+ *
+ * Usage:
+ *   node bin/gateguard-clear.mjs <file_path> [<file_path>...] [--state <path>]
+ *
+ * Default resolves the session dir canonically, the same way the hook does.
+ * --state <path> writes that exact gateguard-session.json — the path the block
+ * reason prints — bypassing resolution for any residual env mismatch.
+ */
+import { dirname, join } from "node:path";
+import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
+function main() {
+    const argv = process.argv.slice(2);
+    const files = [];
+    let stateFile = "";
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === "--state") {
+            stateFile = argv[i + 1] ?? "";
+            i += 1;
+        }
+        else {
+            files.push(arg);
+        }
+    }
+    if (files.length === 0) {
+        process.stderr.write("usage: gateguard-clear <file_path> [<file_path>...] [--state <gateguard-session.json>]\n");
+        process.exit(2);
+    }
+    // clearFiles writes <sessionDir>/gateguard-session.json. With --state the
+    // caller hands us the full state-file path the block reason printed, so the
+    // session dir is its parent.
+    const sessionDir = stateFile ? dirname(stateFile) : resolveSessionDir();
+    const { cleared, skippedForCap } = clearFiles(sessionDir, files);
+    process.stdout.write(`Cleared ${cleared.length}: ${cleared.length > 0 ? cleared.join(", ") : "(none — already cleared)"}\n`);
+    if (skippedForCap.length > 0) {
+        process.stdout.write(`Skipped — session cap of ${MAX_CLEARED_FILES} reached: ${skippedForCap.join(", ")}\n`);
+    }
+    process.stdout.write(`State: ${join(sessionDir, "gateguard-session.json")}\n`);
+}
+main();

--- a/plugins/continuous-improvement/bin/mcp-server.mjs
+++ b/plugins/continuous-improvement/bin/mcp-server.mjs
@@ -21,6 +21,7 @@ import { PACKAGE_NAME, VERSION, getToolDefinitions, isPluginMode, } from "../lib
 import { formatDriftReport, parseGoalFromPlan, scoreObservations, } from "../lib/goal-state.mjs";
 import { buildIndex, formatRecallHits, parseSince, query as queryRecall, } from "../lib/recall-index.mjs";
 import { draftFromCandidate, extractTrajectories, findCandidates, formatCandidates, serializeDraft, } from "../lib/skill-distill.mjs";
+import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 function getHomeDir() {
     return process.env.HOME || process.env.USERPROFILE || homedir();
 }
@@ -504,6 +505,33 @@ function handleTool(name, params) {
                 "  (or just `1. None — goal met, stop.` if the original goal is fully resolved)",
             ].join("\n");
             return text(reflection);
+        }
+        case "ci_gateguard_clear": {
+            // Beginner-available on purpose: the GateGuard hook fires for every
+            // install, so the clearance action must too. Resolves the session dir via
+            // gateguard-state (canonical), the same way the hook does, so the marker
+            // lands where the hook looks regardless of how each process spelled the
+            // project root.
+            const rawList = Array.isArray(params.file_paths) ? params.file_paths : [];
+            const listPaths = rawList.filter((value) => typeof value === "string" && value.length > 0);
+            const single = getString(params.file_path).trim();
+            const paths = single ? [...listPaths, single] : listPaths;
+            if (paths.length === 0) {
+                return error("file_paths is required — pass the file path(s) named in the GateGuard block reason, e.g. { file_paths: [\"src/x.ts\"] }.");
+            }
+            const sessionDir = resolveSessionDir();
+            const { cleared, skippedForCap } = clearFiles(sessionDir, paths);
+            const lines = [
+                "## GateGuard clearance",
+                "",
+                `**State file:** ${join(sessionDir, "gateguard-session.json")}`,
+                `**Cleared (${cleared.length}):** ${cleared.length > 0 ? cleared.join(", ") : "(none — already cleared)"}`,
+            ];
+            if (skippedForCap.length > 0) {
+                lines.push(`**Skipped — session cap of ${MAX_CLEARED_FILES} reached (${skippedForCap.length}):** ${skippedForCap.join(", ")}`, "Start a new session to reset the gate.");
+            }
+            lines.push("", "Retry the Edit/Write now — it will pass.");
+            return text(lines.join("\n"));
         }
         case "ci_reinforce": {
             if (MODE !== "expert") {

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -88,14 +88,10 @@ function extractFilePaths(toolInput) {
         return [toolInput.command];
     return [];
 }
+// The call site only reads this inside the block branch, where at least one
+// path is uncleared; an all-cleared batch returns "" and is never consumed.
 function firstUnclearedFilePath(toolInput, state) {
-    const filePaths = extractFilePaths(toolInput);
-    const uncleared = filePaths.find((path) => !isFileCleared(state, path));
-    if (uncleared)
-        return uncleared;
-    if (filePaths.length > 0)
-        return filePaths[0];
-    return "";
+    return extractFilePaths(toolInput).find((path) => !isFileCleared(state, path)) ?? "";
 }
 function countDistinctNewFilePaths(filePaths, state) {
     return new Set(filePaths.filter((path) => !isFileCleared(state, path)).map((path) => canonicalizeFileKey(path))).size;
@@ -112,7 +108,7 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
     const pathList = filePaths.filter((p) => p !== "");
     const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
-    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => `"${p}"`).join(" ");
+    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(" ");
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
         "",

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -28,7 +28,7 @@
  */
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { MAX_CLEARED_FILES, isCapReached, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, isCapReached, isFileCleared, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
     Grep: "allow",
@@ -88,17 +88,17 @@ function extractFilePaths(toolInput) {
         return [toolInput.command];
     return [];
 }
-function firstUnclearedFilePath(toolInput, clearedFiles) {
+function firstUnclearedFilePath(toolInput, state) {
     const filePaths = extractFilePaths(toolInput);
-    const uncleared = filePaths.find((path) => !(path in clearedFiles));
+    const uncleared = filePaths.find((path) => !isFileCleared(state, path));
     if (uncleared)
         return uncleared;
     if (filePaths.length > 0)
         return filePaths[0];
     return "";
 }
-function countDistinctNewFilePaths(filePaths, clearedFiles) {
-    return new Set(filePaths.filter((path) => !(path in clearedFiles))).size;
+function countDistinctNewFilePaths(filePaths, state) {
+    return new Set(filePaths.filter((path) => !isFileCleared(state, path)).map((path) => canonicalizeFileKey(path))).size;
 }
 function formatFileTarget(filePaths) {
     const nonEmpty = filePaths.filter((path) => path !== "");
@@ -110,6 +110,9 @@ function formatFileTarget(filePaths) {
 }
 function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
+    const pathList = filePaths.filter((p) => p !== "");
+    const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
+    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => `"${p}"`).join(" ");
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
         "",
@@ -118,13 +121,13 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "  3. If this file reads/writes data files, show field names, structure, and date format",
         "  4. Quote the user's current instruction verbatim",
         "",
-        "Then clear the gate and retry the same call. Two clearance paths:",
-        `  A. Portable (works on every harness): append each path above to "cleared_files" in`,
-        `     ${stateFilePath} with a non-destructive Bash write, then retry. Bash is not gated`,
-        "     unless the command itself is destructive.",
-        "  B. Inline: retry with `_gateguard_facts_presented: true` in tool_input. This only works",
-        "     where the harness forwards unknown tool params; Claude Code's strict tool schema",
-        "     rejects it with InputValidationError, so use path A on Claude Code.",
+        "Then clear the gate and retry the same call. Any one of:",
+        `  A. MCP tool:  ci_gateguard_clear  {file_paths: [${jsonArray}]}`,
+        `  B. CLI (Bash, never gated): node "\${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" ${cliArgs}`,
+        `  C. Manual: append each path to "cleared_files" in ${stateFilePath} via a non-destructive Bash write.`,
+        "  Clearance matches regardless of drive-letter case or path separator.",
+        "  (On harnesses that forward unknown tool params you may instead retry with",
+        "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A/B/C.)",
     ].join("\n");
 }
 function buildDestructiveBashReason(command) {
@@ -183,10 +186,10 @@ function main() {
     const stateFilePath = join(sessionDir, "gateguard-session.json");
     const state = loadState(sessionDir);
     const filePaths = extractFilePaths(toolInput);
-    const filePath = firstUnclearedFilePath(toolInput, state.cleared_files);
+    const filePath = firstUnclearedFilePath(toolInput, state);
     const factsFlagged = toolInput._gateguard_facts_presented === true;
-    const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => path in state.cleared_files);
-    const newFileCount = countDistinctNewFilePaths(filePaths, state.cleared_files);
+    const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => isFileCleared(state, path));
+    const newFileCount = countDistinctNewFilePaths(filePaths, state);
     if (!factsFlagged && !alreadyCleared) {
         emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath], stateFilePath) });
         return;

--- a/plugins/continuous-improvement/lib/gateguard-state.mjs
+++ b/plugins/continuous-improvement/lib/gateguard-state.mjs
@@ -96,7 +96,7 @@ function canonicalizePath(p) {
     if (/^[A-Za-z]:/.test(out)) {
         out = out.charAt(0).toLowerCase() + out.slice(1);
     }
-    if (out.length > 1 && out.endsWith("/")) {
+    while (out.length > 1 && out.endsWith("/")) {
         out = out.slice(0, -1);
     }
     return out;

--- a/plugins/continuous-improvement/lib/gateguard-state.mjs
+++ b/plugins/continuous-improvement/lib/gateguard-state.mjs
@@ -1,0 +1,137 @@
+/**
+ * Gateguard per-session state.
+ *
+ * State file: <sessionDir>/gateguard-session.json. sessionDir resolves to
+ * GATEGUARD_SESSION_DIR (env override, used by tests) or
+ * ~/.claude/instincts/<projectHash>/ in production.
+ *
+ * V1 limitations (documented for honesty, not mitigated in code):
+ * - Honor system: clearance is granted whenever the agent sets
+ *   `_gateguard_facts_presented: true` in tool_input or has a prior per-file
+ *   marker. The hook cannot verify that real investigation occurred.
+ * - State-file deletion: rm'ing the state file resets every gate in the
+ *   session. Defensible because the session itself is the trust boundary;
+ *   the cap below limits cumulative damage.
+ * - Concurrency: two parallel hook invocations can race the read+write.
+ *   Acceptable trade-off vs OS-specific atomic-rename complexity on Windows.
+ * - Cap: MAX_CLEARED_FILES caps the number of distinct files a single
+ *   session can clear, bounding stuck-loop / rogue-agent damage.
+ */
+import { createHash } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { homedir } from "node:os";
+import { join } from "node:path";
+export const MAX_CLEARED_FILES = 50;
+export function resolveSessionDir() {
+    const fromEnv = process.env.GATEGUARD_SESSION_DIR;
+    if (fromEnv)
+        return fromEnv;
+    const home = process.env.HOME || process.env.USERPROFILE || homedir();
+    const projectRoot = resolveProjectRoot();
+    const projectHash = createHash("sha256").update(canonicalizeProjectRoot(projectRoot)).digest("hex").slice(0, 12);
+    return join(home, ".claude", "instincts", projectHash);
+}
+function resolveProjectRoot() {
+    const fromEnv = process.env.CLAUDE_PROJECT_DIR;
+    if (fromEnv)
+        return fromEnv;
+    try {
+        const root = execFileSync("git", ["rev-parse", "--show-toplevel"], {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
+        if (root)
+            return root;
+    }
+    catch {
+        // not in a git repo
+    }
+    return "global";
+}
+export function loadState(sessionDir) {
+    const path = join(sessionDir, "gateguard-session.json");
+    if (!existsSync(path)) {
+        return { created_at: new Date().toISOString(), cleared_files: {} };
+    }
+    try {
+        const raw = readFileSync(path, "utf8");
+        const parsed = JSON.parse(raw);
+        return {
+            created_at: parsed.created_at ?? new Date().toISOString(),
+            cleared_files: parsed.cleared_files ?? {},
+        };
+    }
+    catch {
+        return { created_at: new Date().toISOString(), cleared_files: {} };
+    }
+}
+export function saveState(sessionDir, state) {
+    if (!existsSync(sessionDir))
+        mkdirSync(sessionDir, { recursive: true });
+    writeFileSync(join(sessionDir, "gateguard-session.json"), `${JSON.stringify(state, null, 2)}\n`);
+}
+export function isCapReached(state) {
+    return Object.keys(state.cleared_files).length >= MAX_CLEARED_FILES;
+}
+export function markFileCleared(state, filePath) {
+    return {
+        ...state,
+        cleared_files: {
+            ...state.cleared_files,
+            [canonicalizeFileKey(filePath)]: { cleared_at: new Date().toISOString() },
+        },
+    };
+}
+// Canonicalize a path so the hook and any clearance helper agree regardless of
+// which process resolved it. Two processes can supply the same directory in
+// different forms — CLAUDE_PROJECT_DIR gives `d:/...` (lowercase drive) while
+// `git rev-parse --show-toplevel` gives `D:/...` (uppercase) — and tool inputs
+// vary by separator. Normalizing the drive-letter case and separators (only;
+// directory/file-name case is preserved) makes the hash and the per-file key
+// stable. Relative and POSIX paths have no drive letter or backslash, so they
+// pass through unchanged and existing relative-key state keeps matching.
+function canonicalizePath(p) {
+    let out = p.replace(/\\/g, "/");
+    if (/^[A-Za-z]:/.test(out)) {
+        out = out.charAt(0).toLowerCase() + out.slice(1);
+    }
+    if (out.length > 1 && out.endsWith("/")) {
+        out = out.slice(0, -1);
+    }
+    return out;
+}
+export function canonicalizeProjectRoot(p) {
+    return canonicalizePath(p);
+}
+export function canonicalizeFileKey(p) {
+    return canonicalizePath(p);
+}
+export function isFileCleared(state, filePath) {
+    return canonicalizeFileKey(filePath) in state.cleared_files;
+}
+// Shared clearance writer used by the MCP tool and the CLI. Loads, marks each
+// not-yet-cleared canonical key (respecting MAX_CLEARED_FILES), and saves once.
+// Idempotent across path forms; returns what it cleared and what it skipped for
+// the cap so callers can report partial results on a MultiEdit-sized batch.
+export function clearFiles(sessionDir, filePaths) {
+    const cleared = [];
+    const skippedForCap = [];
+    let state = loadState(sessionDir);
+    for (const filePath of filePaths) {
+        const key = canonicalizeFileKey(filePath);
+        if (key in state.cleared_files) {
+            continue; // already cleared — idempotent, no cap charge
+        }
+        if (Object.keys(state.cleared_files).length >= MAX_CLEARED_FILES) {
+            skippedForCap.push(filePath);
+            continue;
+        }
+        state = markFileCleared(state, filePath);
+        cleared.push(key);
+    }
+    if (cleared.length > 0) {
+        saveState(sessionDir, state);
+    }
+    return { cleared, skippedForCap };
+}

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -127,6 +127,26 @@ const BEGINNER_TOOL_ENTRIES = [
             required: ["summary"],
         },
     },
+    {
+        name: "ci_gateguard_clear",
+        description: "Clear the GateGuard gate for one or more files after presenting the required facts (importers, affected APIs, data schema, the user's instruction). Records canonical per-file clearance in the session state the hook reads, so the next Edit/Write to those paths is allowed. Clearance matches regardless of drive-letter case or path separator. Available in beginner mode because the gate fires for every install.",
+        manifestWhat: "Clear the GateGuard gate for files after presenting facts",
+        inputSchema: {
+            type: "object",
+            properties: {
+                file_paths: {
+                    type: "array",
+                    description: "File paths to clear — the paths named in the GateGuard block reason",
+                    items: { type: "string" },
+                },
+                file_path: {
+                    type: "string",
+                    description: "A single file path to clear (alternative to file_paths)",
+                },
+            },
+            required: [],
+        },
+    },
 ];
 const EXPERT_TOOL_ENTRIES = [
     {

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -140,9 +140,19 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 Smoke-test the runtime gate after install: ask Claude to write a throwaway file with no research first. The hook should return a `block` decision with a fact-list reason; Claude should pause rather than write.
 
+### Clearing the gate (after presenting the facts)
+
+The block reason prints the exact `gateguard-session.json` path and the clearance commands. Clearance matches a file regardless of drive-letter case or path separator (`d:\x` and `D:/x` resolve to the same key), so it no longer matters whether the hook and the helper spelled the project root differently. Any one of these allows the retry:
+
+- **MCP tool** (beginner + expert): `ci_gateguard_clear` with `file_paths: ["<path>", …]`.
+- **CLI** (Bash, never gated): `node "${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" "<path>"`; add `--state <gateguard-session.json>` to write the exact file the block reason printed.
+- **Manual**: append each path to `cleared_files` in the printed `gateguard-session.json` via a non-destructive Bash write.
+
+The inline `_gateguard_facts_presented: true` retry still works on harnesses that forward unknown tool params, but Claude Code's strict tool schema (`additionalProperties: false`) rejects it with `InputValidationError` — use one of the above on Claude Code.
+
 ### V1 honest limitations (not mitigated, documented)
 
-- **Honor system.** Clearance is recorded either by retrying with `_gateguard_facts_presented: true` in `tool_input` (only on harnesses that forward unknown tool params) or by appending the file path to `cleared_files` in the session state file with a non-destructive Bash write. Claude Code's strict tool schema (`additionalProperties: false`) rejects the inline flag with `InputValidationError`, so on Claude Code the state-file path is the working route. Either way the hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
+- **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
 - **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
 - **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
 

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -17,6 +17,10 @@
       "what": "Reflect on what you did this session"
     },
     {
+      "name": "ci_gateguard_clear",
+      "what": "Clear the GateGuard gate for files after presenting facts"
+    },
+    {
       "name": "ci_reinforce",
       "what": "Accept or reject instinct suggestions to tune confidence"
     },

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -140,9 +140,19 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 Smoke-test the runtime gate after install: ask Claude to write a throwaway file with no research first. The hook should return a `block` decision with a fact-list reason; Claude should pause rather than write.
 
+### Clearing the gate (after presenting the facts)
+
+The block reason prints the exact `gateguard-session.json` path and the clearance commands. Clearance matches a file regardless of drive-letter case or path separator (`d:\x` and `D:/x` resolve to the same key), so it no longer matters whether the hook and the helper spelled the project root differently. Any one of these allows the retry:
+
+- **MCP tool** (beginner + expert): `ci_gateguard_clear` with `file_paths: ["<path>", …]`.
+- **CLI** (Bash, never gated): `node "${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" "<path>"`; add `--state <gateguard-session.json>` to write the exact file the block reason printed.
+- **Manual**: append each path to `cleared_files` in the printed `gateguard-session.json` via a non-destructive Bash write.
+
+The inline `_gateguard_facts_presented: true` retry still works on harnesses that forward unknown tool params, but Claude Code's strict tool schema (`additionalProperties: false`) rejects it with `InputValidationError` — use one of the above on Claude Code.
+
 ### V1 honest limitations (not mitigated, documented)
 
-- **Honor system.** Clearance is recorded either by retrying with `_gateguard_facts_presented: true` in `tool_input` (only on harnesses that forward unknown tool params) or by appending the file path to `cleared_files` in the session state file with a non-destructive Bash write. Claude Code's strict tool schema (`additionalProperties: false`) rejects the inline flag with `InputValidationError`, so on Claude Code the state-file path is the working route. Either way the hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
+- **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
 - **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
 - **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
 

--- a/src/bin/gateguard-clear.mts
+++ b/src/bin/gateguard-clear.mts
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * gateguard-clear — record GateGuard clearance for files from the Bash route.
+ *
+ * The GateGuard PreToolUse hook blocks the first Edit/Write per file and prints
+ * the session-state path in its block reason. After presenting the required
+ * facts, run this to clear the gate so the retry is allowed. Bash is not gated
+ * (unless the command is destructive), so this surface always works — including
+ * where the ci_gateguard_clear MCP tool is not connected.
+ *
+ * Usage:
+ *   node bin/gateguard-clear.mjs <file_path> [<file_path>...] [--state <path>]
+ *
+ * Default resolves the session dir canonically, the same way the hook does.
+ * --state <path> writes that exact gateguard-session.json — the path the block
+ * reason prints — bypassing resolution for any residual env mismatch.
+ */
+
+import { dirname, join } from "node:path";
+
+import {
+  MAX_CLEARED_FILES,
+  clearFiles,
+  resolveSessionDir,
+} from "../lib/gateguard-state.mjs";
+
+function main(): void {
+  const argv = process.argv.slice(2);
+  const files: string[] = [];
+  let stateFile = "";
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]!;
+    if (arg === "--state") {
+      stateFile = argv[i + 1] ?? "";
+      i += 1;
+    } else {
+      files.push(arg);
+    }
+  }
+
+  if (files.length === 0) {
+    process.stderr.write(
+      "usage: gateguard-clear <file_path> [<file_path>...] [--state <gateguard-session.json>]\n",
+    );
+    process.exit(2);
+  }
+
+  // clearFiles writes <sessionDir>/gateguard-session.json. With --state the
+  // caller hands us the full state-file path the block reason printed, so the
+  // session dir is its parent.
+  const sessionDir = stateFile ? dirname(stateFile) : resolveSessionDir();
+  const { cleared, skippedForCap } = clearFiles(sessionDir, files);
+
+  process.stdout.write(
+    `Cleared ${cleared.length}: ${cleared.length > 0 ? cleared.join(", ") : "(none — already cleared)"}\n`,
+  );
+  if (skippedForCap.length > 0) {
+    process.stdout.write(
+      `Skipped — session cap of ${MAX_CLEARED_FILES} reached: ${skippedForCap.join(", ")}\n`,
+    );
+  }
+  process.stdout.write(`State: ${join(sessionDir, "gateguard-session.json")}\n`);
+}
+
+main();

--- a/src/bin/gateguard-clear.mts
+++ b/src/bin/gateguard-clear.mts
@@ -38,6 +38,11 @@ function main(): void {
     }
   }
 
+  if (argv.includes("--state") && stateFile === "") {
+    process.stderr.write("--state requires a <gateguard-session.json> path argument\n");
+    process.exit(2);
+  }
+
   if (files.length === 0) {
     process.stderr.write(
       "usage: gateguard-clear <file_path> [<file_path>...] [--state <gateguard-session.json>]\n",

--- a/src/bin/generate-plugin-manifests.mts
+++ b/src/bin/generate-plugin-manifests.mts
@@ -207,6 +207,10 @@ async function writePluginBundle(): Promise<void> {
     copyFileTo(join(REPO_ROOT, "bin", "observe.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "observe.mjs")),
     copyFileTo(join(REPO_ROOT, "bin", "backfill.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "backfill.mjs")),
     copyFileTo(
+      join(REPO_ROOT, "bin", "gateguard-clear.mjs"),
+      join(PLUGIN_BUNDLE_DIR, "bin", "gateguard-clear.mjs"),
+    ),
+    copyFileTo(
       join(REPO_ROOT, "lib", "gateguard-state.mjs"),
       join(PLUGIN_BUNDLE_DIR, "lib", "gateguard-state.mjs"),
     ),

--- a/src/bin/generate-plugin-manifests.mts
+++ b/src/bin/generate-plugin-manifests.mts
@@ -207,6 +207,10 @@ async function writePluginBundle(): Promise<void> {
     copyFileTo(join(REPO_ROOT, "bin", "observe.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "observe.mjs")),
     copyFileTo(join(REPO_ROOT, "bin", "backfill.mjs"), join(PLUGIN_BUNDLE_DIR, "bin", "backfill.mjs")),
     copyFileTo(
+      join(REPO_ROOT, "lib", "gateguard-state.mjs"),
+      join(PLUGIN_BUNDLE_DIR, "lib", "gateguard-state.mjs"),
+    ),
+    copyFileTo(
       join(REPO_ROOT, "lib", "plugin-metadata.mjs"),
       join(PLUGIN_BUNDLE_DIR, "lib", "plugin-metadata.mjs"),
     ),

--- a/src/bin/mcp-server.mts
+++ b/src/bin/mcp-server.mts
@@ -48,6 +48,11 @@ import {
   serializeDraft,
   type DistillObservation,
 } from "../lib/skill-distill.mjs";
+import {
+  MAX_CLEARED_FILES,
+  clearFiles,
+  resolveSessionDir,
+} from "../lib/gateguard-state.mjs";
 
 type Level = "AUTO-APPLY" | "SUGGEST" | "ANALYZE" | "CAPTURE";
 type InstinctScope = "project" | "global";
@@ -655,6 +660,40 @@ function handleTool(name: string, params: Record<string, unknown>): ToolResult {
         "  (or just `1. None — goal met, stop.` if the original goal is fully resolved)",
       ].join("\n");
       return text(reflection);
+    }
+
+    case "ci_gateguard_clear": {
+      // Beginner-available on purpose: the GateGuard hook fires for every
+      // install, so the clearance action must too. Resolves the session dir via
+      // gateguard-state (canonical), the same way the hook does, so the marker
+      // lands where the hook looks regardless of how each process spelled the
+      // project root.
+      const rawList = Array.isArray(params.file_paths) ? params.file_paths : [];
+      const listPaths = rawList.filter((value): value is string => typeof value === "string" && value.length > 0);
+      const single = getString(params.file_path).trim();
+      const paths = single ? [...listPaths, single] : listPaths;
+      if (paths.length === 0) {
+        return error(
+          "file_paths is required — pass the file path(s) named in the GateGuard block reason, e.g. { file_paths: [\"src/x.ts\"] }.",
+        );
+      }
+
+      const sessionDir = resolveSessionDir();
+      const { cleared, skippedForCap } = clearFiles(sessionDir, paths);
+      const lines = [
+        "## GateGuard clearance",
+        "",
+        `**State file:** ${join(sessionDir, "gateguard-session.json")}`,
+        `**Cleared (${cleared.length}):** ${cleared.length > 0 ? cleared.join(", ") : "(none — already cleared)"}`,
+      ];
+      if (skippedForCap.length > 0) {
+        lines.push(
+          `**Skipped — session cap of ${MAX_CLEARED_FILES} reached (${skippedForCap.length}):** ${skippedForCap.join(", ")}`,
+          "Start a new session to reset the gate.",
+        );
+      }
+      lines.push("", "Retry the Edit/Write now — it will pass.");
+      return text(lines.join("\n"));
     }
 
     case "ci_reinforce": {

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -31,11 +31,14 @@ import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import {
   MAX_CLEARED_FILES,
+  canonicalizeFileKey,
   isCapReached,
+  isFileCleared,
   loadState,
   markFileCleared,
   resolveSessionDir,
   saveState,
+  type GateguardState,
 } from "../lib/gateguard-state.mjs";
 
 type GateType = "allow" | "mutating-file" | "destructive-bash";
@@ -118,19 +121,18 @@ function extractFilePaths(toolInput: ToolInput): string[] {
   return [];
 }
 
-function firstUnclearedFilePath(toolInput: ToolInput, clearedFiles: Record<string, { cleared_at: string }>): string {
+function firstUnclearedFilePath(toolInput: ToolInput, state: GateguardState): string {
   const filePaths = extractFilePaths(toolInput);
-  const uncleared = filePaths.find((path) => !(path in clearedFiles));
+  const uncleared = filePaths.find((path) => !isFileCleared(state, path));
   if (uncleared) return uncleared;
   if (filePaths.length > 0) return filePaths[0]!;
   return "";
 }
 
-function countDistinctNewFilePaths(
-  filePaths: string[],
-  clearedFiles: Record<string, { cleared_at: string }>,
-): number {
-  return new Set(filePaths.filter((path) => !(path in clearedFiles))).size;
+function countDistinctNewFilePaths(filePaths: string[], state: GateguardState): number {
+  return new Set(
+    filePaths.filter((path) => !isFileCleared(state, path)).map((path) => canonicalizeFileKey(path)),
+  ).size;
 }
 
 function formatFileTarget(filePaths: string[]): string {
@@ -142,6 +144,9 @@ function formatFileTarget(filePaths: string[]): string {
 
 function buildMutatingFileReason(toolName: string, filePaths: string[], stateFilePath: string): string {
   const target = formatFileTarget(filePaths);
+  const pathList = filePaths.filter((p) => p !== "");
+  const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
+  const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => `"${p}"`).join(" ");
   return [
     `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
     "",
@@ -150,13 +155,13 @@ function buildMutatingFileReason(toolName: string, filePaths: string[], stateFil
     "  3. If this file reads/writes data files, show field names, structure, and date format",
     "  4. Quote the user's current instruction verbatim",
     "",
-    "Then clear the gate and retry the same call. Two clearance paths:",
-    `  A. Portable (works on every harness): append each path above to "cleared_files" in`,
-    `     ${stateFilePath} with a non-destructive Bash write, then retry. Bash is not gated`,
-    "     unless the command itself is destructive.",
-    "  B. Inline: retry with `_gateguard_facts_presented: true` in tool_input. This only works",
-    "     where the harness forwards unknown tool params; Claude Code's strict tool schema",
-    "     rejects it with InputValidationError, so use path A on Claude Code.",
+    "Then clear the gate and retry the same call. Any one of:",
+    `  A. MCP tool:  ci_gateguard_clear  {file_paths: [${jsonArray}]}`,
+    `  B. CLI (Bash, never gated): node "\${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" ${cliArgs}`,
+    `  C. Manual: append each path to "cleared_files" in ${stateFilePath} via a non-destructive Bash write.`,
+    "  Clearance matches regardless of drive-letter case or path separator.",
+    "  (On harnesses that forward unknown tool params you may instead retry with",
+    "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A/B/C.)",
   ].join("\n");
 }
 
@@ -220,10 +225,10 @@ function main(): void {
   const stateFilePath = join(sessionDir, "gateguard-session.json");
   const state = loadState(sessionDir);
   const filePaths = extractFilePaths(toolInput);
-  const filePath = firstUnclearedFilePath(toolInput, state.cleared_files);
+  const filePath = firstUnclearedFilePath(toolInput, state);
   const factsFlagged = toolInput._gateguard_facts_presented === true;
-  const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => path in state.cleared_files);
-  const newFileCount = countDistinctNewFilePaths(filePaths, state.cleared_files);
+  const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => isFileCleared(state, path));
+  const newFileCount = countDistinctNewFilePaths(filePaths, state);
 
   if (!factsFlagged && !alreadyCleared) {
     emit({ decision: "block", reason: buildMutatingFileReason(toolName, filePaths.length > 0 ? filePaths : [filePath], stateFilePath) });

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -121,12 +121,10 @@ function extractFilePaths(toolInput: ToolInput): string[] {
   return [];
 }
 
+// The call site only reads this inside the block branch, where at least one
+// path is uncleared; an all-cleared batch returns "" and is never consumed.
 function firstUnclearedFilePath(toolInput: ToolInput, state: GateguardState): string {
-  const filePaths = extractFilePaths(toolInput);
-  const uncleared = filePaths.find((path) => !isFileCleared(state, path));
-  if (uncleared) return uncleared;
-  if (filePaths.length > 0) return filePaths[0]!;
-  return "";
+  return extractFilePaths(toolInput).find((path) => !isFileCleared(state, path)) ?? "";
 }
 
 function countDistinctNewFilePaths(filePaths: string[], state: GateguardState): number {
@@ -146,7 +144,7 @@ function buildMutatingFileReason(toolName: string, filePaths: string[], stateFil
   const target = formatFileTarget(filePaths);
   const pathList = filePaths.filter((p) => p !== "");
   const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
-  const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => `"${p}"`).join(" ");
+  const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(" ");
   return [
     `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
     "",

--- a/src/lib/gateguard-state.mts
+++ b/src/lib/gateguard-state.mts
@@ -36,7 +36,7 @@ export function resolveSessionDir(): string {
   if (fromEnv) return fromEnv;
   const home = process.env.HOME || process.env.USERPROFILE || homedir();
   const projectRoot = resolveProjectRoot();
-  const projectHash = createHash("sha256").update(projectRoot).digest("hex").slice(0, 12);
+  const projectHash = createHash("sha256").update(canonicalizeProjectRoot(projectRoot)).digest("hex").slice(0, 12);
   return join(home, ".claude", "instincts", projectHash);
 }
 
@@ -89,7 +89,67 @@ export function markFileCleared(state: GateguardState, filePath: string): Gategu
     ...state,
     cleared_files: {
       ...state.cleared_files,
-      [filePath]: { cleared_at: new Date().toISOString() },
+      [canonicalizeFileKey(filePath)]: { cleared_at: new Date().toISOString() },
     },
   };
+}
+
+// Canonicalize a path so the hook and any clearance helper agree regardless of
+// which process resolved it. Two processes can supply the same directory in
+// different forms — CLAUDE_PROJECT_DIR gives `d:/...` (lowercase drive) while
+// `git rev-parse --show-toplevel` gives `D:/...` (uppercase) — and tool inputs
+// vary by separator. Normalizing the drive-letter case and separators (only;
+// directory/file-name case is preserved) makes the hash and the per-file key
+// stable. Relative and POSIX paths have no drive letter or backslash, so they
+// pass through unchanged and existing relative-key state keeps matching.
+function canonicalizePath(p: string): string {
+  let out = p.replace(/\\/g, "/");
+  if (/^[A-Za-z]:/.test(out)) {
+    out = out.charAt(0).toLowerCase() + out.slice(1);
+  }
+  if (out.length > 1 && out.endsWith("/")) {
+    out = out.slice(0, -1);
+  }
+  return out;
+}
+
+export function canonicalizeProjectRoot(p: string): string {
+  return canonicalizePath(p);
+}
+
+export function canonicalizeFileKey(p: string): string {
+  return canonicalizePath(p);
+}
+
+export function isFileCleared(state: GateguardState, filePath: string): boolean {
+  return canonicalizeFileKey(filePath) in state.cleared_files;
+}
+
+// Shared clearance writer used by the MCP tool and the CLI. Loads, marks each
+// not-yet-cleared canonical key (respecting MAX_CLEARED_FILES), and saves once.
+// Idempotent across path forms; returns what it cleared and what it skipped for
+// the cap so callers can report partial results on a MultiEdit-sized batch.
+export function clearFiles(
+  sessionDir: string,
+  filePaths: string[],
+): { cleared: string[]; skippedForCap: string[] } {
+  const cleared: string[] = [];
+  const skippedForCap: string[] = [];
+  let state = loadState(sessionDir);
+  for (const filePath of filePaths) {
+    const key = canonicalizeFileKey(filePath);
+    if (key in state.cleared_files) {
+      continue; // already cleared — idempotent, no cap charge
+    }
+    if (Object.keys(state.cleared_files).length >= MAX_CLEARED_FILES) {
+      skippedForCap.push(filePath);
+      continue;
+    }
+    state = markFileCleared(state, filePath);
+    cleared.push(key);
+  }
+  if (cleared.length > 0) {
+    saveState(sessionDir, state);
+  }
+  return { cleared, skippedForCap };
 }

--- a/src/lib/gateguard-state.mts
+++ b/src/lib/gateguard-state.mts
@@ -107,7 +107,7 @@ function canonicalizePath(p: string): string {
   if (/^[A-Za-z]:/.test(out)) {
     out = out.charAt(0).toLowerCase() + out.slice(1);
   }
-  if (out.length > 1 && out.endsWith("/")) {
+  while (out.length > 1 && out.endsWith("/")) {
     out = out.slice(0, -1);
   }
   return out;

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -258,6 +258,27 @@ const BEGINNER_TOOL_ENTRIES: ToolCatalogEntry[] = [
       required: ["summary"],
     },
   },
+  {
+    name: "ci_gateguard_clear",
+    description:
+      "Clear the GateGuard gate for one or more files after presenting the required facts (importers, affected APIs, data schema, the user's instruction). Records canonical per-file clearance in the session state the hook reads, so the next Edit/Write to those paths is allowed. Clearance matches regardless of drive-letter case or path separator. Available in beginner mode because the gate fires for every install.",
+    manifestWhat: "Clear the GateGuard gate for files after presenting facts",
+    inputSchema: {
+      type: "object",
+      properties: {
+        file_paths: {
+          type: "array",
+          description: "File paths to clear — the paths named in the GateGuard block reason",
+          items: { type: "string" },
+        },
+        file_path: {
+          type: "string",
+          description: "A single file path to clear (alternative to file_paths)",
+        },
+      },
+      required: [],
+    },
+  },
 ];
 
 const EXPERT_TOOL_ENTRIES: ToolCatalogEntry[] = [

--- a/src/test/gateguard-clear.test.mts
+++ b/src/test/gateguard-clear.test.mts
@@ -1,0 +1,74 @@
+/**
+ * Tests for the gateguard-clear CLI — the no-MCP clearance surface the block
+ * reason names. Spawns the built bin/gateguard-clear.mjs like the hook test
+ * spawns the hook.
+ */
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const CLI = join(__dirname, "..", "bin", "gateguard-clear.mjs");
+
+function run(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    encoding: "utf8",
+    env: { ...process.env, ...env },
+  });
+}
+
+describe("bin/gateguard-clear.mjs", () => {
+  let dir = "";
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "ggclear-"));
+  });
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("clears a file via --state and records the canonical key", () => {
+    const state = join(dir, "gateguard-session.json");
+    const result = run(["D:\\proj\\a.ts", "--state", state]);
+    assert.equal(result.status, 0, result.stderr);
+    assert.ok(existsSync(state), "state file written");
+    const parsed = JSON.parse(readFileSync(state, "utf8")) as { cleared_files: Record<string, unknown> };
+    assert.ok("d:/proj/a.ts" in parsed.cleared_files, "canonical key recorded");
+    assert.match(result.stdout, /Cleared 1/);
+  });
+
+  it("clears multiple files in one call and creates the state dir", () => {
+    const state = join(dir, "nested", "gateguard-session.json");
+    const result = run(["x/one.ts", "x/two.ts", "--state", state]);
+    assert.equal(result.status, 0, result.stderr);
+    const parsed = JSON.parse(readFileSync(state, "utf8")) as { cleared_files: Record<string, unknown> };
+    assert.ok("x/one.ts" in parsed.cleared_files);
+    assert.ok("x/two.ts" in parsed.cleared_files);
+  });
+
+  it("exits non-zero with usage when no file paths are given", () => {
+    const result = run(["--state", join(dir, "gateguard-session.json")]);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /usage/i);
+  });
+
+  it("falls back to the resolved session dir when --state is omitted", () => {
+    const sess = mkdtempSync(join(tmpdir(), "ggclear-resolved-"));
+    try {
+      const result = run(["D:/proj/b.ts"], { GATEGUARD_SESSION_DIR: sess });
+      assert.equal(result.status, 0, result.stderr);
+      const parsed = JSON.parse(readFileSync(join(sess, "gateguard-session.json"), "utf8")) as {
+        cleared_files: Record<string, unknown>;
+      };
+      assert.ok("d:/proj/b.ts" in parsed.cleared_files);
+    } finally {
+      rmSync(sess, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test/gateguard-clear.test.mts
+++ b/src/test/gateguard-clear.test.mts
@@ -58,6 +58,12 @@ describe("bin/gateguard-clear.mjs", () => {
     assert.match(result.stderr, /usage/i);
   });
 
+  it("errors when --state is given without a path argument", () => {
+    const result = run(["file.ts", "--state"]);
+    assert.equal(result.status, 2);
+    assert.match(result.stderr, /--state requires/i);
+  });
+
   it("falls back to the resolved session dir when --state is omitted", () => {
     const sess = mkdtempSync(join(tmpdir(), "ggclear-resolved-"));
     try {

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -280,5 +280,18 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it("block reason CLI args are JSON-escaped, not bare-quoted", () => {
+      const dir = mkdtempSync(join(tmpdir(), "gateguard-esc-"));
+      try {
+        const decision = runHook("Write", { file_path: 'a"b.ts', content: "x" }, dir);
+        assert.equal(decision.decision, "block");
+        const cliLine = (decision.reason ?? "").split("\n").find((line) => line.includes("gateguard-clear.mjs")) ?? "";
+        assert.match(cliLine, /a\\"b\.ts/, "CLI arg must be JSON-escaped");
+        assert.doesNotMatch(cliLine, /"a"b\.ts"/, "CLI arg must not contain a bare unescaped quote");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -253,4 +253,32 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
       assert.equal(retry.decision, "allow", "retry is allowed after all files are cleared");
     });
   });
+
+  describe("canonical clearance + block-reason clearance action", () => {
+    it("recognizes a clearance across drive-case and separator forms", () => {
+      const dir = mkdtempSync(join(tmpdir(), "gateguard-canon-"));
+      try {
+        seedClearedFiles(dir, ["d:/proj/file.ts"]);
+        const decision = runHook("Write", { file_path: "D:\\proj\\file.ts", content: "x" }, dir);
+        assert.equal(
+          decision.decision,
+          "allow",
+          "a file cleared as d:/proj/file.ts must be allowed when received as D:\\proj\\file.ts",
+        );
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    it("block reason names the in-harness clearance action", () => {
+      const dir = mkdtempSync(join(tmpdir(), "gateguard-reason-"));
+      try {
+        const decision = runHook("Write", { file_path: "fresh-file.ts", content: "x" }, dir);
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /ci_gateguard_clear|gateguard-clear\.mjs/);
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+  });
 });

--- a/src/test/gateguard-state.test.mts
+++ b/src/test/gateguard-state.test.mts
@@ -39,6 +39,11 @@ describe("canonicalizeProjectRoot", () => {
     assert.equal(canonicalizeProjectRoot("d:/Ai/x/"), "d:/Ai/x");
   });
 
+  it("collapses multiple trailing slashes", () => {
+    assert.equal(canonicalizeProjectRoot("d:/proj//"), "d:/proj");
+    assert.equal(canonicalizeFileKey("d:/Ai/x///"), "d:/Ai/x");
+  });
+
   it("leaves a POSIX path unchanged", () => {
     assert.equal(canonicalizeProjectRoot("/home/u/x"), "/home/u/x");
   });

--- a/src/test/gateguard-state.test.mts
+++ b/src/test/gateguard-state.test.mts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for gateguard-state path canonicalization + the shared clearance
+ * writer. Canonicalization is what lets the hook and any clearance helper agree
+ * on the session dir and the per-file key regardless of drive-letter case or
+ * path separator — the root cause of the marker-seeding fragility.
+ */
+
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+
+import {
+  MAX_CLEARED_FILES,
+  canonicalizeFileKey,
+  canonicalizeProjectRoot,
+  clearFiles,
+  isFileCleared,
+  loadState,
+  markFileCleared,
+  resolveSessionDir,
+} from "../lib/gateguard-state.mjs";
+
+describe("canonicalizeProjectRoot", () => {
+  it("lowercases a Windows drive letter", () => {
+    assert.equal(canonicalizeProjectRoot("D:/Ai/x"), "d:/Ai/x");
+  });
+
+  it("converts backslashes to forward slashes", () => {
+    assert.equal(canonicalizeProjectRoot("d:\\Ai\\x"), "d:/Ai/x");
+  });
+
+  it("normalizes drive case AND separators together", () => {
+    assert.equal(canonicalizeProjectRoot("D:\\Ai\\x"), "d:/Ai/x");
+  });
+
+  it("strips a trailing slash", () => {
+    assert.equal(canonicalizeProjectRoot("d:/Ai/x/"), "d:/Ai/x");
+  });
+
+  it("leaves a POSIX path unchanged", () => {
+    assert.equal(canonicalizeProjectRoot("/home/u/x"), "/home/u/x");
+  });
+
+  it("leaves a relative path unchanged", () => {
+    assert.equal(canonicalizeProjectRoot("x"), "x");
+  });
+});
+
+describe("canonicalizeFileKey", () => {
+  it("normalizes drive case and separators", () => {
+    assert.equal(canonicalizeFileKey("D:\\Ai\\x\\a.ts"), "d:/Ai/x/a.ts");
+  });
+
+  it("is a no-op on relative keys so existing test keys keep matching", () => {
+    assert.equal(canonicalizeFileKey("scratch.txt"), "scratch.txt");
+  });
+
+  it("does NOT lowercase directory/file names, only the drive letter", () => {
+    assert.equal(canonicalizeFileKey("D:/Ai/MyDir/File.TS"), "d:/Ai/MyDir/File.TS");
+  });
+});
+
+describe("resolveSessionDir canonical hashing", () => {
+  it("resolves drive-case/separator-equivalent roots to the same dir", () => {
+    const prevProj = process.env.CLAUDE_PROJECT_DIR;
+    const prevSess = process.env.GATEGUARD_SESSION_DIR;
+    try {
+      delete process.env.GATEGUARD_SESSION_DIR;
+      process.env.CLAUDE_PROJECT_DIR = "d:\\Ai\\continuous-improvement";
+      const a = resolveSessionDir();
+      process.env.CLAUDE_PROJECT_DIR = "D:/Ai/continuous-improvement/";
+      const b = resolveSessionDir();
+      assert.equal(a, b);
+    } finally {
+      if (prevProj === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+      else process.env.CLAUDE_PROJECT_DIR = prevProj;
+      if (prevSess === undefined) delete process.env.GATEGUARD_SESSION_DIR;
+      else process.env.GATEGUARD_SESSION_DIR = prevSess;
+    }
+  });
+});
+
+describe("markFileCleared / isFileCleared canonical matching", () => {
+  it("markFileCleared stores the canonical key", () => {
+    const state = markFileCleared({ created_at: "t", cleared_files: {} }, "D:\\Ai\\a.ts");
+    assert.ok("d:/Ai/a.ts" in state.cleared_files);
+  });
+
+  it("isFileCleared matches across drive-case and separator forms", () => {
+    const state = markFileCleared({ created_at: "t", cleared_files: {} }, "D:\\Ai\\a.ts");
+    assert.equal(isFileCleared(state, "d:/Ai/a.ts"), true);
+    assert.equal(isFileCleared(state, "D:\\Ai\\a.ts"), true);
+    assert.equal(isFileCleared(state, "d:\\Ai\\a.ts"), true);
+  });
+
+  it("isFileCleared is false for an uncleared file", () => {
+    const state = markFileCleared({ created_at: "t", cleared_files: {} }, "D:\\Ai\\a.ts");
+    assert.equal(isFileCleared(state, "d:/Ai/b.ts"), false);
+  });
+});
+
+describe("clearFiles shared writer", () => {
+  let dir = "";
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "gg-state-"));
+  });
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("writes canonical markers and reports them cleared", () => {
+    const result = clearFiles(dir, ["D:\\Ai\\a.ts", "d:/Ai/b.ts"]);
+    assert.deepEqual([...result.cleared].sort(), ["d:/Ai/a.ts", "d:/Ai/b.ts"]);
+    const state = loadState(dir);
+    assert.ok("d:/Ai/a.ts" in state.cleared_files);
+    assert.ok("d:/Ai/b.ts" in state.cleared_files);
+  });
+
+  it("is idempotent across path forms for the same canonical key", () => {
+    clearFiles(dir, ["D:\\Ai\\c.ts"]);
+    const before = Object.keys(loadState(dir).cleared_files).length;
+    clearFiles(dir, ["d:/Ai/c.ts"]);
+    assert.equal(Object.keys(loadState(dir).cleared_files).length, before);
+  });
+
+  it("respects the cap and reports skipped files", () => {
+    const capDir = mkdtempSync(join(tmpdir(), "gg-cap-"));
+    try {
+      const seed = Array.from({ length: MAX_CLEARED_FILES }, (_, i) => `/seed/${i}.ts`);
+      clearFiles(capDir, seed);
+      const result = clearFiles(capDir, ["/over/the/cap.ts"]);
+      assert.deepEqual(result.cleared, []);
+      assert.deepEqual(result.skippedForCap, ["/over/the/cap.ts"]);
+    } finally {
+      rmSync(capDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/src/test/mcp-server.test.mts
+++ b/src/test/mcp-server.test.mts
@@ -193,11 +193,37 @@ describe("MCP server — beginner mode", () => {
     assert.equal(response.result.serverInfo.version, VERSION);
   });
 
-  it("lists beginner tools only (3 tools)", async () => {
+  it("lists beginner tools only (4 tools)", async () => {
     const response = await client.send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
     const names = response.result.tools.map((tool: { name: string }) => tool.name);
     assert.deepEqual(names, getToolNames("beginner"));
     assert.ok(!names.includes("ci_reinforce"), "Should NOT include expert tools");
+  });
+
+  it("ci_gateguard_clear is available in beginner mode and clears the gate canonically", async () => {
+    const list = await client.send({ jsonrpc: "2.0", id: 40, method: "tools/list", params: {} });
+    const names = list.result.tools.map((tool: { name: string }) => tool.name);
+    assert.ok(names.includes("ci_gateguard_clear"), "ci_gateguard_clear must be in beginner tools/list");
+
+    const response = await client.send({
+      jsonrpc: "2.0",
+      id: 41,
+      method: "tools/call",
+      params: { name: "ci_gateguard_clear", arguments: { file_paths: ["D:\\proj\\x.ts"] } },
+    });
+    assert.ok(!response.result.isError, "ci_gateguard_clear should succeed");
+    assert.match(response.result.content[0].text, /d:\/proj\/x\.ts/, "reports the canonical cleared key");
+  });
+
+  it("ci_gateguard_clear requires at least one path", async () => {
+    const response = await client.send({
+      jsonrpc: "2.0",
+      id: 42,
+      method: "tools/call",
+      params: { name: "ci_gateguard_clear", arguments: {} },
+    });
+    assert.ok(response.result.isError, "empty clear request must error");
+    assert.match(response.result.content[0].text, /file_paths/);
   });
 
   it("ci_status returns project info", async () => {
@@ -389,7 +415,7 @@ describe("MCP server — expert mode", () => {
     }
   });
 
-  it("lists all 12 tools in expert mode", async () => {
+  it("lists all expert tools (18) in expert mode", async () => {
     await client.send({ jsonrpc: "2.0", id: 10, method: "initialize", params: {} });
     const response = await client.send({ jsonrpc: "2.0", id: 11, method: "tools/list", params: {} });
     const names = response.result.tools.map((tool: { name: string }) => tool.name);

--- a/test/gateguard-clear.test.mjs
+++ b/test/gateguard-clear.test.mjs
@@ -1,0 +1,63 @@
+/**
+ * Tests for the gateguard-clear CLI — the no-MCP clearance surface the block
+ * reason names. Spawns the built bin/gateguard-clear.mjs like the hook test
+ * spawns the hook.
+ */
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const CLI = join(__dirname, "..", "bin", "gateguard-clear.mjs");
+function run(args, env = {}) {
+    return spawnSync(process.execPath, [CLI, ...args], {
+        encoding: "utf8",
+        env: { ...process.env, ...env },
+    });
+}
+describe("bin/gateguard-clear.mjs", () => {
+    let dir = "";
+    before(() => {
+        dir = mkdtempSync(join(tmpdir(), "ggclear-"));
+    });
+    after(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+    it("clears a file via --state and records the canonical key", () => {
+        const state = join(dir, "gateguard-session.json");
+        const result = run(["D:\\proj\\a.ts", "--state", state]);
+        assert.equal(result.status, 0, result.stderr);
+        assert.ok(existsSync(state), "state file written");
+        const parsed = JSON.parse(readFileSync(state, "utf8"));
+        assert.ok("d:/proj/a.ts" in parsed.cleared_files, "canonical key recorded");
+        assert.match(result.stdout, /Cleared 1/);
+    });
+    it("clears multiple files in one call and creates the state dir", () => {
+        const state = join(dir, "nested", "gateguard-session.json");
+        const result = run(["x/one.ts", "x/two.ts", "--state", state]);
+        assert.equal(result.status, 0, result.stderr);
+        const parsed = JSON.parse(readFileSync(state, "utf8"));
+        assert.ok("x/one.ts" in parsed.cleared_files);
+        assert.ok("x/two.ts" in parsed.cleared_files);
+    });
+    it("exits non-zero with usage when no file paths are given", () => {
+        const result = run(["--state", join(dir, "gateguard-session.json")]);
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /usage/i);
+    });
+    it("falls back to the resolved session dir when --state is omitted", () => {
+        const sess = mkdtempSync(join(tmpdir(), "ggclear-resolved-"));
+        try {
+            const result = run(["D:/proj/b.ts"], { GATEGUARD_SESSION_DIR: sess });
+            assert.equal(result.status, 0, result.stderr);
+            const parsed = JSON.parse(readFileSync(join(sess, "gateguard-session.json"), "utf8"));
+            assert.ok("d:/proj/b.ts" in parsed.cleared_files);
+        }
+        finally {
+            rmSync(sess, { recursive: true, force: true });
+        }
+    });
+});

--- a/test/gateguard-clear.test.mjs
+++ b/test/gateguard-clear.test.mjs
@@ -48,6 +48,11 @@ describe("bin/gateguard-clear.mjs", () => {
         assert.equal(result.status, 2);
         assert.match(result.stderr, /usage/i);
     });
+    it("errors when --state is given without a path argument", () => {
+        const result = run(["file.ts", "--state"]);
+        assert.equal(result.status, 2);
+        assert.match(result.stderr, /--state requires/i);
+    });
     it("falls back to the resolved session dir when --state is omitted", () => {
         const sess = mkdtempSync(join(tmpdir(), "ggclear-resolved-"));
         try {

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -200,5 +200,18 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
                 rmSync(dir, { recursive: true, force: true });
             }
         });
+        it("block reason CLI args are JSON-escaped, not bare-quoted", () => {
+            const dir = mkdtempSync(join(tmpdir(), "gateguard-esc-"));
+            try {
+                const decision = runHook("Write", { file_path: 'a"b.ts', content: "x" }, dir);
+                assert.equal(decision.decision, "block");
+                const cliLine = (decision.reason ?? "").split("\n").find((line) => line.includes("gateguard-clear.mjs")) ?? "";
+                assert.match(cliLine, /a\\"b\.ts/, "CLI arg must be JSON-escaped");
+                assert.doesNotMatch(cliLine, /"a"b\.ts"/, "CLI arg must not contain a bare unescaped quote");
+            }
+            finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
     });
 });

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -177,4 +177,28 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
             assert.equal(retry.decision, "allow", "retry is allowed after all files are cleared");
         });
     });
+    describe("canonical clearance + block-reason clearance action", () => {
+        it("recognizes a clearance across drive-case and separator forms", () => {
+            const dir = mkdtempSync(join(tmpdir(), "gateguard-canon-"));
+            try {
+                seedClearedFiles(dir, ["d:/proj/file.ts"]);
+                const decision = runHook("Write", { file_path: "D:\\proj\\file.ts", content: "x" }, dir);
+                assert.equal(decision.decision, "allow", "a file cleared as d:/proj/file.ts must be allowed when received as D:\\proj\\file.ts");
+            }
+            finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+        it("block reason names the in-harness clearance action", () => {
+            const dir = mkdtempSync(join(tmpdir(), "gateguard-reason-"));
+            try {
+                const decision = runHook("Write", { file_path: "fresh-file.ts", content: "x" }, dir);
+                assert.equal(decision.decision, "block");
+                assert.match(decision.reason ?? "", /ci_gateguard_clear|gateguard-clear\.mjs/);
+            }
+            finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
+    });
 });

--- a/test/gateguard-state.test.mjs
+++ b/test/gateguard-state.test.mjs
@@ -23,6 +23,10 @@ describe("canonicalizeProjectRoot", () => {
     it("strips a trailing slash", () => {
         assert.equal(canonicalizeProjectRoot("d:/Ai/x/"), "d:/Ai/x");
     });
+    it("collapses multiple trailing slashes", () => {
+        assert.equal(canonicalizeProjectRoot("d:/proj//"), "d:/proj");
+        assert.equal(canonicalizeFileKey("d:/Ai/x///"), "d:/Ai/x");
+    });
     it("leaves a POSIX path unchanged", () => {
         assert.equal(canonicalizeProjectRoot("/home/u/x"), "/home/u/x");
     });

--- a/test/gateguard-state.test.mjs
+++ b/test/gateguard-state.test.mjs
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for gateguard-state path canonicalization + the shared clearance
+ * writer. Canonicalization is what lets the hook and any clearance helper agree
+ * on the session dir and the per-file key regardless of drive-letter case or
+ * path separator — the root cause of the marker-seeding fragility.
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { after, before, describe, it } from "node:test";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, canonicalizeProjectRoot, clearFiles, isFileCleared, loadState, markFileCleared, resolveSessionDir, } from "../lib/gateguard-state.mjs";
+describe("canonicalizeProjectRoot", () => {
+    it("lowercases a Windows drive letter", () => {
+        assert.equal(canonicalizeProjectRoot("D:/Ai/x"), "d:/Ai/x");
+    });
+    it("converts backslashes to forward slashes", () => {
+        assert.equal(canonicalizeProjectRoot("d:\\Ai\\x"), "d:/Ai/x");
+    });
+    it("normalizes drive case AND separators together", () => {
+        assert.equal(canonicalizeProjectRoot("D:\\Ai\\x"), "d:/Ai/x");
+    });
+    it("strips a trailing slash", () => {
+        assert.equal(canonicalizeProjectRoot("d:/Ai/x/"), "d:/Ai/x");
+    });
+    it("leaves a POSIX path unchanged", () => {
+        assert.equal(canonicalizeProjectRoot("/home/u/x"), "/home/u/x");
+    });
+    it("leaves a relative path unchanged", () => {
+        assert.equal(canonicalizeProjectRoot("x"), "x");
+    });
+});
+describe("canonicalizeFileKey", () => {
+    it("normalizes drive case and separators", () => {
+        assert.equal(canonicalizeFileKey("D:\\Ai\\x\\a.ts"), "d:/Ai/x/a.ts");
+    });
+    it("is a no-op on relative keys so existing test keys keep matching", () => {
+        assert.equal(canonicalizeFileKey("scratch.txt"), "scratch.txt");
+    });
+    it("does NOT lowercase directory/file names, only the drive letter", () => {
+        assert.equal(canonicalizeFileKey("D:/Ai/MyDir/File.TS"), "d:/Ai/MyDir/File.TS");
+    });
+});
+describe("resolveSessionDir canonical hashing", () => {
+    it("resolves drive-case/separator-equivalent roots to the same dir", () => {
+        const prevProj = process.env.CLAUDE_PROJECT_DIR;
+        const prevSess = process.env.GATEGUARD_SESSION_DIR;
+        try {
+            delete process.env.GATEGUARD_SESSION_DIR;
+            process.env.CLAUDE_PROJECT_DIR = "d:\\Ai\\continuous-improvement";
+            const a = resolveSessionDir();
+            process.env.CLAUDE_PROJECT_DIR = "D:/Ai/continuous-improvement/";
+            const b = resolveSessionDir();
+            assert.equal(a, b);
+        }
+        finally {
+            if (prevProj === undefined)
+                delete process.env.CLAUDE_PROJECT_DIR;
+            else
+                process.env.CLAUDE_PROJECT_DIR = prevProj;
+            if (prevSess === undefined)
+                delete process.env.GATEGUARD_SESSION_DIR;
+            else
+                process.env.GATEGUARD_SESSION_DIR = prevSess;
+        }
+    });
+});
+describe("markFileCleared / isFileCleared canonical matching", () => {
+    it("markFileCleared stores the canonical key", () => {
+        const state = markFileCleared({ created_at: "t", cleared_files: {} }, "D:\\Ai\\a.ts");
+        assert.ok("d:/Ai/a.ts" in state.cleared_files);
+    });
+    it("isFileCleared matches across drive-case and separator forms", () => {
+        const state = markFileCleared({ created_at: "t", cleared_files: {} }, "D:\\Ai\\a.ts");
+        assert.equal(isFileCleared(state, "d:/Ai/a.ts"), true);
+        assert.equal(isFileCleared(state, "D:\\Ai\\a.ts"), true);
+        assert.equal(isFileCleared(state, "d:\\Ai\\a.ts"), true);
+    });
+    it("isFileCleared is false for an uncleared file", () => {
+        const state = markFileCleared({ created_at: "t", cleared_files: {} }, "D:\\Ai\\a.ts");
+        assert.equal(isFileCleared(state, "d:/Ai/b.ts"), false);
+    });
+});
+describe("clearFiles shared writer", () => {
+    let dir = "";
+    before(() => {
+        dir = mkdtempSync(join(tmpdir(), "gg-state-"));
+    });
+    after(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+    it("writes canonical markers and reports them cleared", () => {
+        const result = clearFiles(dir, ["D:\\Ai\\a.ts", "d:/Ai/b.ts"]);
+        assert.deepEqual([...result.cleared].sort(), ["d:/Ai/a.ts", "d:/Ai/b.ts"]);
+        const state = loadState(dir);
+        assert.ok("d:/Ai/a.ts" in state.cleared_files);
+        assert.ok("d:/Ai/b.ts" in state.cleared_files);
+    });
+    it("is idempotent across path forms for the same canonical key", () => {
+        clearFiles(dir, ["D:\\Ai\\c.ts"]);
+        const before = Object.keys(loadState(dir).cleared_files).length;
+        clearFiles(dir, ["d:/Ai/c.ts"]);
+        assert.equal(Object.keys(loadState(dir).cleared_files).length, before);
+    });
+    it("respects the cap and reports skipped files", () => {
+        const capDir = mkdtempSync(join(tmpdir(), "gg-cap-"));
+        try {
+            const seed = Array.from({ length: MAX_CLEARED_FILES }, (_, i) => `/seed/${i}.ts`);
+            clearFiles(capDir, seed);
+            const result = clearFiles(capDir, ["/over/the/cap.ts"]);
+            assert.deepEqual(result.cleared, []);
+            assert.deepEqual(result.skippedForCap, ["/over/the/cap.ts"]);
+        }
+        finally {
+            rmSync(capDir, { recursive: true, force: true });
+        }
+    });
+});

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -138,11 +138,34 @@ describe("MCP server — beginner mode", () => {
         assert.equal(response.result.serverInfo.name, PACKAGE_NAME);
         assert.equal(response.result.serverInfo.version, VERSION);
     });
-    it("lists beginner tools only (3 tools)", async () => {
+    it("lists beginner tools only (4 tools)", async () => {
         const response = await client.send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
         const names = response.result.tools.map((tool) => tool.name);
         assert.deepEqual(names, getToolNames("beginner"));
         assert.ok(!names.includes("ci_reinforce"), "Should NOT include expert tools");
+    });
+    it("ci_gateguard_clear is available in beginner mode and clears the gate canonically", async () => {
+        const list = await client.send({ jsonrpc: "2.0", id: 40, method: "tools/list", params: {} });
+        const names = list.result.tools.map((tool) => tool.name);
+        assert.ok(names.includes("ci_gateguard_clear"), "ci_gateguard_clear must be in beginner tools/list");
+        const response = await client.send({
+            jsonrpc: "2.0",
+            id: 41,
+            method: "tools/call",
+            params: { name: "ci_gateguard_clear", arguments: { file_paths: ["D:\\proj\\x.ts"] } },
+        });
+        assert.ok(!response.result.isError, "ci_gateguard_clear should succeed");
+        assert.match(response.result.content[0].text, /d:\/proj\/x\.ts/, "reports the canonical cleared key");
+    });
+    it("ci_gateguard_clear requires at least one path", async () => {
+        const response = await client.send({
+            jsonrpc: "2.0",
+            id: 42,
+            method: "tools/call",
+            params: { name: "ci_gateguard_clear", arguments: {} },
+        });
+        assert.ok(response.result.isError, "empty clear request must error");
+        assert.match(response.result.content[0].text, /file_paths/);
     });
     it("ci_status returns project info", async () => {
         const response = await client.send({
@@ -312,7 +335,7 @@ describe("MCP server — expert mode", () => {
             // Windows can briefly keep stdio handles open after the child exits.
         }
     });
-    it("lists all 12 tools in expert mode", async () => {
+    it("lists all expert tools (18) in expert mode", async () => {
         await client.send({ jsonrpc: "2.0", id: 10, method: "initialize", params: {} });
         const response = await client.send({ jsonrpc: "2.0", id: 11, method: "tools/list", params: {} });
         const names = response.result.tools.map((tool) => tool.name);


### PR DESCRIPTION
## Problem

GateGuard's per-session clearance is keyed by a project-hash dir (`sha256(projectRoot)`) and per-file keys (the raw `tool_input.file_path`). Both are path-form sensitive: the **hook** resolves the root from `CLAUDE_PROJECT_DIR` (`d:/…` lowercase drive) while the **MCP server** uses `git rev-parse --show-toplevel` (`D:/…` uppercase), and file keys vary by separator. Different form → different dir/key → a clearance written by one process is invisible to the hook. The only way to clear the gate today is to hand-seed every path variant across several candidate session dirs (observed live while shipping #193).

Follows #193, which fixed the block reason to stop instructing the impossible `_gateguard_facts_presented` inline flag (rejected by Claude Code's strict tool schema). This PR removes the remaining fragility.

## What changed (one commit per layer)

- **lib canonicalization** (`gateguard-state.mts`) — `canonicalizeProjectRoot` / `canonicalizeFileKey` (lowercase drive letter, `\`→`/`, collapse trailing slashes; relative/POSIX paths pass through unchanged). `resolveSessionDir` hashes the canonical root; `markFileCleared` stores the canonical key. New `isFileCleared` (canonical lookup) and `clearFiles` (shared writer: idempotent across forms, respects the 50-file cap, reports cleared + cap-skipped).
- **hook** (`gateguard.mts`) — matches clearance through `isFileCleared`, so `d:/x` and `D:\x` are the same key. Block reason now names the in-harness clearance action.
- **MCP tool** `ci_gateguard_clear` — registered in `BEGINNER_TOOL_ENTRIES` (available in **beginner + expert**, since the gate fires for every install); resolves the session dir the same way the hook does.
- **CLI** `bin/gateguard-clear.mjs` — the no-MCP, Bash-route surface; `--state <path>` targets the exact `gateguard-session.json` the block reason prints.
- **bundle plumbing** — `generate-plugin-manifests` now copies `lib/gateguard-state.mjs` + `bin/gateguard-clear.mjs` into the bundle (the bundled hook/mcp-server import the lib — a pre-existing gap in the `./plugins/continuous-improvement` distribution).
- **docs** — skill (both mirrors) "Clearing the gate" section; CHANGELOG `[Unreleased]`.

Spec + plan: `docs/plans/2026-06-07-gateguard-canonical-clearance.md`.

## Adversarial review

Ran a 3-lens review (correctness / security / build-integrity) → verify pass. **5 findings confirmed and fixed** in `ad48c2e`: double-slash canonicalization, block-reason CLI-arg escaping (`JSON.stringify`), `--state`-without-value guard, dead-branch removal, and the **bundle `gateguard-state.mjs` exec bit** (100644→100755, would have failed Linux CI `verify:generated`). **3 findings dismissed** on verification as false positives (local-only `--state` write; dot-dot keys never used as write paths; cheap internal over-cap iteration).

## Verification

- `npm run verify:all` green — 11 invariants + typecheck (everything-mirror 55, skill-mirror 25, doc-runtime-claims, derived tool counts beginner 4 / expert 18).
- gateguard suites 71/71 (state 19, hook 18, clear 5, mcp 34 incl. the new cross-form + clearance tests). Full suite green modulo the documented `observe.sh` ETIMEDOUT load-flake (passes in isolation).
- Every `.mts` rebuilt before staging; both new bundle `.mjs` carry the exec bit.

## Test plan

- [x] RED→GREEN per layer; review-fix tests RED before fix
- [x] `verify:all` green
- [x] cross-form clearance + cap + escaping + `--state` guard covered
- [ ] CI green on Linux runner