### PR TITLE
ci(landing): daily drift check against the live domain + accurate CF Pages automation note

### DIFF
--- a/.github/workflows/landing-drift.yml
+++ b/.github/workflows/landing-drift.yml
@@ -1,0 +1,36 @@
+name: Landing drift check
+
+# Fails when continuous-improvement.dev is NOT serving the version currently in
+# docs/landing/index.html — i.e. a landing change merged to main but the manual
+# Cloudflare Pages deploy was never run. Read-only (curl + version compare): it
+# needs no secret and cannot deploy. See docs/RELEASING.md "Landing page".
+on:
+  schedule:
+    - cron: '37 7 * * *'   # daily; catches a missed deploy within 24h
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compare live domain to docs/landing source
+        run: |
+          src=$(grep -oE 'REV [0-9]+\.[0-9]+\.[0-9]+' docs/landing/index.html | head -1 | awk '{print $2}')
+          live=$(curl -fsSL --retry 3 --retry-delay 5 https://continuous-improvement.dev/ \
+            | grep -oE 'REV [0-9]+\.[0-9]+\.[0-9]+' | head -1 | awk '{print $2}')
+          echo "source docs/landing/index.html : ${src:-<none>}"
+          echo "live  continuous-improvement.dev : ${live:-<none>}"
+          if [ -z "$src" ] || [ -z "$live" ]; then
+            echo "::error::Could not extract a REV version (source='$src' live='$live'). Check the page markup or the extraction pattern."
+            exit 1
+          fi
+          if [ "$src" != "$live" ]; then
+            echo "::error::Live domain is STALE: serving $live but docs/landing is $src. Redeploy: wrangler pages deploy docs/landing --project-name=continuous-improvement --branch=main --commit-dirty=true"
+            exit 1
+          fi
+          echo "OK: live domain matches docs/landing ($src)"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -129,9 +129,18 @@ curl -s https://continuous-improvement.dev/ | grep -o "REV 3.[0-9.]*"   # confir
 domain (no preview-only step). The deploy uses your local wrangler OAuth session — there is no
 `CLOUDFLARE_API_TOKEN` secret in CI.
 
-**To automate (recommended):** connect the Pages project to the GitHub repo in the Cloudflare dashboard
-(Builds & deployments → Connect to Git; no build command, output directory `docs/landing`). Then every
-push to `main` rebuilds the live domain with no token and no manual step.
+**Catch staleness automatically:** the [`landing-drift.yml`](../.github/workflows/landing-drift.yml)
+workflow runs daily (and on demand) and fails if `continuous-improvement.dev` is not serving the version
+in `docs/landing/index.html` — so a missed deploy pages you instead of going unnoticed for weeks. It is
+read-only (curl + version compare) and needs no secret.
+
+**Full push-to-deploy (optional, involves a cutover):** Cloudflare fixes a Pages project's connection
+type at creation — a **Direct Upload** project (this one) cannot be connected to Git in place, and the
+[docs](https://developers.cloudflare.com/pages/get-started/git-integration/) confirm the reverse is also
+one-way. To get auto-deploy you must create a *new* Git-connected Pages project from the repo (no build
+command, output directory `docs/landing`), verify it on its `*.pages.dev` URL, then move the
+`continuous-improvement.dev` custom domain off the old project onto the new one. Since the OAuth-CLI
+deploy already works, the manual deploy + drift check above is the lower-risk default.
 
 > The former CI workflows `pages.yml` (GitHub Pages) and `cf-pages.yml` (Cloudflare) were removed. The
 > first deployed only to an orphaned `github.io` URL the domain never pointed at; the second failed on


### PR DESCRIPTION
## What

- **new** `.github/workflows/landing-drift.yml` — a scheduled (daily) + on-demand check that fails when `continuous-improvement.dev` is **not** serving the version in `docs/landing/index.html`. Read-only (curl + version compare); **no secret**, cannot deploy.
- **docs** `docs/RELEASING.md` — corrects the automation note added in #222 and documents the drift check.

## Why

The live site silently froze ~weeks behind `main` (v3.10.0 vs v3.12.3) under green CI because nothing watched the gap. This check pages you within 24h of a missed manual deploy.

It also fixes an inaccuracy in #222: that section said to 'connect the Pages project to the GitHub repo in the dashboard'. Cloudflare **fixes a Pages project's connection type at creation** — a Direct Upload project (this one) can't be connected to Git in place ([docs](https://developers.cloudflare.com/pages/get-started/git-integration/) confirm the reverse is one-way too). The corrected note explains the real options: the manual deploy + this drift check (lower-risk default), or a cutover to a new Git-connected project + domain move (optional).

## Verification

- Dry-ran the check logic locally against the live site: source `3.12.3` == live `3.12.3` -> OK.
- `npm run verify:all` -> exit 0 (12 invariants + typecheck). Workflow + doc only; no `.mts`/generated churn.

The check goes green immediately (the domain was deployed to v3.12.3 earlier today). It will go red only when a future landing change lands without a redeploy — which is the point.