### PR TITLE
ci(release): drop setup-node registry-url so OIDC trusted publishing works

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,13 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Do NOT set registry-url here: setup-node would write an .npmrc with
+      # `_authToken=${NODE_AUTH_TOKEN}` and a dummy placeholder token, which npm
+      # uses for the publish PUT instead of OIDC — causing E404. OIDC trusted
+      # publishing needs no token-bearing .npmrc. (Fix for the v3.12.0 publish.)
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-          registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.x.
       - name: Upgrade npm for trusted publishing


### PR DESCRIPTION
## What & why

The `v3.12.0` tag publish failed with `E404` on the registry PUT, even though OIDC provenance signing succeeded. Root cause: `actions/setup-node@v4` with `registry-url` writes an `.npmrc` containing `//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}` and sets `NODE_AUTH_TOKEN` to its dummy placeholder (`XXXXX-XXXXX-XXXXX-XXXXX`, visible in the run env). npm authenticated the publish with that dummy token instead of OIDC, so the registry rejected it.

Removing `registry-url` stops the token-bearing `.npmrc` from being written, so `npm publish --provenance` falls back to OIDC trusted publishing as intended. This completes the #202 migration (which dropped the env token but left the registry-url that re-introduced one).

## Change

One step in `.github/workflows/release.yml`: drop `registry-url` from the setup-node `with:` block, plus a comment explaining why it must not be re-added.

## Verification

YAML-only workflow change; no source/generated files touched. The real proof is the next tag publishing green — gated behind the v3.12.1 release PR that follows this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
