### PR TITLE
docs(report): record PR #200 merge and sync test counts 752→779

### DIFF
--- a/reports/assets/update-card.html
+++ b/reports/assets/update-card.html
@@ -166,11 +166,11 @@
   <div class="stats">
     <div class="stat">
       <div class="stat-label"><i data-lucide="check-circle-2" width="14" height="14"></i> Tests Passing</div>
-      <div class="stat-value green">752</div>
+      <div class="stat-value green">779</div>
     </div>
     <div class="stat">
       <div class="stat-label"><i data-lucide="flask-conical" width="14" height="14"></i> Total Tests</div>
-      <div class="stat-value">752</div>
+      <div class="stat-value">779</div>
     </div>
     <div class="stat">
       <div class="stat-label"><i data-lucide="shield-check" width="14" height="14"></i> Pass Rate</div>
@@ -196,7 +196,7 @@
 
   <div class="badge">
     <i data-lucide="trophy" width="18" height="18"></i>
-    ALL TESTS PASSING — 752 / 752
+    ALL TESTS PASSING — 779 / 779
   </div>
 
   <div class="footer">

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,5 +1,10 @@
 # Daily Improvement Report — 2026-06-07
 
+## 2026-06-07 — Sync test counts 752→779 after recent regression tests
+- `npm test` now reports 779 pass / 0 fail (up from 752) after the test suite grew with new regression coverage (e.g., gateguard MultiEdit parity, empty-path fallback, installer coexistence, MCP temp-home flake fix, and lint-transcript Windows pipe compatibility). The `Project Snapshot` table and `Remaining Failures` prose in this report, plus the HTML summary card at `reports/assets/update-card.html`, still showed the stale `752` count.
+- Updated all three occurrences in the card (Tests Passing, Total Tests, badge) from `752` to `779`, and updated the snapshot table and Remaining Failures prose from `752` to `779`.
+- Verified with `npm test` (779 pass / 0 fail) and `npm run verify:all` (all 11 content invariants + typecheck pass). Working tree has a single doc-only diff.
+
 ## 2026-06-07 — Create PR #200 for missed version-reference sync and enable auto-merge
 - The branch `hourly/2026-06-07-sync-stale-version-refs-missed-in-197` (commit `736b487`) had the landing-page and CloudPlugin version fixes but was not yet merged to `main`.
 - Created PR #200 (`docs: sync missed 3.10.0 → 3.11.0 version references from PR #197`) and enabled squash auto-merge with `gh pr merge 200 --squash --delete-branch --auto`. CI checks (lint-transcript + Node 18/20/22 test matrix) are running; merge will complete once they pass.
@@ -591,7 +596,7 @@
 | Project | continuous-improvement v3.11.0 |
 | Stack | Node.js (ESM), MCP server, GitHub Action, CLI tools |
 | Stage | Published npm package, active development |
-| Tests (current) | 752 pass / 0 fail |
+| Tests (current) | 779 pass / 0 fail |
 
 ## Changes Implemented
 
@@ -611,7 +616,7 @@
 
 ## Remaining Failures
 
-None. All 752 tests pass / 0 fail as of this cycle.
+None. All 779 tests pass / 0 fail as of this cycle.
 
 ## Deferred Items
 

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,5 +1,10 @@
 # Daily Improvement Report — 2026-06-07
 
+## 2026-06-07 — Create PR #200 for missed version-reference sync and enable auto-merge
+- The branch `hourly/2026-06-07-sync-stale-version-refs-missed-in-197` (commit `736b487`) had the landing-page and CloudPlugin version fixes but was not yet merged to `main`.
+- Created PR #200 (`docs: sync missed 3.10.0 → 3.11.0 version references from PR #197`) and enabled squash auto-merge with `gh pr merge 200 --squash --delete-branch --auto`. CI checks (lint-transcript + Node 18/20/22 test matrix) are running; merge will complete once they pass.
+- Verified with `npm run verify:all` locally (all 11 content invariants + typecheck pass, 752 pass / 0 fail). Working tree is clean.
+
 ## 2026-06-07 — Sync missed 3.10.0 → 3.11.0 version references from PR #197
 - PR #197's post-merge sync claimed to update `docs/landing/index.html` version badge from `v3.10.0` → `v3.11.0`, but two occurrences of `REV 3.10.0` were missed: the hero kicker line (`<span class="kicker reveal">`) and the footer copyright line (`<span class="foot-doc">`). Additionally, `.cloudplugin/marketplace.json` was never updated and still advertised `"version": "3.10.0"`.
 - Updated both missed `REV 3.10.0` references in `docs/landing/index.html` to `REV 3.11.0` so the landing page is internally consistent. Updated `.cloudplugin/marketplace.json` `"version"` from `3.10.0` to `3.11.0` so the CloudPlugin marketplace listing matches the current release.


### PR DESCRIPTION
- Records PR #200 creation and auto-merge in daily improvement log
- Syncs test counts from 752 → 779 in update-card and report snapshot
- All changes are doc-only; verified with npm run verify:all