### PR TITLE
chore(release): cut v3.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [3.11.0] — 2026-06-07
+
 ### Added
 
 - **In-harness GateGuard clearance: `ci_gateguard_clear` + `bin/gateguard-clear.mjs`** — after presenting the facts, clear the gate with the `ci_gateguard_clear` MCP tool (available in beginner *and* expert mode, since the gate fires for every install) or the `gateguard-clear.mjs` CLI over the hook-allowed Bash route, instead of hand-writing the session-state JSON. Both take one or more file paths and record clearance through the shared canonical writer; the CLI accepts `--state <gateguard-session.json>` to target the exact file the block reason prints.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.",
-      "version": "3.10.0",
+      "version": "3.11.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.10.0",
+  "version": "3.11.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## Why

`v3.10.0` was cut in #177 (2026-06-03) but **never reached npm** — its release workflow ([run 26837289058](https://github.com/naimkatiman/continuous-improvement/actions/runs/26837289058)) passed build + verify + tests, then died at `npm publish` with `E404 PUT` — the classic symptom of an expired/invalid `NPM_TOKEN`. npm `latest` is still **3.9.2**.

Since that cut, four PRs merged and sat in CHANGELOG `[Unreleased]`. This release promotes them from HEAD instead of re-running the stale `v3.10.0` tag (which points 4 PRs behind).

## What

- `package.json` **3.10.0 -> 3.11.0**; the 6 derived manifests regenerated via `npm run build` (root + plugin `marketplace.json`, `plugin.json`, `beginner.json`, `expert.json`, `package-lock.json`).
- CHANGELOG `[Unreleased] -> [3.11.0] — 2026-06-07`, covering:
  - `ci_gateguard_clear` MCP tool + `gateguard-clear.mjs` CLI (#195) — **new surface, minor bump**
  - GateGuard block-reason + canonical-path-match fixes (#193/#195)
  - Landing rebuild on `continuous-improvement.dev` (#192)
  - Pages auto-deploy on main (#196)

npm `latest` will go **3.9.2 -> 3.11.0**; 3.10.0 stays an unpublished milestone.

## Operator prerequisite (blocks publish)

Before tagging `v3.11.0`, **`NPM_TOKEN` must be refreshed** (new npm granular/automation token with publish rights to `continuous-improvement`, then `gh secret set NPM_TOKEN`). Without it, `release.yml` fails the same way.

## Verification

- `npm run verify:all` — green (11 invariants + typecheck)
- Test suite: 776/779. The 3 failures are documented wall-clock flakes in `observe.sh`/hook timing on a loaded Windows host (different timing tests fail run-to-run); this diff is version-string + CHANGELOG only and imports into none of them. CI (Linux) is authoritative.

## Post-merge release steps

1. Fast-forward main.
2. `git tag v3.11.0 && git push origin v3.11.0` -> `release.yml` publishes to npm, creates the GH release, updates the `v3` major tag.
3. `claude plugin update continuous-improvement` to refresh the local cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
