### PR TITLE
chore(release): cut v3.12.3

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.2",
+      "version": "3.12.3",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this skill are documented here.
 
 ## [Unreleased]
 
+## [3.12.3] — 2026-06-08
+
+### Fixed
+
+- **Completed the OIDC trusted-publishing pipeline by restoring setup-node `registry-url`** — #211 had removed it to kill the dummy-token `.npmrc`, but that left npm with no registry anchor for the OIDC token exchange (`ENEEDAUTH` on 3.12.1/3.12.2). With `registry-url` back, Node 22 (#213), npm ≥ 11.5.1, and a configured trusted publisher, npm mints and uses the OIDC token. **3.12.3 is the first version actually published to npm** carrying the 3.12.0 changes (#198 positioning, #199 recall hook, #202 OIDC, #203 doc-drift, #204 tool-count); 3.12.0–3.12.2 were never published. (#215)
+
 ## [3.12.2] — 2026-06-08
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.12.2",
+      "version": "3.12.3",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.2",
+      "version": "3.12.3",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.2",
+  "version": "3.12.3",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## What & why

First version to actually publish to npm carrying the 3.12.0 work. The OIDC pipeline failed on v3.12.0 (E404), v3.12.1, v3.12.2 (ENEEDAUTH); fixed across #211 (drop dummy token), #213 (Node 22), #215 (restore registry-url to anchor the OIDC exchange). Trusted publisher confirmed on npmjs.com.

Ships to npm: #198 positioning reframe, #199 recall hook, #202 OIDC, #203 doc-drift, #204 tool-count. 3.12.0–3.12.2 were never published.

## Files (8, version-only except CHANGELOG)

Per `docs/RELEASING.md`. `npm run verify:all` green; generated tree clean.

## After merge

Tag `v3.12.3` → release.yml (Node 22 + registry-url + OIDC) publishes and cuts the GitHub Release. npm page refreshes to the new README/description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)