### PR TITLE
ci(pages): auto-deploy docs/landing to Cloudflare Pages on main

### DIFF
--- a/.github/workflows/cf-pages.yml
+++ b/.github/workflows/cf-pages.yml
@@ -1,0 +1,29 @@
+name: Deploy Landing to Cloudflare Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/landing/**'
+      - '.github/workflows/cf-pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cf-pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Deploy docs/landing to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy docs/landing --project-name=continuous-improvement --branch=main --commit-dirty=true


### PR DESCRIPTION
## Summary

Adds a GitHub Action that deploys `docs/landing` to the Cloudflare Pages project `continuous-improvement` on every `main` push that touches `docs/landing` (and via manual dispatch). This keeps the live custom domain **continuous-improvement.dev** in sync with the repo.

## Why

`continuous-improvement.dev` is hosted on Cloudflare Pages (apex `CNAME -> continuous-improvement.pages.dev`, proxied, valid SSL). The initial deploy was a one-off manual `wrangler` upload, so future landing-page edits would auto-deploy to `github.io` (via `pages.yml`) but **not** to the `.dev` domain, leaving it stale. This closes that gap; the two deploys run independently and in parallel.

## Required repo secrets

For the workflow to run after merge:

- **`CLOUDFLARE_API_TOKEN`** — a Cloudflare API token scoped to **Account -> Cloudflare Pages -> Edit**. You add this (it is a credential).
- **`CLOUDFLARE_ACCOUNT_ID`** — `4b74285069061c907cf51c1ec89d65a9`. Already set via `gh secret set` (not sensitive).

## Behavior

- Triggers: push to `main` under `docs/landing/**` or this workflow file; plus `workflow_dispatch`.
- Runs `cloudflare/wrangler-action@v3` -> `wrangler pages deploy docs/landing --project-name=continuous-improvement --branch=main` (production).

## Test plan

- [ ] Add the `CLOUDFLARE_API_TOKEN` secret.
- [ ] After merge, edit `docs/landing` (or run the workflow via dispatch) and confirm a new Cloudflare Pages production deployment plus `continuous-improvement.dev` reflecting it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)