### PR TITLE
fix(gateguard): print resolved clear-CLI path in block reason

### DIFF
--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -27,7 +27,8 @@
  * path.
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { MAX_CLEARED_FILES, canonicalizeFileKey, isCapReached, isFileCleared, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
@@ -104,11 +105,23 @@ function formatFileTarget(filePaths) {
         return nonEmpty[0];
     return `${nonEmpty.length} files (${nonEmpty.join(", ")})`;
 }
+// Resolved from the hook's own location at load time. The block reason must
+// print a command the agent can run in its OWN shell, where ${CLAUDE_PLUGIN_ROOT}
+// is empty — that variable is only populated while this hook itself executes.
+// bin/ is a sibling of hooks/ in both the repo layout and the plugin-bundle
+// mirror, so this resolves correctly from either.
+const CLEAR_CLI_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "gateguard-clear.mjs");
+// Quote a path for the printed clearance command. Forward slashes (node accepts
+// them on every platform and they survive a Bash double-quote without escaping)
+// inside JSON quotes — JSON.stringify still escapes any embedded quote, so a
+// path like a"b.ts stays safe rather than collapsing into a bare-quoted token.
+function quotePath(p) {
+    return JSON.stringify(p.replace(/\\/g, "/"));
+}
 function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
     const pathList = filePaths.filter((p) => p !== "");
-    const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
-    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(" ");
+    const quoted = (pathList.length > 0 ? pathList : [target]).map((p) => quotePath(p));
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
         "",
@@ -117,13 +130,12 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "  3. If this file reads/writes data files, show field names, structure, and date format",
         "  4. Quote the user's current instruction verbatim",
         "",
