### PR TITLE
feat(positioning): reframe identity from seatbelt to intelligence amplifier

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.",
+      "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
       "version": "3.11.0",
       "source": "./plugins/continuous-improvement",
       "author": {

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to continuous-improvement
 
-Thanks for your interest in making AI agents more disciplined! Here's how to contribute.
+Thanks for your interest in making AI agents sharper and more effective! Here's how to contribute.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
   <img src="assets/combined.gif" alt="Before vs After — The 7 Laws of AI Agent Discipline" width="700" />
 </p>
 
-<h1 align="center">A seatbelt for Claude Code</h1>
+<h1 align="center">Claude Code that gets sharper every session</h1>
 
 <p align="center">
-  <b>Research first. Edit safely. Verify before done. Remember what worked.</b>
+  <b>Reasons deeper. Recalls what it already solved. Verifies before "done". Keeps every lesson.</b>
 </p>
 
 <p align="center">
-  <i>The 7 Laws of AI Agent Discipline — runtime hooks, enforcement skills, and project memory.</i>
+  <i>The 7 Laws of AI Agent Discipline — runtime hooks, instinct memory, and skills that compound what it learns.</i>
 </p>
 
 <p align="center">
@@ -26,13 +26,13 @@
   <b>New here?</b> → <a href="QUICKSTART.md">QUICKSTART.md</a> (2 minutes) · <a href="https://continuous-improvement.dev">continuous-improvement.dev</a>
 </p>
 
-> **What this is *not*:** a prompt template, a `CLAUDE.md`, or a vibes-based reminder. It is a runtime hook (`hooks/gateguard.mjs`) plus a bundled skill set that physically blocks `Edit` / `Write` / destructive `Bash` until the agent has done the work.
+> **What this is *not*:** a prompt template, a `CLAUDE.md`, or a vibes-based reminder. It is a runtime hook (`hooks/gateguard.mjs`) plus a bundled skill set that makes the agent ground every change in real facts — it physically blocks `Edit` / `Write` / destructive `Bash` until the investigation is done, so edits land on understanding instead of guesses.
 
 ---
 
 ## What this does
 
-Claude Code is powerful but skips the boring discipline: it edits before reading, guesses instead of checking, stacks five concerns into one commit, and says "done" without running tests. Continuous Improvement adds three layers that stop that:
+Claude Code is powerful but leaves intelligence on the table: it edits before reading, guesses instead of checking, stacks five concerns into one commit, and says "done" without running tests. Continuous Improvement adds three layers that make it sharper:
 
 1. **Before an edit** — [`gateguard`](skills/gateguard.md) ships as a `PreToolUse` hook (`hooks/gateguard.mjs`) that physically blocks `Edit` / `Write` / `MultiEdit` and destructive `Bash` until the agent presents a fact-list investigation.
 2. **During work** — bundled skills enforce planning, one-thing-at-a-time execution, TDD ([`tdd-workflow`](skills/tdd-workflow.md)), and a six-phase verification ladder ([`verification-loop`](skills/verification-loop.md)) before "done".
@@ -52,7 +52,7 @@ With Continuous Improvement, the same prompt is forced through the gate:
 
 > `gateguard` blocks the first `Edit` until Claude presents a fact list. Claude reads `useAuth.ts`, finds the existing `redirectAfterLogin` helper, traces *why* the redirect loops (a stale `from` query param), and edits one line in one file. `verification-loop` runs the tests. The reply names the file, the line, the cause.
 
-Same agent. Same model. Different discipline.
+Same agent. Same model. Different intelligence.
 
 ---
 
@@ -176,15 +176,15 @@ The framework has documented operator-level modes that change hook behavior with
 
 ## The 7 Laws
 
-| # | Law | Without it, agents... |
+| # | Law | What it gives the agent |
 |---|-----|----------------------|
-| 1 | **Research Before Executing** | reinvent what already exists |
-| 2 | **Plan Is Sacred** | scope-creep and overbuild |
-| 3 | **One Thing at a Time** | stack untested changes |
-| 4 | **Verify Before Reporting** | lie about being "done" |
-| 5 | **Reflect After Sessions** | repeat the same failures |
-| 6 | **Iterate One Change** | debug 5 changes at once |
-| 7 | **Learn From Every Session** | lose knowledge when context ends |
+| 1 | **Research Before Executing** | builds on what already exists instead of reinventing it |
+| 2 | **Plan Is Sacred** | lands effort on the goal with success defined up front |
+| 3 | **One Thing at a Time** | ships each change on a known-good base |
+| 4 | **Verify Before Reporting** | backs every "done" with evidence you can trust |
+| 5 | **Reflect After Sessions** | turns each session into a captured lesson |
+| 6 | **Iterate One Change** | keeps debugging isolated and the signal clean |
+| 7 | **Learn From Every Session** | compounds knowledge so next week's agent is sharper |
 
 ```
 Research -> Plan -> Execute (one thing) -> Verify -> Reflect -> Learn -> Iterate

--- a/SKILL.md
+++ b/SKILL.md
@@ -6,7 +6,7 @@ description: "Install structured self-improvement loops with instinct-based lear
 
 # continuous-improvement
 
-You follow the continuous-improvement framework. These 7 laws govern all your work.
+You follow the continuous-improvement framework. These 7 laws make every task sharper — each is a capability that compounds: research deeper, plan tighter, verify with evidence, reflect, and learn so the same lesson is never re-taught.
 
 ## Law 1: Research Before Executing
 

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -4,16 +4,16 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
-  <title>continuous-improvement · A seatbelt for Claude Code</title>
-  <meta name="description" content="A behavioral standard for AI coding agents. The 7 Laws of AI Agent Discipline, enforced at the tool boundary by runtime hooks.">
-  <meta property="og:title" content="continuous-improvement · A seatbelt for Claude Code">
-  <meta property="og:description" content="The 7 Laws of AI Agent Discipline. Runtime hooks, enforcement skills, and project memory for Claude Code.">
+  <title>continuous-improvement · Claude Code that gets sharper every session</title>
+  <meta name="description" content="An intelligence amplifier for AI coding agents. The 7 Laws of AI Agent Discipline plus the Mulahazah instinct engine make Claude reason deeper, recall past fixes, and compound what it learns.">
+  <meta property="og:title" content="continuous-improvement · Claude Code that gets sharper every session">
+  <meta property="og:description" content="The 7 Laws of AI Agent Discipline plus instinct memory — Claude Code that researches deeper, verifies with evidence, and gets sharper every session.">
   <meta property="og:type" content="website">
   <link rel="canonical" href="https://continuous-improvement.dev/">
   <meta property="og:url" content="https://continuous-improvement.dev/">
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="continuous-improvement · A seatbelt for Claude Code">
-  <meta name="twitter:description" content="The 7 Laws of AI Agent Discipline. Enforced at the tool boundary, not suggested in a doc.">
+  <meta name="twitter:title" content="continuous-improvement · Claude Code that gets sharper every session">
+  <meta name="twitter:description" content="The 7 Laws of AI Agent Discipline, wired into the runtime — Claude Code that compounds what it learns, not just suggested in a doc.">
   <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect x='2.5' y='2.5' width='27' height='27' rx='6' fill='%23faf7f0' stroke='%23231f17' stroke-width='2'/%3E%3Cpath d='M8 24 L24 8' stroke='%23d24a2e' stroke-width='4' stroke-linecap='round'/%3E%3Crect x='13' y='13' width='6' height='6' rx='1.5' fill='%23231f17'/%3E%3C/svg%3E">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -218,9 +218,9 @@
     <section class="hero">
       <div class="container hero-grid">
         <div class="hero-lead">
-          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.10.0</span>
-          <h1 class="display reveal" style="--i:1">A seatbelt for <span class="belt draw">Claude Code</span></h1>
-          <p class="hero-sub reveal" style="--i:2">continuous-improvement is a behavioral standard for AI coding agents. Seven laws, enforced at the tool boundary by runtime hooks, so the agent researches before it edits, verifies before it reports done, and keeps what worked.</p>
+          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.11.0</span>
+          <h1 class="display reveal" style="--i:1">Claude Code that gets <span class="belt draw">sharper every session</span></h1>
+          <p class="hero-sub reveal" style="--i:2">continuous-improvement makes the agent research before it edits, prove every completion before it reports done, and turn each fix into an instinct it reuses next time. Seven laws run the loop; the Mulahazah engine compounds what it learns.</p>
           <div class="install reveal" style="--i:3">
             <span class="tag">install</span>
             <code><span class="dollar" aria-hidden="true">$</span>npx continuous-improvement install</code>
@@ -263,8 +263,8 @@
       <div class="container">
         <div class="sec-head">
           <span class="kicker"><b>01</b> · The seven laws</span>
-          <h2>Discipline, written as clauses.</h2>
-          <p>Each law has one check to pass and one red flag that means stop. The runtime holds you to them, so you do not have to remember.</p>
+          <h2>Intelligence, written as clauses.</h2>
+          <p>Each law has one check to pass and one red flag to catch. The runtime keeps them automatic, so the agent reasons at a higher level instead of relying on memory.</p>
         </div>
         <div class="clauses">
           <article class="clause reveal" id="law-1">
@@ -347,8 +347,8 @@
       <div class="container">
         <div class="sec-head">
           <span class="kicker"><b>02</b> · Enforcement</span>
-          <h2>Enforced at the boundary, not suggested in a doc.</h2>
-          <p>Hooks sit between the agent and your files. They block the action, not just warn about it.</p>
+          <h2>Built into the runtime, not suggested in a doc.</h2>
+          <p>Hooks sit between the agent and your files — they force grounding before an edit and proof before completion, acting at the boundary instead of just reminding.</p>
         </div>
         <div class="mechs">
           <article class="mech reveal">
@@ -407,7 +407,7 @@
       <div class="container">
         <div class="cta-frame">
           <div>
-            <h2>Put a seatbelt on your agent.</h2>
+            <h2>Make your agent sharper every session.</h2>
             <p>Install in under a minute. Two slash commands inside Claude Code, no setup.</p>
           </div>
           <div class="cta-actions">
@@ -431,7 +431,7 @@
 
   <footer>
     <div class="container foot-grid">
-      <span class="foot-doc">DOC. CI-7L &middot; REV 3.10.0 &middot; MIT LICENSE</span>
+      <span class="foot-doc">DOC. CI-7L &middot; REV 3.11.0 &middot; MIT LICENSE</span>
       <div class="foot-links">
         <a href="https://github.com/naimkatiman/continuous-improvement">GitHub</a>
         <a href="https://www.npmjs.com/package/continuous-improvement">npm</a>

--- a/docs/plans/2026-06-07-intelligence-amplifier-reframe.md
+++ b/docs/plans/2026-06-07-intelligence-amplifier-reframe.md
@@ -1,0 +1,116 @@
+# 2026-06-07 — Intelligence-amplifier reframe (motto realignment)
+
+## Goal
+
+Realign continuous-improvement's identity from a **discipline/seatbelt** framing to a
+**higher-intelligence / higher-effectiveness amplifier** framing, across every user-facing
+surface. Operator's words: *"the goal of continuous-improvement is give Claude Code higher
+intelligence and higher effectiveness instead of focusing on efficiency... this is the motto,
+not give Claude Code a seatbelt."*
+
+Operator decisions (asked up front):
+- **Scope:** both story (positioning/copy) and capability (real behavior, not just relabeling).
+- **Execution:** autonomous — research, plan, ship; no approval gate before edits.
+- **7 Laws brand:** keep the names, reframe each Law from a restriction into a capability the
+  agent gains. "The 7 Laws of AI Agent Discipline" stays as a sub-brand; "Discipline" is no
+  longer the headline.
+
+## The smoking gun
+
+The rejected framing is the loudest copy in the repo, not subtext:
+- `README.md:7` — `<h1>A seatbelt for Claude Code</h1>`
+- `docs/landing/index.html` — `<title>`, OG, Twitter cards all "A seatbelt for Claude Code";
+  hero `<h1>` "A seatbelt for Claude Code"; CTA "Put a seatbelt on your agent."; a `.belt`
+  CSS motif animating the wordplay.
+- `src/lib/plugin-metadata.mts` `SHARED_PLUGIN_DESCRIPTION` — "Stops Claude Code from skipping
+  research, claiming 'done' without verifying, and repeating yesterday's mistakes." (fans out
+  to package.json + the three generated manifests).
+- `llms.txt` — "A discipline framework... It enforces seven laws".
+
+## Source-of-truth chain (what's source vs generated)
+
+- `SHARED_PLUGIN_DESCRIPTION` in `src/lib/plugin-metadata.mts` is the canonical description. It
+  is NOT read from package.json — it is hardcoded. `npm run build` (= `tsc` then
+  `bin/generate-plugin-manifests.mjs`) propagates it to the three generated manifests
+  (`.claude-plugin/marketplace.json`, `plugins/continuous-improvement/.claude-plugin/{plugin,marketplace}.json`).
+- `npm run build` **`rm`s and fully regenerates** `plugins/continuous-improvement/` — it copies
+  root `SKILL.md`, `skills/*.md`, `commands/*.md`, `hooks/*`, etc. into the mirror tree. So the
+  plugin mirrors are NEVER hand-edited; edit flat source, rebuild, commit both. `verify:skill-mirror`
+  / `verify:everything-mirror` byte-compare to catch a forgotten rebuild.
+- Hand-maintained mirrors (build does NOT regenerate): `package.json` description, `llms.txt`,
+  `README.md`, `QUICKSTART.md`, `CONTRIBUTING.md`, `docs/landing/index.html`.
+
+## Invariants threaded (must-preserve)
+
+- `verify:skill-count` — literal `25 bundled skills` (regex `(?<!\d)25 bundled skills`) in
+  marketplace.json, plugin.json, package.json, llms.txt. Reword around it; keep the token.
+- 7 Law NAMES are pinned (skill.test/commands.test/community.test via check-docs-substrings):
+  Research Before Executing / Plan Is Sacred / One Thing at a Time / Verify Before Reporting /
+  Reflect After (SKILL) + "Reflect After Sessions" (discipline.md/llms) / Iterate (SKILL) +
+  "Iterate One Change" (discipline.md/llms) / Learn From Every Session. Do NOT homogenize the
+  three files' law wording.
+- `verify:doc-runtime-claims` — README/QUICKSTART/skills lines containing "physically block" /
+  "PreToolUse hook" / "runtime gate" need a `hooks/<name>.mjs` ref within +/-5 lines. Keep the
+  factual gateguard mechanics + their anchors; only recast the surrounding lead.
+- Em-dash (U+2014): keep `Iteration — Next best recommendations (ranked, top 3)` and the
+  `— 25 bundled skills`-style boundaries intact.
+- Pinned README substrings: `If you don't know which to pick, use Beginner.`,
+  `planning-with-files`, `task_plan.md`, `ci_plan_init`.
+- Do NOT touch per-skill `Enforces Law N (...)` frontmatter (verify:skill-law-tag).
+
+## Chosen copy
+
+- Headline (README h1 + landing hero): **"Claude Code that gets sharper every session"**
+- Tagline: "Claude gets sharper every session — reasons deeper, recalls past fixes, and keeps
+  what worked."
+- Description (SHARED_PLUGIN_DESCRIPTION): "Makes Claude Code reason harder, recall past
+  corrections, and learn from every session so its competence compounds run over run. The
+  Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied
+  automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline
+  (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware
+  hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that
+  feeds real work history back into sharper instincts."
+- 7 Laws reframed as amplifiers (names preserved) — see README `## The 7 Laws` table.
+
+## Honesty guardrail
+
+No over-claiming beyond shipped mechanics: recall is BM25/lexical (not semantic), distillation
+drafts never auto-apply, instincts decay and need reinforcement, gateguard genuinely blocks
+(framed as "forces grounding -> smarter edits", not deleted). All copy stays inside these truths.
+
+## Files (PR1 — reframe)
+
+Flat source (hand-edited): `src/lib/plugin-metadata.mts`, `package.json`, `llms.txt`,
+`README.md`, `SKILL.md`, `CONTRIBUTING.md`, `docs/landing/index.html`.
+Generated (via `npm run build`, committed): `lib/plugin-metadata.mjs`, the three manifests,
+`plugins/continuous-improvement/**` mirror tree.
+
+## Verification
+
+`npm run verify:all` (11 invariants + typecheck) must pass green. Baseline was green before edits.
+
+## PR split (no bundled concerns)
+
+- **PR1 (this plan):** the reframe across all surfaces + this plan doc + capability roadmap.
+  One concern: identity/positioning.
+- **PR2 (separate, TDD):** the capability increment — a SessionStart "recall briefing" hook that
+  auto-runs `ci_recall` on the first prompt and injects the top-3 prior hits, making episodic
+  memory proactive. Real behavior change -> RED-GREEN-REFACTOR, own PR.
+
+## Capability roadmap (ranked, for follow-up PRs)
+
+1. SessionStart recall briefing (PR2 — recommended increment).
+2. Auto-draft distillation at the Stop boundary (ci_distill_candidates -> drafts).
+3. Reflect-to-instinct bridge (ci_reflect emits a candidate instinct).
+4. Recall hits inside the gateguard block (pre-load the forced investigation).
+5. Cross-project instinct suggestion on a new project.
+6. Semantic recall (embedding index alongside BM25).
+7. goal-coach amplifier skill (adds a skill -> defer until a count bump is intended).
+
+## Deferred
+
+- Keyword `ai-discipline` in `KEYWORDS` (plugin-metadata.mts) + package.json keywords still
+  encodes the old framing. Left as-is for PR1 (honest: the engine is still discipline-based);
+  an intelligence-forward keyword swap is a separate decision (touches the KEYWORDS source const
+  -> propagates to manifests).
+- Release/version bump + npm publish + landing deploy are operator actions, not part of this PR.

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -26,7 +26,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.";
+const SHARED_PLUGIN_DESCRIPTION = "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
 // See third-party/MANIFEST.md for refresh recipes and per-snapshot
@@ -376,12 +376,12 @@ const EXPERT_TOOL_ENTRIES = [
 ];
 const MODE_METADATA = {
     beginner: {
-        description: "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
+        description: "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
         hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit"],
-        hookDescription: "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking.",
+        hookDescription: "Silently captures every tool call as observations and routes prompts to the matching skill via the route table. Lightweight and non-blocking.",
     },
     expert: {
-        description: "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
+        description: "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
         hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd"],
         hookDescription: "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection.",
     },

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,10 @@
 # continuous-improvement
 
-> Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.
+> Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.
 
 ## What This Is
 
-A discipline framework for AI coding agents. It enforces seven laws — research, plan, execute one thing at a time, verify, reflect, iterate, learn — and builds behavioral instincts over time via the Mulahazah learning system, so the same correction does not have to be given twice.
+An intelligence amplifier for AI coding agents. It makes Claude reason at a higher level on every task, recall the corrections it has already received, and learn from each session so its competence compounds over time — research, plan, execute one thing at a time, verify, reflect, iterate, learn — building behavioral instincts via the Mulahazah learning system, so the same correction never has to be given twice and each run starts smarter than the last.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.11.0",
-  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
+  "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -2,7 +2,7 @@
   "name": "continuous-improvement",
   "version": "3.11.0",
   "mode": "beginner",
-  "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
+  "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [
     {
       "name": "ci_status",
@@ -53,6 +53,6 @@
       "PostToolUse",
       "UserPromptSubmit"
     ],
-    "description": "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking."
+    "description": "Silently captures every tool call as observations and routes prompts to the matching skill via the route table. Lightweight and non-blocking."
   }
 }

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.",
+      "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
       "version": "3.11.0",
       "source": "./",
       "author": {

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.11.0",
-  "description": "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.",
+  "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",
     "url": "https://github.com/naimkatiman"

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -26,7 +26,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.";
+const SHARED_PLUGIN_DESCRIPTION = "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
 // See third-party/MANIFEST.md for refresh recipes and per-snapshot
@@ -376,12 +376,12 @@ const EXPERT_TOOL_ENTRIES = [
 ];
 const MODE_METADATA = {
     beginner: {
-        description: "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
+        description: "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
         hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit"],
-        hookDescription: "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking.",
+        hookDescription: "Silently captures every tool call as observations and routes prompts to the matching skill via the route table. Lightweight and non-blocking.",
     },
     expert: {
-        description: "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
+        description: "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
         hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd"],
         hookDescription: "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection.",
     },

--- a/plugins/continuous-improvement/skills/continuous-improvement/SKILL.md
+++ b/plugins/continuous-improvement/skills/continuous-improvement/SKILL.md
@@ -6,7 +6,7 @@ description: "Install structured self-improvement loops with instinct-based lear
 
 # continuous-improvement
 
-You follow the continuous-improvement framework. These 7 laws govern all your work.
+You follow the continuous-improvement framework. These 7 laws make every task sharper — each is a capability that compounds: research deeper, plan tighter, verify with evidence, reflect, and learn so the same lesson is never re-taught.
 
 ## Law 1: Research Before Executing
 

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -2,7 +2,7 @@
   "name": "continuous-improvement",
   "version": "3.11.0",
   "mode": "expert",
-  "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
+  "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [
     {
       "name": "ci_status",

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -147,7 +147,7 @@ const KEYWORDS = [
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
 const SHARED_PLUGIN_DESCRIPTION =
-  "Stops Claude Code from skipping research, claiming 'done' without verifying, and repeating yesterday's mistakes. The 7 Laws of AI Agent Discipline — 25 bundled skills, gating hooks, the Mulahazah auto-leveling instinct engine, and a GitHub Action transcript linter.";
+  "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
 
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
@@ -525,14 +525,14 @@ const EXPERT_TOOL_ENTRIES: ToolCatalogEntry[] = [
 const MODE_METADATA: Record<PluginMode, ModeMetadata> = {
   beginner: {
     description:
-      "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four discipline skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default.",
+      "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
     hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit"],
     hookDescription:
-      "Silently captures every tool call as observations and routes prompts to the matching discipline skill via the route table. Lightweight and non-blocking.",
+      "Silently captures every tool call as observations and routes prompts to the matching skill via the route table. Lightweight and non-blocking.",
   },
   expert: {
     description:
-      "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay disciplined and learnings survive context resets.",
+      "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
     hooks: ["PreToolUse", "PostToolUse", "UserPromptSubmit", "SessionStart", "SessionEnd"],
     hookDescription:
       "Full hook suite: observation capture, lazy prompt routing, session-level instinct loading, and auto-reflection.",


### PR DESCRIPTION
## Why

The project's own motto, in the operator's words: *"give Claude Code higher intelligence and higher effectiveness... not give Claude Code a seatbelt."* The rejected framing was the **loudest copy in the repo** — `README.md` h1 literally read "A seatbelt for Claude Code", the landing page title/OG/Twitter/hero/CTA all said "seatbelt", and the npm/manifest description led with "Stops Claude Code from skipping research...".

This PR realigns the identity to an **intelligence amplifier** across every user-facing surface. Per the operator's decisions: keep the **7 Laws of AI Agent Discipline** by name, reframe each Law from a restriction into a capability; "Discipline" is no longer the headline.

## What changed

| Surface | Before | After |
|---|---|---|
| README h1 | "A seatbelt for Claude Code" | "Claude Code that gets sharper every session" |
| Landing title/OG/Twitter/hero/CTA | "A seatbelt for Claude Code" / "Put a seatbelt on your agent." | amplifier copy; belt motif now underlines "sharper every session" |
| `SHARED_PLUGIN_DESCRIPTION` (source) + package.json + llms.txt | "Stops Claude Code from skipping research..." | "Makes Claude Code reason harder, recall past corrections, and learn..." |
| README "## The 7 Laws" table | "Without it, agents..." (loss) | "What it gives the agent" (capability) |
| SKILL.md / CONTRIBUTING.md intros | "govern all your work" / "more disciplined" | amplifier framing |

## Invariants threaded

- `25 bundled skills` token preserved in all 4 checked files (skill-count green).
- All pinned 7-Law name substrings preserved (per-file wording kept distinct: SKILL vs discipline.md vs llms.txt).
- `doc-runtime-claims` anchors kept — README still pairs "physically blocks" with `hooks/gateguard.mjs`.
- Landing JS hooks (`belt draw` span, `data-copy` install block, `reveal`/`--i` IntersectionObserver) and `#law-*` anchors untouched; stale `REV 3.10.0` reconciled to `3.11.0`.
- Honesty held: recall stays lexical/BM25, instincts decay, gateguard still blocks (reframed as forced grounding, not removed). No over-claiming.

## How the build propagates

Edited flat source (`src/lib/plugin-metadata.mts`, README, llms.txt, package.json, SKILL.md, CONTRIBUTING.md, landing). `npm run build` regenerated `lib/plugin-metadata.mjs`, the three manifests, and the `plugins/continuous-improvement/**` mirror tree (committed).

## Verification

- `npm run verify:all` — green (11 invariants + typecheck), EXIT=0.
- `npm test` — **779/779 pass, 0 fail**.
- Plan doc: `docs/plans/2026-06-07-intelligence-amplifier-reframe.md`.

## Scope / follow-up

This PR is **story + the capability roadmap**. The capability **code** (a SessionStart "recall briefing" hook that auto-runs `ci_recall` on the first prompt and injects the top-3 prior hits, making episodic memory proactive) ships as a **separate, TDD'd PR** per the no-bundled-concerns rule. Roadmap is in the plan doc.

Release/version bump + npm publish + landing deploy are deliberately left as operator actions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
