### PR TITLE
docs(changelog): record verify:tool-count invariant under [3.12.0]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this skill are documented here.
 ### Added
 
 - **Proactive recall-briefing hook (opt-in episodic memory)** — `hooks/recall-briefing.mjs` runs on `UserPromptSubmit`, queries the BM25 observation index in-process, and surfaces the most relevant prior corrections as a briefing before the agent acts. First capability increment of the intelligence-amplifier reframe: a lesson learned once is recalled automatically on the next related prompt instead of being re-taught. Opt-in — disabled unless wired into the hook config.
+- **`verify:tool-count` content invariant (12th in `verify:all`)** — `bin/check-tool-count.mjs` pins MCP tool-count claims in docs and source to the generated `plugins/{expert,beginner}.json` `tools[].length`, so a count can't drift when a tool is added — the gap that let "12 tools" pass `verify:all` green in the 2026-06-07 audit. Pins four claims across `docs/skills.md`, `README.md`, `QUICKSTART.md`, and the `mcp-server` banner. Follow-up to #203 (PR #204).
 
 ### Changed
 


### PR DESCRIPTION
## What & why

The `verify:tool-count` invariant (PR #204) shipped in **3.12.0** — its commits were bundled into the release squash (`c4a7ff8`) because they sat on local `main` when the release branch was cut, and #204 itself later merged as an empty no-op (`fe1fb70`). But the `[3.12.0]` CHANGELOG entry authored in #206 predated that and never mentioned it.

This adds the one missing `### Added` bullet so the shipped changelog matches what 3.12.0 actually contains, before the `v3.12.0` tag is pushed.

## Change

One line under `## [3.12.0]` → `### Added` documenting `verify:tool-count` / `bin/check-tool-count.mjs` as the 12th invariant. CHANGELOG is not part of the `plugins/` mirror, so no rebuild.

## Verification

`npm run typecheck` green (doc-only floor per CLAUDE.md). No source or manifest change.

## Note

Land this before tagging `v3.12.0`. The tag is on hold pending the one-time OIDC trusted-publisher setup on npmjs.com (first tag since #202).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
