### PR TITLE
ci(release): restore setup-node registry-url for OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,13 +17,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      # Do NOT set registry-url here: setup-node would write an .npmrc with
-      # `_authToken=${NODE_AUTH_TOKEN}` and a dummy placeholder token, which npm
-      # uses for the publish PUT instead of OIDC — causing E404. OIDC trusted
-      # publishing needs no token-bearing .npmrc. (Fix for the v3.12.0 publish.)
+      # registry-url is required for OIDC trusted publishing (it's in npm's
+      # documented example): it points npm at registry.npmjs.org for the OIDC
+      # token exchange. On Node >= 22.14 + npm >= 11.5.1 with a configured
+      # trusted publisher, npm mints and uses the OIDC token, overriding the
+      # placeholder _authToken setup-node writes. Do NOT add a NODE_AUTH_TOKEN
+      # env to the publish step — that reintroduced a real (dummy) token and
+      # caused E404 on Node 20.
       - uses: actions/setup-node@v4
         with:
           node-version: 22
+          registry-url: 'https://registry.npmjs.org'
 
       # Trusted publishing (OIDC) requires npm >= 11.5.1 AND Node >= 22.14.0.
       # Node 22 ships npm 10.x, so still upgrade npm to the trusted-publishing


### PR DESCRIPTION
## What & why

Completes the OIDC pipeline fix. #211 removed `registry-url` to eliminate the dummy-token `.npmrc` (which caused `E404` on Node 20), but that left npm with no registry anchor for the OIDC token exchange — `ENEEDAUTH` on v3.12.1/v3.12.2 (the latter on Node 22, so version wasn't the blocker).

npm's documented trusted-publishing example keeps `registry-url`. On Node >= 22.14 + npm >= 11.5.1 with a configured trusted publisher (confirmed on npmjs.com), npm mints the OIDC token and uses it, overriding the placeholder `_authToken` setup-node writes. The publish step still sets **no** `NODE_AUTH_TOKEN` env.

## Verification

YAML-only. The v3.12.3 release PR that follows tags and proves the publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)