### PR TITLE
chore(release): cut v3.12.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [3.12.1] — 2026-06-08
+
+### Fixed
+
+- **npm release pipeline now authenticates via OIDC instead of a dummy token** — the `v3.12.0` tag publish failed with `E404` on the registry PUT: `actions/setup-node` with `registry-url` wrote an `.npmrc` carrying `_authToken=${NODE_AUTH_TOKEN}` set to its placeholder value, so npm used that dummy token for the publish instead of OIDC trusted publishing (provenance still signed, since the sigstore OIDC token is separate). Dropping `registry-url` from `release.yml` lets `npm publish --provenance` fall back to OIDC as intended. **3.12.1 is the first npm artifact to carry the 3.12.0 changes** (intelligence-amplifier positioning #198, recall-briefing hook #199, OIDC pipeline #202, doc-drift fixes #203, `verify:tool-count` invariant #204); the `3.12.0` version was never published to npm. (#211)
+
 ## [3.12.0] — 2026-06-07
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.0",
+      "version": "3.12.1",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.0",
+  "version": "3.12.1",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## What & why

Re-release of the 3.12.0 changes. The `v3.12.0` npm publish failed with `E404` because `setup-node`'s `registry-url` forced a dummy-token `.npmrc` that shadowed OIDC (fixed in #211, now on `main`). `3.12.0` was never published to npm, so this cuts **3.12.1** as the first npm artifact carrying that work.

What 3.12.1 ships to npm (refreshing the package page):

| PR | Change |
|---|---|
| #198 | Positioning reframe: "seatbelt" → intelligence amplifier (README + description) |
| #199 | Proactive recall-briefing hook (opt-in episodic memory) |
| #202 | OIDC trusted publishing pipeline |
| #203 | Post-merge doc/count drift fixes |
| #204 | `verify:tool-count` invariant (12th in verify:all) |
| #211 | Release pipeline fix that makes this publish succeed |

## Files (8, version-only except CHANGELOG)

`package.json`, `package-lock.json`, `CHANGELOG.md`, and the 5 build-regenerated manifests. Generated via `npm run build` per `docs/RELEASING.md`.

## Verification

- `npm run verify:all` — green (12 invariants + typecheck).
- Generated tree clean; only the expected 8 files changed.

## After merge

Tag `v3.12.1` → `release.yml` (now OIDC-correct) publishes via trusted publishing and cuts the GitHub Release. npm page picks up the new README/description.

> The dangling `v3.12.0` git tag (no npm/GH artifacts) is left in place; it can be deleted at leisure — harmless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
