### PR TITLE
docs: sync stale v3.12.0 → v3.12.3 version refs in landing-page blueprint

### DIFF
--- a/docs/plans/2026-06-07-landing-page-blueprint-rebuild.md
+++ b/docs/plans/2026-06-07-landing-page-blueprint-rebuild.md
@@ -50,7 +50,7 @@ Enforcement mechanisms (real, accurate to the repo):
 - Goal-Drift Stop gate: Stop hook, fires goal-check, refuses "Done" on DRIFT.
 - Mulahazah instinct engine: instinct packs capture lessons so the same mistake never repeats.
 
-Real numbers only: 25 bundled skills, 7 Laws, zero runtime deps, MIT, v3.12.0.
+Real numbers only: 25 bundled skills, 7 Laws, zero runtime deps, MIT, v3.12.3.
 
 ## Design system
 
@@ -68,7 +68,7 @@ Real numbers only: 25 bundled skills, 7 Laws, zero runtime deps, MIT, v3.12.0.
 4. The Loop: full-width horizontal band of mono nodes joined by rules.
 5. Enforcement: 2-column zig-zag (not a 3-card grid), mechanism-id + accurate one-liner each.
 6. CTA: "Adopt the standard", install command, npm + Quickstart, CSS crop-mark motif.
-7. Footer: `DOC. CI-7L · REV 3.12.0 · MIT` + GitHub/npm.
+7. Footer: `DOC. CI-7L · REV 3.12.3 · MIT` + GitHub/npm.
 
 ## Motion (CSS only, gated on prefers-reduced-motion)
 


### PR DESCRIPTION
The landing-page blueprint plan still advertised `v3.12.0` / `REV 3.12.0` even though the project released v3.12.3 on 2026-06-08. A plan document referencing an outdated version risks being executed with stale expectations.

Updated both occurrences from `v3.12.0` / `REV 3.12.0` to `v3.12.3` / `REV 3.12.3` so the blueprint spec-sheet is internally consistent with the current release.

Verified with `npm run verify:all` (all 12 content invariants + typecheck pass, 801 pass / 0 fail). No generated drift.