### PR TITLE
ci(release): run release on Node 22 (OIDC trusted publishing needs Node >= 22.14)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,9 +23,12 @@ jobs:
       # publishing needs no token-bearing .npmrc. (Fix for the v3.12.0 publish.)
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
 
-      # Trusted publishing (OIDC) requires npm >= 11.5.1; Node 20 ships npm 10.x.
+      # Trusted publishing (OIDC) requires npm >= 11.5.1 AND Node >= 22.14.0.
+      # Node 22 ships npm 10.x, so still upgrade npm to the trusted-publishing
+      # minimum. (Node 20 was below the floor and caused the v3.12.0/v3.12.1
+      # publish to skip OIDC — E404 then ENEEDAUTH.)
       - name: Upgrade npm for trusted publishing
         run: npm install -g npm@latest
 


### PR DESCRIPTION
## What & why

The v3.12.0 publish failed `E404` and v3.12.1 failed `ENEEDAUTH` — both because `release.yml` ran on **Node 20**. Per docs.npmjs.com/trusted-publishers, OIDC trusted publishing requires **npm >= 11.5.1 AND Node >= 22.14.0**. On Node 20 the OIDC token exchange never engaged, so npm fell back to a dummy `.npmrc` token (E404) or no auth (ENEEDAUTH after registry-url was dropped in #211).

Bumps `setup-node` to Node 22. Combined with #211 (no token-bearing .npmrc) this is the complete fix; the v3.12.2 release PR that follows will prove it by publishing green.

## Verification

YAML-only. The real proof is the next tagged publish succeeding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)