-        "Then clear the gate and retry the same call. Any one of:",
-        `  A. MCP tool:  ci_gateguard_clear  {file_paths: [${jsonArray}]}`,
-        `  B. CLI (Bash, never gated): node "\${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" ${cliArgs}`,
-        `  C. Manual: append each path to "cleared_files" in ${stateFilePath} via a non-destructive Bash write.`,
-        "  Clearance matches regardless of drive-letter case or path separator.",
-        "  (On harnesses that forward unknown tool params you may instead retry with",
-        "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A/B/C.)",
+        "Then clear the gate and retry the same call. Either route works:",
+        `  A. Bash (always works — run verbatim): node ${quotePath(CLEAR_CLI_PATH)} --state ${quotePath(stateFilePath)} ${quoted.join(" ")}`,
+        `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}]}`,
+        "  Both canonicalize paths — drive-letter case and separators don't matter.",
+        "  (Harnesses that forward unknown tool params may instead retry the call with",
+        "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
     ].join("\n");
 }
 function buildDestructiveBashReason(command) {

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -27,7 +27,8 @@
  * path.
  */
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { MAX_CLEARED_FILES, canonicalizeFileKey, isCapReached, isFileCleared, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
@@ -104,11 +105,23 @@ function formatFileTarget(filePaths) {
         return nonEmpty[0];
     return `${nonEmpty.length} files (${nonEmpty.join(", ")})`;
 }
+// Resolved from the hook's own location at load time. The block reason must
+// print a command the agent can run in its OWN shell, where ${CLAUDE_PLUGIN_ROOT}
+// is empty — that variable is only populated while this hook itself executes.
+// bin/ is a sibling of hooks/ in both the repo layout and the plugin-bundle
+// mirror, so this resolves correctly from either.
+const CLEAR_CLI_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "gateguard-clear.mjs");
+// Quote a path for the printed clearance command. Forward slashes (node accepts
+// them on every platform and they survive a Bash double-quote without escaping)
+// inside JSON quotes — JSON.stringify still escapes any embedded quote, so a
+// path like a"b.ts stays safe rather than collapsing into a bare-quoted token.
+function quotePath(p) {
+    return JSON.stringify(p.replace(/\\/g, "/"));
+}
 function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
     const target = formatFileTarget(filePaths);
     const pathList = filePaths.filter((p) => p !== "");
-    const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
-    const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(" ");
+    const quoted = (pathList.length > 0 ? pathList : [target]).map((p) => quotePath(p));
     return [
         `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
         "",
@@ -117,13 +130,12 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "  3. If this file reads/writes data files, show field names, structure, and date format",
         "  4. Quote the user's current instruction verbatim",
         "",
-        "Then clear the gate and retry the same call. Any one of:",
-        `  A. MCP tool:  ci_gateguard_clear  {file_paths: [${jsonArray}]}`,
-        `  B. CLI (Bash, never gated): node "\${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" ${cliArgs}`,
-        `  C. Manual: append each path to "cleared_files" in ${stateFilePath} via a non-destructive Bash write.`,
-        "  Clearance matches regardless of drive-letter case or path separator.",
-        "  (On harnesses that forward unknown tool params you may instead retry with",
-        "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A/B/C.)",
+        "Then clear the gate and retry the same call. Either route works:",
+        `  A. Bash (always works — run verbatim): node ${quotePath(CLEAR_CLI_PATH)} --state ${quotePath(stateFilePath)} ${quoted.join(" ")}`,
+        `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}]}`,
+        "  Both canonicalize paths — drive-letter case and separators don't matter.",
+        "  (Harnesses that forward unknown tool params may instead retry the call with",
+        "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
     ].join("\n");
 }
 function buildDestructiveBashReason(command) {

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -28,7 +28,8 @@
  */
 
 import { readFileSync } from "node:fs";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import {
   MAX_CLEARED_FILES,
   canonicalizeFileKey,
@@ -140,11 +141,25 @@ function formatFileTarget(filePaths: string[]): string {
   return `${nonEmpty.length} files (${nonEmpty.join(", ")})`;
 }
 
+// Resolved from the hook's own location at load time. The block reason must
+// print a command the agent can run in its OWN shell, where ${CLAUDE_PLUGIN_ROOT}
+// is empty — that variable is only populated while this hook itself executes.
+// bin/ is a sibling of hooks/ in both the repo layout and the plugin-bundle
+// mirror, so this resolves correctly from either.
+const CLEAR_CLI_PATH = join(dirname(fileURLToPath(import.meta.url)), "..", "bin", "gateguard-clear.mjs");
+
+// Quote a path for the printed clearance command. Forward slashes (node accepts
+// them on every platform and they survive a Bash double-quote without escaping)
+// inside JSON quotes — JSON.stringify still escapes any embedded quote, so a
+// path like a"b.ts stays safe rather than collapsing into a bare-quoted token.
+function quotePath(p: string): string {
+  return JSON.stringify(p.replace(/\\/g, "/"));
+}
+
 function buildMutatingFileReason(toolName: string, filePaths: string[], stateFilePath: string): string {
   const target = formatFileTarget(filePaths);
   const pathList = filePaths.filter((p) => p !== "");
-  const jsonArray = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(", ");
-  const cliArgs = (pathList.length > 0 ? pathList : [target]).map((p) => JSON.stringify(p)).join(" ");
+  const quoted = (pathList.length > 0 ? pathList : [target]).map((p) => quotePath(p));
   return [
     `Before ${toolName === "Write" ? "creating" : "editing"} ${target}, present these facts:`,
     "",
@@ -153,13 +168,12 @@ function buildMutatingFileReason(toolName: string, filePaths: string[], stateFil
     "  3. If this file reads/writes data files, show field names, structure, and date format",
     "  4. Quote the user's current instruction verbatim",
     "",
-    "Then clear the gate and retry the same call. Any one of:",
-    `  A. MCP tool:  ci_gateguard_clear  {file_paths: [${jsonArray}]}`,
-    `  B. CLI (Bash, never gated): node "\${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs" ${cliArgs}`,
-    `  C. Manual: append each path to "cleared_files" in ${stateFilePath} via a non-destructive Bash write.`,
-    "  Clearance matches regardless of drive-letter case or path separator.",
-    "  (On harnesses that forward unknown tool params you may instead retry with",
-    "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A/B/C.)",
+    "Then clear the gate and retry the same call. Either route works:",
+    `  A. Bash (always works — run verbatim): node ${quotePath(CLEAR_CLI_PATH)} --state ${quotePath(stateFilePath)} ${quoted.join(" ")}`,
+    `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}]}`,
+    "  Both canonicalize paths — drive-letter case and separators don't matter.",
+    "  (Harnesses that forward unknown tool params may instead retry the call with",
+    "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
   ].join("\n");
 }
 

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -293,5 +293,24 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+
+    it("block reason CLI command uses a resolved path, not the literal ${CLAUDE_PLUGIN_ROOT}", () => {
+      const dir = mkdtempSync(join(tmpdir(), "gateguard-resolved-"));
+      try {
+        const decision = runHook("Write", { file_path: "fresh-resolved.ts", content: "x" }, dir);
+        assert.equal(decision.decision, "block");
+        const reason = decision.reason ?? "";
+        assert.doesNotMatch(
+          reason,
+          /\$\{CLAUDE_PLUGIN_ROOT\}/,
+          "block reason must not print the unexpanded ${CLAUDE_PLUGIN_ROOT} — it is empty in the agent shell",
+        );
+        const cliLine = reason.split("\n").find((line) => line.includes("gateguard-clear.mjs")) ?? "";
+        assert.match(cliLine, /bin\/gateguard-clear\.mjs/, "CLI path must resolve to the bin script");
+        assert.match(cliLine, /--state/, "CLI command must pass --state for resolution-proof clearance");
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
   });
 });

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -213,5 +213,20 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
                 rmSync(dir, { recursive: true, force: true });
             }
         });
+        it("block reason CLI command uses a resolved path, not the literal ${CLAUDE_PLUGIN_ROOT}", () => {
+            const dir = mkdtempSync(join(tmpdir(), "gateguard-resolved-"));
+            try {
+                const decision = runHook("Write", { file_path: "fresh-resolved.ts", content: "x" }, dir);
+                assert.equal(decision.decision, "block");
+                const reason = decision.reason ?? "";
+                assert.doesNotMatch(reason, /\$\{CLAUDE_PLUGIN_ROOT\}/, "block reason must not print the unexpanded ${CLAUDE_PLUGIN_ROOT} — it is empty in the agent shell");
+                const cliLine = reason.split("\n").find((line) => line.includes("gateguard-clear.mjs")) ?? "";
+                assert.match(cliLine, /bin\/gateguard-clear\.mjs/, "CLI path must resolve to the bin script");
+                assert.match(cliLine, /--state/, "CLI command must pass --state for resolution-proof clearance");
+            }
+            finally {
+                rmSync(dir, { recursive: true, force: true });
+            }
+        });
     });
 });


### PR DESCRIPTION
## Problem
The PreToolUse gateguard block message documented three clearance paths; all three were dead in practice, so agents routed around the gate (Bash writes, `rm`) instead of clearing it — defeating the pause-and-present-facts purpose.

Root cause, confirmed by live reproduction:
- **CLI (code bug):** the reason printed `node "${CLAUDE_PLUGIN_ROOT}/bin/gateguard-clear.mjs"`. `${CLAUDE_PLUGIN_ROOT}` is empty in the agent’s own shell (only set while the hook executes) → `MODULE_NOT_FOUND`.
- **MCP:** `ci_gateguard_clear` listed first, but it requires the CI MCP server connected.
- **Manual:** “append each path to cleared_files” under-specified — it’s an object map keyed by *canonical* paths (lowercase drive, forward slashes); naive array / uppercase-drive writes silently miss.

The clearance mechanism (lib canonicalization + `clearFiles` + the CLI `--state` override) was already correct in 3.11.0 — only the message was wrong.

## Fix (message only)
- Resolve the CLI path from the hook’s own location via `import.meta.url` instead of the literal env var.
- Lead with the always-works Bash route: `node "<resolved>/bin/gateguard-clear.mjs" --state "<printed state path>" <args>` (the `--state` override is resolution-proof).
- Demote the MCP tool to “when connected”; drop the error-prone hand-edit option.
- Paths printed with forward slashes inside JSON quotes (copy-paste-safe across shells; embedded quotes still escaped).

## Tests
- New RED→GREEN test: block reason must carry a resolved `bin/gateguard-clear.mjs` path + `--state`, and must not contain literal `${CLAUDE_PLUGIN_ROOT}`.
- Existing escaping / clearance-action / canonical tests stay green. gateguard suites 40/40; `verify:all` green (exit 0).
- Unrelated `observe.*` timing-budget tests flake on a loaded Windows box — the diff touches zero observe files.

Scope: `src/hooks/gateguard.mts` + test, and the regenerated `.mjs` (repo + plugin mirror).