### PR TITLE
docs(positioning): reposition copy as the persistent-memory + discipline layer (vs native ultracode)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
+      "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
       "version": "3.12.3",
       "source": "./plugins/continuous-improvement",
       "author": {

--- a/.cloudplugin/marketplace.json
+++ b/.cloudplugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.12.0",
-  "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
+  "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": "naimkatiman",
   "license": "MIT",
   "repository": "https://github.com/naimkatiman/continuous-improvement",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <h1 align="center">Claude Code that gets sharper every session</h1>
 
 <p align="center">
-  <b>Reasons deeper. Recalls what it already solved. Verifies before "done". Keeps every lesson.</b>
+  <b>Remembers what it already solved. Grounds every edit in facts. Verifies before "done". Carries every lesson into the next session.</b>
 </p>
 
 <p align="center">

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="color-scheme" content="light">
   <title>continuous-improvement · Claude Code that gets sharper every session</title>
-  <meta name="description" content="An intelligence amplifier for AI coding agents. The 7 Laws of AI Agent Discipline plus the Mulahazah instinct engine make Claude reason deeper, recall past fixes, and compound what it learns.">
+  <meta name="description" content="The persistent-memory and runtime-discipline layer for Claude Code. The 7 Laws of AI Agent Discipline plus the Mulahazah instinct engine ground every edit in facts, recall past fixes, and compound what Claude learns across sessions.">
   <meta property="og:title" content="continuous-improvement · Claude Code that gets sharper every session">
   <meta property="og:description" content="The 7 Laws of AI Agent Discipline plus instinct memory — Claude Code that researches deeper, verifies with evidence, and gets sharper every session.">
   <meta property="og:type" content="website">
@@ -263,8 +263,8 @@
       <div class="container">
         <div class="sec-head">
           <span class="kicker"><b>01</b> · The seven laws</span>
-          <h2>Intelligence, written as clauses.</h2>
-          <p>Each law has one check to pass and one red flag to catch. The runtime keeps them automatic, so the agent reasons at a higher level instead of relying on memory.</p>
+          <h2>The standard, written as clauses.</h2>
+          <p>Each law has one check to pass and one red flag to catch. The runtime keeps them automatic, so the discipline holds on every task instead of depending on the agent to remember it.</p>
         </div>
         <div class="clauses">
           <article class="clause reveal" id="law-1">

--- a/docs/plans/2026-06-08-reposition-copy-under-orchestration.md
+++ b/docs/plans/2026-06-08-reposition-copy-under-orchestration.md
@@ -1,0 +1,74 @@
+# 2026-06-08 — Reposition copy under the orchestration layer
+
+## Goal
+
+Move continuous-improvement's positioning off the "intelligence amplifier / reason
+harder" framing (shipped 2026-06-07) and onto **"the persistent-memory and
+runtime-discipline layer for Claude Code."** Opus 4.8 shipped native Workflow
+orchestration + ultracode, which already owns the "reason harder via multi-agent
+depth" claim. The defensible, non-commoditized differentiators are cross-session
+memory (recall + Mulahazah instincts) and runtime enforcement (gateguard) — things
+an in-turn orchestration primitive structurally cannot provide.
+
+## Decision
+
+- Keep the headline **"Claude Code that gets sharper every session"** — it already
+  encodes cross-session compounding, the durable promise. Not a collision.
+- Keep "The 7 Laws of AI Agent Discipline" as the sub-brand; keep Mulahazah.
+- Pivot only the supporting copy that leaned on raw-reasoning claims
+  ("reason harder/deeper", "intelligence amplifier", "reasons at a higher level").
+- Add one wedge line in llms.txt: "Orchestration tools run a task; this is the
+  layer that makes the lessons survive the run." Positioning contrast only — NOT a
+  claim of an ultracode/Workflow integration (none is built; that is PR2).
+
+## Honesty guardrail
+
+No over-claiming. Recall is BM25/lexical; instincts decay and need reinforcement;
+gateguard genuinely blocks. The orchestration contrast is positioning, not an
+integration claim.
+
+## Files (hand-edited source)
+
+- src/lib/plugin-metadata.mts — SHARED_PLUGIN_DESCRIPTION (canonical; npm run build
+  propagates to the three manifests + lib mirror).
+- package.json — description (hand-maintained; the generator does not write it).
+- llms.txt — blockquote mirror + "What This Is" + orchestration wedge.
+- README.md — subtitle bold line.
+- docs/landing/index.html — meta description + "the seven laws" sec-head h2/p.
+- .cloudplugin/marketplace.json — description (hand-maintained; build does not
+  regenerate it).
+
+## Generated (via npm run build, committed)
+
+.claude-plugin/marketplace.json, plugins/continuous-improvement/.claude-plugin/{plugin,marketplace}.json,
+lib/plugin-metadata.mjs + plugin lib mirror.
+
+## Invariants preserved
+
+- verify:skill-count — "25 bundled skills" literal kept in every description surface.
+- 7-Law names, verify:doc-runtime-claims gateguard anchors, the README install
+  decision rule, planning-with-files / task_plan.md / ci_plan_init — all untouched.
+
+## Verification
+
+npm run verify:all (12 invariants + typecheck) green.
+
+## Deferred
+
+- .cloudplugin/marketplace.json version is stale (3.12.0 vs package 3.12.3) —
+  pre-existing, out of scope for a copy PR; bump in a release/version PR.
+- Explicit "CI x ultracode" wedge on the public landing page (a sharper, named
+  contrast) — deferred to operator review. PR1 only de-collides; it adds no
+  ultracode-named section.
+- PR2: Workflow-run -> instinct bridge (Stop-boundary distiller turning a completed
+  native Workflow run into a persisted Mulahazah instinct) — the real integration;
+  separate TDD PR.
+- Release/version bump + npm publish + landing deploy are operator actions.
+
+## Tension acknowledged
+
+This partially walks back the operator's 2026-06-07 "higher intelligence /
+effectiveness" motto. Surfaced in the audit that preceded this PR; operator
+approved the repositioning ("yes, copy first"). The motto's intent (capability,
+not seatbelt-restriction) is preserved — persistent memory and grounded edits are
+capabilities, framed as such.

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -26,7 +26,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
+const SHARED_PLUGIN_DESCRIPTION = "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
 // See third-party/MANIFEST.md for refresh recipes and per-snapshot

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,10 @@
 # continuous-improvement
 
-> Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.
+> The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.
 
 ## What This Is
 
-An intelligence amplifier for AI coding agents. It makes Claude reason at a higher level on every task, recall the corrections it has already received, and learn from each session so its competence compounds over time — research, plan, execute one thing at a time, verify, reflect, iterate, learn — building behavioral instincts via the Mulahazah learning system, so the same correction never has to be given twice and each run starts smarter than the last.
+The persistent-memory and discipline layer for AI coding agents. It carries the corrections Claude has already received from one session into the next, grounds each edit in real facts before it lands, and learns from every session so its competence compounds over time — research, plan, execute one thing at a time, verify, reflect, iterate, learn — building behavioral instincts via the Mulahazah learning system, so the same correction never has to be given twice and each run starts smarter than the last. Orchestration tools run a task; this is the layer that makes the lessons survive the run.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.12.3",
-  "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
+  "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",
     "claude-code-skill",

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
   "plugins": [
     {
       "name": "continuous-improvement",
-      "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
+      "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
       "version": "3.12.3",
       "source": "./",
       "author": {

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "continuous-improvement",
   "version": "3.12.3",
-  "description": "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
+  "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",
     "url": "https://github.com/naimkatiman"

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -26,7 +26,7 @@ const KEYWORDS = [
     "transcript-linter",
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
-const SHARED_PLUGIN_DESCRIPTION = "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
+const SHARED_PLUGIN_DESCRIPTION = "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.
 // See third-party/MANIFEST.md for refresh recipes and per-snapshot

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -147,7 +147,7 @@ const KEYWORDS = [
 ];
 const CLAUDE_PLUGIN_CATEGORY = "productivity";
 const SHARED_PLUGIN_DESCRIPTION =
-  "Makes Claude Code reason harder, recall past corrections, and learn from every session so its competence compounds run over run. The Mulahazah engine turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time — no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
+  "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.";
 
 // Four vendored upstream companions registered alongside the CI plugin.
 // Each entry points at a pinned-SHA snapshot under third-party/<name>/.


### PR DESCRIPTION
## Why

Opus 4.8 shipped native **Workflow** orchestration + **ultracode**, which now own the "reason harder via multi-agent depth" claim. The 2026-06-07 reframe had just pointed our headline copy at exactly that lane ("intelligence amplifier", "reason harder/deeper", "reasons at a higher level"). This repositions the user-facing copy onto the two differentiators an in-turn orchestration primitive **structurally cannot** provide:

- **Persistent cross-session memory** — recall (BM25) + Mulahazah instincts that survive between runs.
- **Runtime enforcement** — `gateguard` grounding edits in facts before they land.

Orchestration runs a task; this is the layer that makes the lessons survive the run.

## What changed (copy only — no behavior change)

| Surface | Change |
|---|---|
| `src/lib/plugin-metadata.mts` | `SHARED_PLUGIN_DESCRIPTION` repositioned (canonical; build propagates to the 3 manifests + lib mirror) |
| `package.json` | description (hand-maintained; generator does not write it) |
| `llms.txt` | blockquote mirror + "What This Is" + one orchestration wedge line |
| `README.md` | subtitle bold line |
| `docs/landing/index.html` | meta description + "the seven laws" sec-head h2/p |
| `.cloudplugin/marketplace.json` | description (hand-maintained; build does not regenerate it) |
| generated | `.claude-plugin/marketplace.json`, plugin `{plugin,marketplace}.json`, lib mirrors |

**Headline kept:** "Claude Code that gets sharper every session" already encodes cross-session compounding — it is the durable promise, not a collision.

## Invariants preserved

- `verify:skill-count` — `25 bundled skills` literal kept in every description surface.
- 7-Law names, `verify:doc-runtime-claims` gateguard anchors, the README install decision rule, `planning-with-files` / `task_plan.md` / `ci_plan_init` — all untouched.

## Honesty guardrail

No over-claiming. Recall is lexical (BM25), instincts decay, gateguard genuinely blocks. The orchestration contrast is **positioning, not an integration claim** — there is no ultracode/Workflow integration yet (that is the deferred PR2 bridge).

## Verification

- `npm run verify:all` → green (12 invariants + typecheck).
- `npm run verify:generated` → clean (`git diff --exit-code` on generated dirs returns 0).

## Deferred (logged in the plan doc)

- **PR2** — Workflow-run → instinct bridge: a Stop-boundary distiller turning a completed native Workflow run into a persisted Mulahazah instinct. The real integration; separate TDD PR.
- Explicit "CI × ultracode" wedge on the public landing page — left to operator review; PR1 only de-collides.
- `.cloudplugin/marketplace.json` version stale (3.12.0 vs 3.12.3) — pre-existing, out of scope; bump in a release PR.
- Release/version bump + npm publish + landing deploy — operator actions.

Plan: `docs/plans/2026-06-08-reposition-copy-under-orchestration.md`