### PR TITLE
chore(release): cut v3.12.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [3.12.2] — 2026-06-08
+
+### Fixed
+
+- **Release workflow now runs on Node 22 so OIDC trusted publishing actually authenticates** — npm trusted publishing requires npm ≥ 11.5.1 **and Node ≥ 22.14.0** ([docs.npmjs.com/trusted-publishers](https://docs.npmjs.com/trusted-publishers)). `release.yml` ran on Node 20, below the floor, so the OIDC token exchange never engaged: the `v3.12.0` publish fell back to setup-node's dummy `.npmrc` token (`E404`) and `v3.12.1` had no auth at all (`ENEEDAUTH`). Bumping `setup-node` to Node 22 (plus #211 dropping the token-bearing `.npmrc`) completes the OIDC pipeline. **3.12.2 is the first npm artifact to carry the 3.12.0 changes** (#198 positioning, #199 recall hook, #202 OIDC pipeline, #203 doc-drift, #204 tool-count invariant); `3.12.0` and `3.12.1` were never published to npm. (#211, #213)
+
 ## [3.12.1] — 2026-06-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.1",
+      "version": "3.12.2",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.1",
+  "version": "3.12.2",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## What & why

Re-release after the OIDC pipeline failures: `v3.12.0` (E404, dummy-token .npmrc) and `v3.12.1` (ENEEDAUTH, Node 20 below the trusted-publishing floor). Both root causes are now fixed on `main` — #211 (drop token-bearing .npmrc) and #213 (Node 22, since trusted publishing needs Node >= 22.14.0). **3.12.2 is the first npm artifact to carry the 3.12.0 work** (#198 positioning, #199 recall hook, #202 OIDC, #203 doc-drift, #204 tool-count); 3.12.0/3.12.1 were never published.

## Files (8, version-only except CHANGELOG)

`package.json`, `package-lock.json`, `CHANGELOG.md`, and the 5 build-regenerated manifests. Per `docs/RELEASING.md`.

## Verification

`npm run verify:all` green (12 invariants + typecheck); generated tree clean; only the 8 expected files changed.

## After merge

Tag `v3.12.2` → `release.yml` (now Node 22 + no dummy token) publishes via OIDC and cuts the GitHub Release. This is the run that proves the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)