### PR TITLE
ci(release): run npm publish via npx npm@latest to guarantee >= 11.5.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,8 +66,16 @@ jobs:
       # Prerequisite: a trusted publisher must be configured on npmjs.com for this
       # repo + workflow file (see docs/RELEASING.md). Provenance attestations are
       # generated automatically from the OIDC claims.
+      #
+      # Run the publish through `npx npm@latest` to GUARANTEE npm >= 11.5.1 in this
+      # step: the v3.12.0-v3.12.3 OIDC publishes failed because the global
+      # `npm install -g npm@latest` above didn't reach the publish step (npm signed
+      # provenance but never minted a trusted-publishing token — the signature of
+      # npm < 11.5.1). The version echo proves which npm actually runs the publish.
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: |
+          echo "node $(node -v) / global npm $(npm -v)"
+          npx -y npm@latest publish --access public --provenance
 
       - name: Create GitHub Release
         env:


### PR DESCRIPTION
## What & why

The v3.12.0–v3.12.3 OIDC publishes failed (E404 then ENEEDAUTH then E404). The tell: npm **signed provenance** via OIDC (works on npm 10) but **never minted a trusted-publishing token** for the registry PUT — the exact signature of the publish step running npm < 11.5.1. The separate `npm install -g npm@latest` step wasn't reaching the publish step.

This runs the publish through `npx -y npm@latest publish --access public --provenance` so it definitively uses npm >= 11.5.1, and echoes `node -v`/`npm -v` before it so the next run's logs prove the version either way.

Combined with the already-merged #213 (Node 22) and #215 (registry-url), this should make OIDC trusted publishing work on the next tag.

## Status

3.12.3 already shipped to npm **manually** (login + OTP) since the OIDC path was blocked. This PR de-risks the **next** release — it's validated only on the next tag push, not by this PR's CI.

## Verification

YAML-only; the Node 18/20/22 test matrix confirms the workflow parses and the suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)