### PR TITLE
feat(distill): turn a verified Workflow run into a draft instinct (the ultracode-to-memory bridge)

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -130,7 +130,7 @@ Corrections drop instinct confidence. Unused instincts decay. The system self-co
 
 ## Expert (npx) — only if you want MCP, hooks, or instinct packs
 
-The Beginner path above is enough for most users. Pick this only if you want the MCP tools (18 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, or the starter instinct packs.
+The Beginner path above is enough for most users. Pick this only if you want the MCP tools (19 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, or the starter instinct packs.
 
 Do not run both paths against the same `~/.claude/` — that produces duplicated state. Pick one and stick with it.
 

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ V1 honest limitations: the runtime gate is honor-system once the agent flips `_g
 
 ### Expert — adds MCP server, observation hooks, and instinct packs
 
-Pick this if you want the MCP tools (18 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, and starter packs.
+Pick this if you want the MCP tools (19 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, and starter packs.
 
 Preconditions: Node 18 / 20 / 22, plus bash on Windows (Git Bash or WSL — `hooks/observe.sh` is a bash script and silently no-ops without it). **`jq` is no longer required**: as of v3.6.0, `observe.sh` prefers the Node observer (`bin/observe.mjs`) which writes the rich event schema natively without external dependencies. The bash thin-schema path is kept as a two-phase shim, so legacy installs that have not re-run `npx continuous-improvement install` since v3.5.x will still degrade silently without `jq` (`winget install jqlang.jq` on Windows, `brew install jq` on macOS, `apt install jq` on Debian/Ubuntu) — re-running the installer is the cleaner fix and removes the dependency entirely. See [CHANGELOG.md](CHANGELOG.md) `[3.6.0]` for the migration details.
 

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -20,7 +20,7 @@ import { createHash } from "node:crypto";
 import { PACKAGE_NAME, VERSION, getToolDefinitions, isPluginMode, } from "../lib/plugin-metadata.mjs";
 import { formatDriftReport, parseGoalFromPlan, scoreObservations, } from "../lib/goal-state.mjs";
 import { buildIndex, formatRecallHits, parseSince, query as queryRecall, } from "../lib/recall-index.mjs";
-import { draftFromCandidate, extractTrajectories, findCandidates, formatCandidates, serializeDraft, } from "../lib/skill-distill.mjs";
+import { draftFromCandidate, draftFromWorkflowRun, extractTrajectories, findCandidates, formatCandidates, serializeDraft, workflowRunFromObservations, } from "../lib/skill-distill.mjs";
 import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 function getHomeDir() {
     return process.env.HOME || process.env.USERPROFILE || homedir();
@@ -831,6 +831,37 @@ function handleTool(name, params) {
                 "Edit the body to capture the real recipe (preconditions, concrete steps, gotchas), then promote with:",
                 "",
                 `  ci_distill_promote id=${id}`,
+                "",
+                "```yaml",
+                draft.trimEnd(),
+                "```",
+            ].join("\n"));
+        }
+        case "ci_distill_from_workflow": {
+            if (MODE !== "expert") {
+                return error("ci_distill_from_workflow requires expert mode");
+            }
+            const run = workflowRunFromObservations(readDistillObservations(project.hash));
+            if (!run) {
+                return text("No completed-and-verified Workflow run found in this project's observations. " +
+                    "A run qualifies when a `Workflow` tool call is followed by a passing verify/test/build in the same feed. " +
+                    "Run a workflow, verify its output, then try `ci_distill_from_workflow` again.");
+            }
+            const draftInstinct = draftFromWorkflowRun(run);
+            const draft = serializeDraft(draftInstinct);
+            const draftsDir = join(INSTINCTS_DIR, project.hash, "drafts");
+            mkdirSync(draftsDir, { recursive: true });
+            const draftPath = join(draftsDir, `${draftInstinct.id}.yaml`);
+            writeFileSync(draftPath, draft);
+            return text([
+                "## Draft written from a verified workflow run",
+                "",
+                `**Workflow:** ${run.name}`,
+                `**Path:** ${draftPath}`,
+                "",
+                "Edit the body to capture the real recipe (preconditions, concrete steps, gotchas), then promote with:",
+                "",
+                `  ci_distill_promote id=${draftInstinct.id}`,
                 "",
                 "```yaml",
                 draft.trimEnd(),

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -848,11 +848,19 @@ function handleTool(name, params) {
                     "Run a workflow, verify its output, then try `ci_distill_from_workflow` again.");
             }
             const draftInstinct = draftFromWorkflowRun(run);
+            if (!isSafeDraftId(draftInstinct.id)) {
+                return error(`Internal error: generated draft id "${draftInstinct.id}" failed the safety check.`);
+            }
             const draft = serializeDraft(draftInstinct);
             const draftsDir = join(INSTINCTS_DIR, project.hash, "drafts");
-            mkdirSync(draftsDir, { recursive: true });
             const draftPath = join(draftsDir, `${draftInstinct.id}.yaml`);
-            writeFileSync(draftPath, draft);
+            try {
+                mkdirSync(draftsDir, { recursive: true });
+                writeFileSync(draftPath, draft);
+            }
+            catch (err) {
+                return error(`Failed to write draft to ${draftPath}: ${err instanceof Error ? err.message : String(err)}`);
+            }
             return text([
                 "## Draft written from a verified workflow run",
                 "",

--- a/docs/plans/2026-06-08-workflow-instinct-bridge.md
+++ b/docs/plans/2026-06-08-workflow-instinct-bridge.md
@@ -53,9 +53,10 @@ warrants a draft — `minSessions`/`minOccurrences` do not apply.
 - MCP tool `ci_distill_from_workflow` (expert): `readDistillObservations` →
   `workflowRunFromObservations` → `draftFromWorkflowRun` → `serializeDraft` → write to
   `drafts/`. Promotion stays `ci_distill_promote`, unchanged. Tool count 18 → 19.
-- Stop hook `workflow-distill.mjs` (fail-open, opt-in via env, default off): on Stop,
-  if the session shows a verified Workflow run, print ONE stderr nudge to run
-  `ci_distill_from_workflow`. Never writes, never blocks.
+- **Deferred to a fast-follow PR (not in this commit)** — Stop hook
+  `workflow-distill.mjs` (fail-open, opt-in, default off): on Stop, if the session
+  shows a verified Workflow run, print ONE stderr nudge to run
+  `ci_distill_from_workflow`. This PR ships the MCP tool only.
 
 ## Fail-closed boundaries (the 2026-06-03 audit lesson)
 
@@ -70,11 +71,12 @@ null, never fabricated.
 - `src/lib/skill-distill.mts` — two functions + `WorkflowRun` type.
 - `src/test/skill-distill.test.mts` — RED→GREEN boundary + happy-path.
 - `src/bin/mcp-server.mts` — `ci_distill_from_workflow` case.
-- `src/lib/plugin-metadata.mts` — `EXPERT_TOOL_ENTRIES` entry + `workflow-distill`
-  Stop-hook registration in `getPluginHooksConfig`.
-- `src/hooks/workflow-distill.mts` — new Stop hook.
+- `src/lib/plugin-metadata.mts` — `EXPERT_TOOL_ENTRIES` entry for the MCP tool.
 - `docs/skills.md`, `README.md`, `QUICKSTART.md` — expert tool count 18 → 19.
 - Generated (via `npm run build`): manifests + `plugins/` mirror + tool-count claims.
+- **Deferred (fast-follow):** `src/hooks/workflow-distill.mts` + its
+  `getPluginHooksConfig` Stop registration — the auto-detect nudge, shipped
+  separately to keep this PR single-concern (the MCP capability).
 
 ## Verification
 

--- a/docs/plans/2026-06-08-workflow-instinct-bridge.md
+++ b/docs/plans/2026-06-08-workflow-instinct-bridge.md
@@ -1,0 +1,100 @@
+# 2026-06-08 — Workflow-run → instinct bridge
+
+## Goal
+
+Make a completed native Workflow run (Opus 4.8 orchestration / ultracode) leave a
+durable trace in the Mulahazah learning engine, so the lessons of an expensive
+multi-agent run survive the run instead of evaporating when the turn ends — the one
+integration a per-turn orchestration primitive cannot do for itself, and the concrete
+payoff of the PR #225 repositioning.
+
+## Probe findings (grounded, not assumed)
+
+Two probes against the live observation feed (`instincts/<hash>/observations.jsonl`)
+settled the design:
+
+- **Sub-agent activity is captured** — a Workflow/Agent sub-agent's own tool calls
+  land in the same feed, tagged with the **parent** session id (not a separate one).
+  So no journal parsing and no trajectory-split complication.
+- **The `Workflow` row carries the script** in `input_summary` as `{"script":"..."}`,
+  truncated to ~500 chars — `meta.name`/`meta.description`/`meta.phases` sit at the top
+  and survive truncation. `output_summary` = `{"status","taskId","runId","summary"}`.
+- **The feed records the launch, not the completion** — `status: "async_launched"`.
+  So workflow success is NOT in the Workflow row; it must be inferred from a following
+  verify-exit-0 in the same session. This is the success gate.
+- The reader `readDistillObservations` (mcp-server.mts) maps every row with no `event`
+  filter, so both `tool_start` and `tool_complete` flow in; a *completed* row is one
+  with a non-empty `output_summary`. Some bare rows lack `input_summary` → parse
+  defensively.
+
+## Design (reuse first — Law 1)
+
+Extend `src/lib/skill-distill.mts`; reuse `serializeDraft`, the `drafts/` ladder
+(`ci_distill_propose`→edit→`ci_distill_promote` at 0.5), and the `slugify` path guard.
+Two new pure functions (no I/O):
+
+- `workflowRunFromObservations(observations): WorkflowRun | null` — finds the most
+  recent `tool === "Workflow"` row with a parseable `{"script":...}` in
+  `input_summary`, extracts `name`/`description`/`phases` from the script head, and
+  requires a following verify-exit-0 (reusing the existing success classifier on the
+  post-Workflow slice). Returns `null` (fail closed) on: no Workflow row, unparseable
+  meta, no `name`, or no following verification.
+- `draftFromWorkflowRun(run): DraftInstinct` — body = name + description + phase
+  outline + the verify command that proved it; `source: distilled-workflow`,
+  `confidence: 0.4`, `status: draft`. The script is the recipe, so the body is real,
+  not a placeholder; the human still edits before promote.
+
+Singular-run rationale: the existing distiller requires a pattern across ≥2 sessions
+(coincidence guard). A Workflow is an authored recipe, so a single verified run
+warrants a draft — `minSessions`/`minOccurrences` do not apply.
+
+## Surface
+
+- MCP tool `ci_distill_from_workflow` (expert): `readDistillObservations` →
+  `workflowRunFromObservations` → `draftFromWorkflowRun` → `serializeDraft` → write to
+  `drafts/`. Promotion stays `ci_distill_promote`, unchanged. Tool count 18 → 19.
+- Stop hook `workflow-distill.mjs` (fail-open, opt-in via env, default off): on Stop,
+  if the session shows a verified Workflow run, print ONE stderr nudge to run
+  `ci_distill_from_workflow`. Never writes, never blocks.
+
+## Fail-closed boundaries (the 2026-06-03 audit lesson)
+
+RED tests first for: no Workflow row → null; Workflow row with empty/unparseable
+`input_summary` → null; `async_launched` with no following verify → null; verify
+present → run returned; traversal-hostile `meta.name` → slugified id stays inside
+`drafts/`; truncated script (meta intact) → parsed; truncated script (meta cut) →
+null, never fabricated.
+
+## Files
+
+- `src/lib/skill-distill.mts` — two functions + `WorkflowRun` type.
+- `src/test/skill-distill.test.mts` — RED→GREEN boundary + happy-path.
+- `src/bin/mcp-server.mts` — `ci_distill_from_workflow` case.
+- `src/lib/plugin-metadata.mts` — `EXPERT_TOOL_ENTRIES` entry + `workflow-distill`
+  Stop-hook registration in `getPluginHooksConfig`.
+- `src/hooks/workflow-distill.mts` — new Stop hook.
+- `docs/skills.md`, `README.md`, `QUICKSTART.md` — expert tool count 18 → 19.
+- Generated (via `npm run build`): manifests + `plugins/` mirror + tool-count claims.
+
+## Verification
+
+`npm run build` → `node --test test/skill-distill.test.mjs` (RED then GREEN) →
+`npm run verify:all` (incl. tool-count 19) → `npm run verify:generated`. Adversarial
+review (parallel reviewers) on the diff before PR.
+
+## Follow-up: three gateguard defects found while unblocking (separate PR)
+
+Not in scope here, logged so they are not lost:
+
+1. **Cap counts raw keys.** `isCapReached`/the hook count `Object.keys(cleared_files).length`
+   while `isFileCleared` canonicalizes — case/separator/drive-letter variants are stored
+   as distinct keys (`markFileCleared` does canonicalize on store now, but legacy/mixed
+   entries persist), so the 50-cap trips early on duplicate keys. Count canonical keys.
+2. **Naive destructive substring match.** `isDestructiveBash` lowercases the whole
+   command (including heredoc bodies) and substring-matches patterns like `format ` /
+   `truncate ` / `drop ` — prose containing those words false-trips the gate. Match on
+   token/command boundaries.
+3. **Session dir is project-scoped, never resets.** `resolveSessionDir` keys only on
+   project hash, so the "start a new session to reset" message is wrong — the file
+   accumulates across days/sessions until manually deleted. Add a real per-session
+   component or a SessionStart rotation.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -44,7 +44,7 @@ Tier 1 + featured + companion. Auto-installed when you run the plugin install co
 
 ## Expert gets — additionally
 
-Tier 2 (`safety-guard`, `strategic-compact`, `token-budget-advisor`, `wild-risa-balance`), the MCP server (18 tools), session-observation hooks for Mulahazah, and `/learn-eval` for capturing session patterns into new skills.
+Tier 2 (`safety-guard`, `strategic-compact`, `token-budget-advisor`, `wild-risa-balance`), the MCP server (19 tools), session-observation hooks for Mulahazah, and `/learn-eval` for capturing session patterns into new skills.
 
 ## Drop-in single-file install
 

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -373,6 +373,12 @@ const EXPERT_TOOL_ENTRIES = [
             required: ["id"],
         },
     },
+    {
+        name: "ci_distill_from_workflow",
+        description: "Draft a reusable instinct from the most recent completed-and-verified native Workflow run in this project's observation feed. A Workflow script is an authored recipe, so a single run whose output passed verification is enough — unlike ci_distill_candidates, which needs a pattern repeated across sessions. Writes a DRAFT to drafts/ (a skeleton you edit); it changes no behavior until promoted with ci_distill_promote. Returns a message when no verified workflow run is found.",
+        manifestWhat: "Draft a reusable instinct from a verified Workflow run",
+        inputSchema: { type: "object", properties: {}, required: [] },
+    },
 ];
 const MODE_METADATA = {
     beginner: {

--- a/lib/skill-distill.mjs
+++ b/lib/skill-distill.mjs
@@ -260,14 +260,23 @@ function parseWorkflowScript(inputSummary) {
     }
     if (!script)
         return null;
-    const name = (script.match(/name\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    // Scope name/description to the meta head (text before `phases:`) so a phase
+    // object's own description: is never mistaken for meta.description; scope phase
+    // titles to the phases array literal so inline agent/step title: fields are not
+    // captured. The capture classes exclude quotes and newlines, so a hostile
+    // name/description cannot inject lines into the draft YAML — serializeDraft emits
+    // trigger as a quoted scalar.
+    const phasesAt = script.search(/\bphases\s*:/);
+    const metaHead = phasesAt >= 0 ? script.slice(0, phasesAt) : script;
+    const name = (metaHead.match(/\bname\s*:\s*['"]([^'"\r\n]+)['"]/) ?? [])[1] ?? "";
     if (!name)
         return null; // fail closed: no recipe identity
-    const description = (script.match(/description\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    const description = (metaHead.match(/\bdescription\s*:\s*['"]([^'"\r\n]+)['"]/) ?? [])[1] ?? "";
+    const phasesBlock = (script.match(/\bphases\s*:\s*\[([^\]]*)\]/) ?? [])[1] ?? "";
     const phases = [];
-    const phaseRe = /title\s*:\s*['"]([^'"]+)['"]/g;
+    const phaseRe = /\btitle\s*:\s*['"]([^'"\r\n]+)['"]/g;
     let pm;
-    while ((pm = phaseRe.exec(script)) !== null)
+    while ((pm = phaseRe.exec(phasesBlock)) !== null)
         phases.push(pm[1]);
     return { name, description, phases };
 }
@@ -302,10 +311,17 @@ export function workflowRunFromObservations(observations) {
     }
     if (wfIndex === -1 || !meta)
         return null;
+    const wfSession = (observations[wfIndex].session ?? "").toString();
+    // The verify that proves the run must follow the Workflow row in the SAME session.
+    // A verify from an unrelated later task (different session) does not count — the
+    // run is asynchronous, so an interleaved verify could otherwise falsely prove it.
     let verifyCommand = "";
     for (let i = wfIndex + 1; i < observations.length; i += 1) {
-        if (isVerifySuccessRow(observations[i])) {
-            verifyCommand = (observations[i].input_summary ?? "").toString();
+        const row = observations[i];
+        if ((row.session ?? "").toString() !== wfSession)
+            continue;
+        if (isVerifySuccessRow(row)) {
+            verifyCommand = (row.input_summary ?? "").toString();
             break;
         }
     }
@@ -320,7 +336,9 @@ export function workflowRunFromObservations(observations) {
  * `draft-workflow-` id prefix marks the source and stays filesystem-safe.
  */
 export function draftFromWorkflowRun(run) {
-    const slug = slugifyNgram([run.name]);
+    // Cap the slug so a hostile/huge meta.name cannot produce a path that trips
+    // ENAMETOOLONG on write; strip a trailing hyphen left by the cut.
+    const slug = slugifyNgram([run.name]).slice(0, 120).replace(/-+$/, "") || "workflow";
     const phaseLine = run.phases.length > 0 ? run.phases.join(" → ") : "(phases not captured)";
     const lines = [
         `When this situation recurs, the workflow "${run.name}" handled it end to end and its output passed verification.`,

--- a/lib/skill-distill.mjs
+++ b/lib/skill-distill.mjs
@@ -220,3 +220,126 @@ export function formatCandidates(candidates, limit = 10) {
     }
     return lines.join("\n");
 }
+// ── Workflow-run → instinct bridge ───────────────────────────────────────────
+// A native Workflow run (Opus 4.8 orchestration / ultracode) is recorded in the
+// observation feed as a `tool: "Workflow"` row whose input_summary holds
+// {"script":"..."} — truncated (~500 chars), but meta.name/description/phases sit
+// at the head of the script and survive. The output_summary holds
+// {"status","runId",...} with status "async_launched": the feed captures the
+// LAUNCH, not the result. So a workflow's success is never read from the Workflow
+// row itself — it is inferred from a following verify-exit-0 in the same feed.
+//
+// Unlike findCandidates (which needs a pattern recurring across >=2 sessions to
+// reject coincidence), a Workflow script is an AUTHORED recipe: one verified run
+// warrants a draft, so the session/occurrence thresholds do not apply here.
+const WORKFLOW_TOOL = "Workflow";
+// Pull meta.name / meta.description / meta.phases[].title out of a (possibly
+// truncated) workflow script embedded as JSON in the observation input_summary.
+// Fail-closed: returns null unless a name is recoverable — a recipe with no
+// identity is never fabricated.
+function parseWorkflowScript(inputSummary) {
+    if (!inputSummary)
+        return null;
+    let script = "";
+    try {
+        const parsed = JSON.parse(inputSummary);
+        if (typeof parsed.script === "string")
+            script = parsed.script;
+    }
+    catch {
+        // input_summary may itself be truncated mid-JSON; recover the script field loosely.
+        const m = inputSummary.match(/"script"\s*:\s*"((?:[^"\\]|\\.)*)/);
+        if (m) {
+            try {
+                script = JSON.parse(`"${m[1]}"`);
+            }
+            catch {
+                script = m[1].replace(/\\n/g, "\n").replace(/\\"/g, '"').replace(/\\'/g, "'");
+            }
+        }
+    }
+    if (!script)
+        return null;
+    const name = (script.match(/name\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    if (!name)
+        return null; // fail closed: no recipe identity
+    const description = (script.match(/description\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    const phases = [];
+    const phaseRe = /title\s*:\s*['"]([^'"]+)['"]/g;
+    let pm;
+    while ((pm = phaseRe.exec(script)) !== null)
+        phases.push(pm[1]);
+    return { name, description, phases };
+}
+// A single verify-exit-0 Bash row: a verify/test/build command whose output is not
+// failing. Mirrors classifyTrajectorySuccess's verify branch for one observation.
+function isVerifySuccessRow(observation) {
+    if ((observation.tool ?? "") !== "Bash")
+        return false;
+    const input = (observation.input_summary ?? "").toString();
+    const output = (observation.output_summary ?? "").toString();
+    return VERIFY_CMD.test(input) && !FAILURE_MARKER.test(output) && (output === "" || SUCCESS_MARKER.test(output));
+}
+/**
+ * Detect the most recent completed-and-verified Workflow run in an observation
+ * list. Returns null (fail closed) unless: a `tool: "Workflow"` row carries a
+ * parseable script with a name, AND a verify-exit-0 row follows it in the feed.
+ * The trailing verify is the only success signal — the Workflow row records the
+ * launch, never the result.
+ */
+export function workflowRunFromObservations(observations) {
+    let wfIndex = -1;
+    let meta = null;
+    for (let i = observations.length - 1; i >= 0; i -= 1) {
+        if ((observations[i].tool ?? "") !== WORKFLOW_TOOL)
+            continue;
+        const parsed = parseWorkflowScript((observations[i].input_summary ?? "").toString());
+        if (parsed) {
+            wfIndex = i;
+            meta = parsed;
+            break;
+        }
+    }
+    if (wfIndex === -1 || !meta)
+        return null;
+    let verifyCommand = "";
+    for (let i = wfIndex + 1; i < observations.length; i += 1) {
+        if (isVerifySuccessRow(observations[i])) {
+            verifyCommand = (observations[i].input_summary ?? "").toString();
+            break;
+        }
+    }
+    if (!verifyCommand)
+        return null; // fail closed: no evidence the run's output landed
+    return { name: meta.name, description: meta.description, phases: meta.phases, verifyCommand };
+}
+/**
+ * Turn a verified Workflow run into a DRAFT instinct. The script's phase outline is
+ * a real skeleton (not a placeholder n-gram), but the human still edits the body
+ * before promoting. Reuses serializeDraft and the drafts/ ladder; the
+ * `draft-workflow-` id prefix marks the source and stays filesystem-safe.
+ */
+export function draftFromWorkflowRun(run) {
+    const slug = slugifyNgram([run.name]);
+    const phaseLine = run.phases.length > 0 ? run.phases.join(" → ") : "(phases not captured)";
+    const lines = [
+        `When this situation recurs, the workflow "${run.name}" handled it end to end and its output passed verification.`,
+        "",
+    ];
+    if (run.description)
+        lines.push(`Intent: ${run.description}`);
+    lines.push(`Phases: ${phaseLine}`);
+    lines.push(`Verified by: ${run.verifyCommand}`);
+    lines.push("", "Replace this with the concrete steps, preconditions, and gotchas before promoting —", "the phase outline is the skeleton, not the full recipe.");
+    return {
+        id: `draft-workflow-${slug}`,
+        trigger: `Auto-detected from a verified workflow run: ${run.name}${run.description ? ` — ${run.description}` : ""}`,
+        body: lines.join("\n"),
+        confidence: DRAFT_CONFIDENCE,
+        domain: "workflow",
+        ngram: run.phases.length > 0 ? run.phases : [run.name],
+        occurrences: 1,
+        sessions: 1,
+        outcome: "workflow-verified",
+    };
+}

--- a/plugins/continuous-improvement/bin/mcp-server.mjs
+++ b/plugins/continuous-improvement/bin/mcp-server.mjs
@@ -20,7 +20,7 @@ import { createHash } from "node:crypto";
 import { PACKAGE_NAME, VERSION, getToolDefinitions, isPluginMode, } from "../lib/plugin-metadata.mjs";
 import { formatDriftReport, parseGoalFromPlan, scoreObservations, } from "../lib/goal-state.mjs";
 import { buildIndex, formatRecallHits, parseSince, query as queryRecall, } from "../lib/recall-index.mjs";
-import { draftFromCandidate, extractTrajectories, findCandidates, formatCandidates, serializeDraft, } from "../lib/skill-distill.mjs";
+import { draftFromCandidate, draftFromWorkflowRun, extractTrajectories, findCandidates, formatCandidates, serializeDraft, workflowRunFromObservations, } from "../lib/skill-distill.mjs";
 import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 function getHomeDir() {
     return process.env.HOME || process.env.USERPROFILE || homedir();
@@ -831,6 +831,37 @@ function handleTool(name, params) {
                 "Edit the body to capture the real recipe (preconditions, concrete steps, gotchas), then promote with:",
                 "",
                 `  ci_distill_promote id=${id}`,
+                "",
+                "```yaml",
+                draft.trimEnd(),
+                "```",
+            ].join("\n"));
+        }
+        case "ci_distill_from_workflow": {
+            if (MODE !== "expert") {
+                return error("ci_distill_from_workflow requires expert mode");
+            }
+            const run = workflowRunFromObservations(readDistillObservations(project.hash));
+            if (!run) {
+                return text("No completed-and-verified Workflow run found in this project's observations. " +
+                    "A run qualifies when a `Workflow` tool call is followed by a passing verify/test/build in the same feed. " +
+                    "Run a workflow, verify its output, then try `ci_distill_from_workflow` again.");
+            }
+            const draftInstinct = draftFromWorkflowRun(run);
+            const draft = serializeDraft(draftInstinct);
+            const draftsDir = join(INSTINCTS_DIR, project.hash, "drafts");
+            mkdirSync(draftsDir, { recursive: true });
+            const draftPath = join(draftsDir, `${draftInstinct.id}.yaml`);
+            writeFileSync(draftPath, draft);
+            return text([
+                "## Draft written from a verified workflow run",
+                "",
+                `**Workflow:** ${run.name}`,
+                `**Path:** ${draftPath}`,
+                "",
+                "Edit the body to capture the real recipe (preconditions, concrete steps, gotchas), then promote with:",
+                "",
+                `  ci_distill_promote id=${draftInstinct.id}`,
                 "",
                 "```yaml",
                 draft.trimEnd(),

--- a/plugins/continuous-improvement/bin/mcp-server.mjs
+++ b/plugins/continuous-improvement/bin/mcp-server.mjs
@@ -848,11 +848,19 @@ function handleTool(name, params) {
                     "Run a workflow, verify its output, then try `ci_distill_from_workflow` again.");
             }
             const draftInstinct = draftFromWorkflowRun(run);
+            if (!isSafeDraftId(draftInstinct.id)) {
+                return error(`Internal error: generated draft id "${draftInstinct.id}" failed the safety check.`);
+            }
             const draft = serializeDraft(draftInstinct);
             const draftsDir = join(INSTINCTS_DIR, project.hash, "drafts");
-            mkdirSync(draftsDir, { recursive: true });
             const draftPath = join(draftsDir, `${draftInstinct.id}.yaml`);
-            writeFileSync(draftPath, draft);
+            try {
+                mkdirSync(draftsDir, { recursive: true });
+                writeFileSync(draftPath, draft);
+            }
+            catch (err) {
+                return error(`Failed to write draft to ${draftPath}: ${err instanceof Error ? err.message : String(err)}`);
+            }
             return text([
                 "## Draft written from a verified workflow run",
                 "",

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -373,6 +373,12 @@ const EXPERT_TOOL_ENTRIES = [
             required: ["id"],
         },
     },
+    {
+        name: "ci_distill_from_workflow",
+        description: "Draft a reusable instinct from the most recent completed-and-verified native Workflow run in this project's observation feed. A Workflow script is an authored recipe, so a single run whose output passed verification is enough — unlike ci_distill_candidates, which needs a pattern repeated across sessions. Writes a DRAFT to drafts/ (a skeleton you edit); it changes no behavior until promoted with ci_distill_promote. Returns a message when no verified workflow run is found.",
+        manifestWhat: "Draft a reusable instinct from a verified Workflow run",
+        inputSchema: { type: "object", properties: {}, required: [] },
+    },
 ];
 const MODE_METADATA = {
     beginner: {

--- a/plugins/continuous-improvement/lib/skill-distill.mjs
+++ b/plugins/continuous-improvement/lib/skill-distill.mjs
@@ -260,14 +260,23 @@ function parseWorkflowScript(inputSummary) {
     }
     if (!script)
         return null;
-    const name = (script.match(/name\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    // Scope name/description to the meta head (text before `phases:`) so a phase
+    // object's own description: is never mistaken for meta.description; scope phase
+    // titles to the phases array literal so inline agent/step title: fields are not
+    // captured. The capture classes exclude quotes and newlines, so a hostile
+    // name/description cannot inject lines into the draft YAML — serializeDraft emits
+    // trigger as a quoted scalar.
+    const phasesAt = script.search(/\bphases\s*:/);
+    const metaHead = phasesAt >= 0 ? script.slice(0, phasesAt) : script;
+    const name = (metaHead.match(/\bname\s*:\s*['"]([^'"\r\n]+)['"]/) ?? [])[1] ?? "";
     if (!name)
         return null; // fail closed: no recipe identity
-    const description = (script.match(/description\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    const description = (metaHead.match(/\bdescription\s*:\s*['"]([^'"\r\n]+)['"]/) ?? [])[1] ?? "";
+    const phasesBlock = (script.match(/\bphases\s*:\s*\[([^\]]*)\]/) ?? [])[1] ?? "";
     const phases = [];
-    const phaseRe = /title\s*:\s*['"]([^'"]+)['"]/g;
+    const phaseRe = /\btitle\s*:\s*['"]([^'"\r\n]+)['"]/g;
     let pm;
-    while ((pm = phaseRe.exec(script)) !== null)
+    while ((pm = phaseRe.exec(phasesBlock)) !== null)
         phases.push(pm[1]);
     return { name, description, phases };
 }
@@ -302,10 +311,17 @@ export function workflowRunFromObservations(observations) {
     }
     if (wfIndex === -1 || !meta)
         return null;
+    const wfSession = (observations[wfIndex].session ?? "").toString();
+    // The verify that proves the run must follow the Workflow row in the SAME session.
+    // A verify from an unrelated later task (different session) does not count — the
+    // run is asynchronous, so an interleaved verify could otherwise falsely prove it.
     let verifyCommand = "";
     for (let i = wfIndex + 1; i < observations.length; i += 1) {
-        if (isVerifySuccessRow(observations[i])) {
-            verifyCommand = (observations[i].input_summary ?? "").toString();
+        const row = observations[i];
+        if ((row.session ?? "").toString() !== wfSession)
+            continue;
+        if (isVerifySuccessRow(row)) {
+            verifyCommand = (row.input_summary ?? "").toString();
             break;
         }
     }
@@ -320,7 +336,9 @@ export function workflowRunFromObservations(observations) {
  * `draft-workflow-` id prefix marks the source and stays filesystem-safe.
  */
 export function draftFromWorkflowRun(run) {
-    const slug = slugifyNgram([run.name]);
+    // Cap the slug so a hostile/huge meta.name cannot produce a path that trips
+    // ENAMETOOLONG on write; strip a trailing hyphen left by the cut.
+    const slug = slugifyNgram([run.name]).slice(0, 120).replace(/-+$/, "") || "workflow";
     const phaseLine = run.phases.length > 0 ? run.phases.join(" → ") : "(phases not captured)";
     const lines = [
         `When this situation recurs, the workflow "${run.name}" handled it end to end and its output passed verification.`,

--- a/plugins/continuous-improvement/lib/skill-distill.mjs
+++ b/plugins/continuous-improvement/lib/skill-distill.mjs
@@ -220,3 +220,126 @@ export function formatCandidates(candidates, limit = 10) {
     }
     return lines.join("\n");
 }
+// ── Workflow-run → instinct bridge ───────────────────────────────────────────
+// A native Workflow run (Opus 4.8 orchestration / ultracode) is recorded in the
+// observation feed as a `tool: "Workflow"` row whose input_summary holds
+// {"script":"..."} — truncated (~500 chars), but meta.name/description/phases sit
+// at the head of the script and survive. The output_summary holds
+// {"status","runId",...} with status "async_launched": the feed captures the
+// LAUNCH, not the result. So a workflow's success is never read from the Workflow
+// row itself — it is inferred from a following verify-exit-0 in the same feed.
+//
+// Unlike findCandidates (which needs a pattern recurring across >=2 sessions to
+// reject coincidence), a Workflow script is an AUTHORED recipe: one verified run
+// warrants a draft, so the session/occurrence thresholds do not apply here.
+const WORKFLOW_TOOL = "Workflow";
+// Pull meta.name / meta.description / meta.phases[].title out of a (possibly
+// truncated) workflow script embedded as JSON in the observation input_summary.
+// Fail-closed: returns null unless a name is recoverable — a recipe with no
+// identity is never fabricated.
+function parseWorkflowScript(inputSummary) {
+    if (!inputSummary)
+        return null;
+    let script = "";
+    try {
+        const parsed = JSON.parse(inputSummary);
+        if (typeof parsed.script === "string")
+            script = parsed.script;
+    }
+    catch {
+        // input_summary may itself be truncated mid-JSON; recover the script field loosely.
+        const m = inputSummary.match(/"script"\s*:\s*"((?:[^"\\]|\\.)*)/);
+        if (m) {
+            try {
+                script = JSON.parse(`"${m[1]}"`);
+            }
+            catch {
+                script = m[1].replace(/\\n/g, "\n").replace(/\\"/g, '"').replace(/\\'/g, "'");
+            }
+        }
+    }
+    if (!script)
+        return null;
+    const name = (script.match(/name\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    if (!name)
+        return null; // fail closed: no recipe identity
+    const description = (script.match(/description\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+    const phases = [];
+    const phaseRe = /title\s*:\s*['"]([^'"]+)['"]/g;
+    let pm;
+    while ((pm = phaseRe.exec(script)) !== null)
+        phases.push(pm[1]);
+    return { name, description, phases };
+}
+// A single verify-exit-0 Bash row: a verify/test/build command whose output is not
+// failing. Mirrors classifyTrajectorySuccess's verify branch for one observation.
+function isVerifySuccessRow(observation) {
+    if ((observation.tool ?? "") !== "Bash")
+        return false;
+    const input = (observation.input_summary ?? "").toString();
+    const output = (observation.output_summary ?? "").toString();
+    return VERIFY_CMD.test(input) && !FAILURE_MARKER.test(output) && (output === "" || SUCCESS_MARKER.test(output));
+}
+/**
+ * Detect the most recent completed-and-verified Workflow run in an observation
+ * list. Returns null (fail closed) unless: a `tool: "Workflow"` row carries a
+ * parseable script with a name, AND a verify-exit-0 row follows it in the feed.
+ * The trailing verify is the only success signal — the Workflow row records the
+ * launch, never the result.
+ */
+export function workflowRunFromObservations(observations) {
+    let wfIndex = -1;
+    let meta = null;
+    for (let i = observations.length - 1; i >= 0; i -= 1) {
+        if ((observations[i].tool ?? "") !== WORKFLOW_TOOL)
+            continue;
+        const parsed = parseWorkflowScript((observations[i].input_summary ?? "").toString());
+        if (parsed) {
+            wfIndex = i;
+            meta = parsed;
+            break;
+        }
+    }
+    if (wfIndex === -1 || !meta)
+        return null;
+    let verifyCommand = "";
+    for (let i = wfIndex + 1; i < observations.length; i += 1) {
+        if (isVerifySuccessRow(observations[i])) {
+            verifyCommand = (observations[i].input_summary ?? "").toString();
+            break;
+        }
+    }
+    if (!verifyCommand)
+        return null; // fail closed: no evidence the run's output landed
+    return { name: meta.name, description: meta.description, phases: meta.phases, verifyCommand };
+}
+/**
+ * Turn a verified Workflow run into a DRAFT instinct. The script's phase outline is
+ * a real skeleton (not a placeholder n-gram), but the human still edits the body
+ * before promoting. Reuses serializeDraft and the drafts/ ladder; the
+ * `draft-workflow-` id prefix marks the source and stays filesystem-safe.
+ */
+export function draftFromWorkflowRun(run) {
+    const slug = slugifyNgram([run.name]);
+    const phaseLine = run.phases.length > 0 ? run.phases.join(" → ") : "(phases not captured)";
+    const lines = [
+        `When this situation recurs, the workflow "${run.name}" handled it end to end and its output passed verification.`,
+        "",
+    ];
+    if (run.description)
+        lines.push(`Intent: ${run.description}`);
+    lines.push(`Phases: ${phaseLine}`);
+    lines.push(`Verified by: ${run.verifyCommand}`);
+    lines.push("", "Replace this with the concrete steps, preconditions, and gotchas before promoting —", "the phase outline is the skeleton, not the full recipe.");
+    return {
+        id: `draft-workflow-${slug}`,
+        trigger: `Auto-detected from a verified workflow run: ${run.name}${run.description ? ` — ${run.description}` : ""}`,
+        body: lines.join("\n"),
+        confidence: DRAFT_CONFIDENCE,
+        domain: "workflow",
+        ngram: run.phases.length > 0 ? run.phases : [run.name],
+        occurrences: 1,
+        sessions: 1,
+        outcome: "workflow-verified",
+    };
+}

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -75,6 +75,10 @@
     {
       "name": "ci_distill_promote",
       "what": "Promote an edited draft into a live instinct"
+    },
+    {
+      "name": "ci_distill_from_workflow",
+      "what": "Draft a reusable instinct from a verified Workflow run"
     }
   ],
   "setup": {

--- a/src/bin/mcp-server.mts
+++ b/src/bin/mcp-server.mts
@@ -1083,11 +1083,18 @@ function handleTool(name: string, params: Record<string, unknown>): ToolResult {
         );
       }
       const draftInstinct = draftFromWorkflowRun(run);
+      if (!isSafeDraftId(draftInstinct.id)) {
+        return error(`Internal error: generated draft id "${draftInstinct.id}" failed the safety check.`);
+      }
       const draft = serializeDraft(draftInstinct);
       const draftsDir = join(INSTINCTS_DIR, project.hash, "drafts");
-      mkdirSync(draftsDir, { recursive: true });
       const draftPath = join(draftsDir, `${draftInstinct.id}.yaml`);
-      writeFileSync(draftPath, draft);
+      try {
+        mkdirSync(draftsDir, { recursive: true });
+        writeFileSync(draftPath, draft);
+      } catch (err) {
+        return error(`Failed to write draft to ${draftPath}: ${err instanceof Error ? err.message : String(err)}`);
+      }
 
       return text([
         "## Draft written from a verified workflow run",

--- a/src/bin/mcp-server.mts
+++ b/src/bin/mcp-server.mts
@@ -42,10 +42,12 @@ import {
 } from "../lib/recall-index.mjs";
 import {
   draftFromCandidate,
+  draftFromWorkflowRun,
   extractTrajectories,
   findCandidates,
   formatCandidates,
   serializeDraft,
+  workflowRunFromObservations,
   type DistillObservation,
 } from "../lib/skill-distill.mjs";
 import {
@@ -1061,6 +1063,41 @@ function handleTool(name: string, params: Record<string, unknown>): ToolResult {
         "Edit the body to capture the real recipe (preconditions, concrete steps, gotchas), then promote with:",
         "",
         `  ci_distill_promote id=${id}`,
+        "",
+        "```yaml",
+        draft.trimEnd(),
+        "```",
+      ].join("\n"));
+    }
+
+    case "ci_distill_from_workflow": {
+      if (MODE !== "expert") {
+        return error("ci_distill_from_workflow requires expert mode");
+      }
+      const run = workflowRunFromObservations(readDistillObservations(project.hash));
+      if (!run) {
+        return text(
+          "No completed-and-verified Workflow run found in this project's observations. " +
+            "A run qualifies when a `Workflow` tool call is followed by a passing verify/test/build in the same feed. " +
+            "Run a workflow, verify its output, then try `ci_distill_from_workflow` again.",
+        );
+      }
+      const draftInstinct = draftFromWorkflowRun(run);
+      const draft = serializeDraft(draftInstinct);
+      const draftsDir = join(INSTINCTS_DIR, project.hash, "drafts");
+      mkdirSync(draftsDir, { recursive: true });
+      const draftPath = join(draftsDir, `${draftInstinct.id}.yaml`);
+      writeFileSync(draftPath, draft);
+
+      return text([
+        "## Draft written from a verified workflow run",
+        "",
+        `**Workflow:** ${run.name}`,
+        `**Path:** ${draftPath}`,
+        "",
+        "Edit the body to capture the real recipe (preconditions, concrete steps, gotchas), then promote with:",
+        "",
+        `  ci_distill_promote id=${draftInstinct.id}`,
         "",
         "```yaml",
         draft.trimEnd(),

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -520,6 +520,13 @@ const EXPERT_TOOL_ENTRIES: ToolCatalogEntry[] = [
       required: ["id"],
     },
   },
+  {
+    name: "ci_distill_from_workflow",
+    description:
+      "Draft a reusable instinct from the most recent completed-and-verified native Workflow run in this project's observation feed. A Workflow script is an authored recipe, so a single run whose output passed verification is enough — unlike ci_distill_candidates, which needs a pattern repeated across sessions. Writes a DRAFT to drafts/ (a skeleton you edit); it changes no behavior until promoted with ci_distill_promote. Returns a message when no verified workflow run is found.",
+    manifestWhat: "Draft a reusable instinct from a verified Workflow run",
+    inputSchema: { type: "object", properties: {}, required: [] },
+  },
 ];
 
 const MODE_METADATA: Record<PluginMode, ModeMetadata> = {

--- a/src/lib/skill-distill.mts
+++ b/src/lib/skill-distill.mts
@@ -344,13 +344,22 @@ function parseWorkflowScript(inputSummary: string): { name: string; description:
     }
   }
   if (!script) return null;
-  const name = (script.match(/name\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+  // Scope name/description to the meta head (text before `phases:`) so a phase
+  // object's own description: is never mistaken for meta.description; scope phase
+  // titles to the phases array literal so inline agent/step title: fields are not
+  // captured. The capture classes exclude quotes and newlines, so a hostile
+  // name/description cannot inject lines into the draft YAML — serializeDraft emits
+  // trigger as a quoted scalar.
+  const phasesAt = script.search(/\bphases\s*:/);
+  const metaHead = phasesAt >= 0 ? script.slice(0, phasesAt) : script;
+  const name = (metaHead.match(/\bname\s*:\s*['"]([^'"\r\n]+)['"]/) ?? [])[1] ?? "";
   if (!name) return null; // fail closed: no recipe identity
-  const description = (script.match(/description\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+  const description = (metaHead.match(/\bdescription\s*:\s*['"]([^'"\r\n]+)['"]/) ?? [])[1] ?? "";
+  const phasesBlock = (script.match(/\bphases\s*:\s*\[([^\]]*)\]/) ?? [])[1] ?? "";
   const phases: string[] = [];
-  const phaseRe = /title\s*:\s*['"]([^'"]+)['"]/g;
+  const phaseRe = /\btitle\s*:\s*['"]([^'"\r\n]+)['"]/g;
   let pm: RegExpExecArray | null;
-  while ((pm = phaseRe.exec(script)) !== null) phases.push(pm[1]!);
+  while ((pm = phaseRe.exec(phasesBlock)) !== null) phases.push(pm[1]!);
   return { name, description, phases };
 }
 
@@ -383,11 +392,17 @@ export function workflowRunFromObservations(observations: DistillObservation[]):
     }
   }
   if (wfIndex === -1 || !meta) return null;
+  const wfSession = (observations[wfIndex]!.session ?? "").toString();
 
+  // The verify that proves the run must follow the Workflow row in the SAME session.
+  // A verify from an unrelated later task (different session) does not count — the
+  // run is asynchronous, so an interleaved verify could otherwise falsely prove it.
   let verifyCommand = "";
   for (let i = wfIndex + 1; i < observations.length; i += 1) {
-    if (isVerifySuccessRow(observations[i]!)) {
-      verifyCommand = (observations[i]!.input_summary ?? "").toString();
+    const row = observations[i]!;
+    if ((row.session ?? "").toString() !== wfSession) continue;
+    if (isVerifySuccessRow(row)) {
+      verifyCommand = (row.input_summary ?? "").toString();
       break;
     }
   }
@@ -403,7 +418,9 @@ export function workflowRunFromObservations(observations: DistillObservation[]):
  * `draft-workflow-` id prefix marks the source and stays filesystem-safe.
  */
 export function draftFromWorkflowRun(run: WorkflowRun): DraftInstinct {
-  const slug = slugifyNgram([run.name]);
+  // Cap the slug so a hostile/huge meta.name cannot produce a path that trips
+  // ENAMETOOLONG on write; strip a trailing hyphen left by the cut.
+  const slug = slugifyNgram([run.name]).slice(0, 120).replace(/-+$/, "") || "workflow";
   const phaseLine = run.phases.length > 0 ? run.phases.join(" → ") : "(phases not captured)";
   const lines = [
     `When this situation recurs, the workflow "${run.name}" handled it end to end and its output passed verification.`,

--- a/src/lib/skill-distill.mts
+++ b/src/lib/skill-distill.mts
@@ -299,3 +299,133 @@ export function formatCandidates(candidates: Candidate[], limit = 10): string {
   }
   return lines.join("\n");
 }
+
+// ── Workflow-run → instinct bridge ───────────────────────────────────────────
+// A native Workflow run (Opus 4.8 orchestration / ultracode) is recorded in the
+// observation feed as a `tool: "Workflow"` row whose input_summary holds
+// {"script":"..."} — truncated (~500 chars), but meta.name/description/phases sit
+// at the head of the script and survive. The output_summary holds
+// {"status","runId",...} with status "async_launched": the feed captures the
+// LAUNCH, not the result. So a workflow's success is never read from the Workflow
+// row itself — it is inferred from a following verify-exit-0 in the same feed.
+//
+// Unlike findCandidates (which needs a pattern recurring across >=2 sessions to
+// reject coincidence), a Workflow script is an AUTHORED recipe: one verified run
+// warrants a draft, so the session/occurrence thresholds do not apply here.
+
+const WORKFLOW_TOOL = "Workflow";
+
+export interface WorkflowRun {
+  name: string;
+  description: string;
+  phases: string[];
+  verifyCommand: string;
+}
+
+// Pull meta.name / meta.description / meta.phases[].title out of a (possibly
+// truncated) workflow script embedded as JSON in the observation input_summary.
+// Fail-closed: returns null unless a name is recoverable — a recipe with no
+// identity is never fabricated.
+function parseWorkflowScript(inputSummary: string): { name: string; description: string; phases: string[] } | null {
+  if (!inputSummary) return null;
+  let script = "";
+  try {
+    const parsed = JSON.parse(inputSummary) as { script?: unknown };
+    if (typeof parsed.script === "string") script = parsed.script;
+  } catch {
+    // input_summary may itself be truncated mid-JSON; recover the script field loosely.
+    const m = inputSummary.match(/"script"\s*:\s*"((?:[^"\\]|\\.)*)/);
+    if (m) {
+      try {
+        script = JSON.parse(`"${m[1]}"`) as string;
+      } catch {
+        script = m[1]!.replace(/\\n/g, "\n").replace(/\\"/g, '"').replace(/\\'/g, "'");
+      }
+    }
+  }
+  if (!script) return null;
+  const name = (script.match(/name\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+  if (!name) return null; // fail closed: no recipe identity
+  const description = (script.match(/description\s*:\s*['"]([^'"]+)['"]/) ?? [])[1] ?? "";
+  const phases: string[] = [];
+  const phaseRe = /title\s*:\s*['"]([^'"]+)['"]/g;
+  let pm: RegExpExecArray | null;
+  while ((pm = phaseRe.exec(script)) !== null) phases.push(pm[1]!);
+  return { name, description, phases };
+}
+
+// A single verify-exit-0 Bash row: a verify/test/build command whose output is not
+// failing. Mirrors classifyTrajectorySuccess's verify branch for one observation.
+function isVerifySuccessRow(observation: DistillObservation): boolean {
+  if ((observation.tool ?? "") !== "Bash") return false;
+  const input = (observation.input_summary ?? "").toString();
+  const output = (observation.output_summary ?? "").toString();
+  return VERIFY_CMD.test(input) && !FAILURE_MARKER.test(output) && (output === "" || SUCCESS_MARKER.test(output));
+}
+
+/**
+ * Detect the most recent completed-and-verified Workflow run in an observation
+ * list. Returns null (fail closed) unless: a `tool: "Workflow"` row carries a
+ * parseable script with a name, AND a verify-exit-0 row follows it in the feed.
+ * The trailing verify is the only success signal — the Workflow row records the
+ * launch, never the result.
+ */
+export function workflowRunFromObservations(observations: DistillObservation[]): WorkflowRun | null {
+  let wfIndex = -1;
+  let meta: { name: string; description: string; phases: string[] } | null = null;
+  for (let i = observations.length - 1; i >= 0; i -= 1) {
+    if ((observations[i]!.tool ?? "") !== WORKFLOW_TOOL) continue;
+    const parsed = parseWorkflowScript((observations[i]!.input_summary ?? "").toString());
+    if (parsed) {
+      wfIndex = i;
+      meta = parsed;
+      break;
+    }
+  }
+  if (wfIndex === -1 || !meta) return null;
+
+  let verifyCommand = "";
+  for (let i = wfIndex + 1; i < observations.length; i += 1) {
+    if (isVerifySuccessRow(observations[i]!)) {
+      verifyCommand = (observations[i]!.input_summary ?? "").toString();
+      break;
+    }
+  }
+  if (!verifyCommand) return null; // fail closed: no evidence the run's output landed
+
+  return { name: meta.name, description: meta.description, phases: meta.phases, verifyCommand };
+}
+
+/**
+ * Turn a verified Workflow run into a DRAFT instinct. The script's phase outline is
+ * a real skeleton (not a placeholder n-gram), but the human still edits the body
+ * before promoting. Reuses serializeDraft and the drafts/ ladder; the
+ * `draft-workflow-` id prefix marks the source and stays filesystem-safe.
+ */
+export function draftFromWorkflowRun(run: WorkflowRun): DraftInstinct {
+  const slug = slugifyNgram([run.name]);
+  const phaseLine = run.phases.length > 0 ? run.phases.join(" → ") : "(phases not captured)";
+  const lines = [
+    `When this situation recurs, the workflow "${run.name}" handled it end to end and its output passed verification.`,
+    "",
+  ];
+  if (run.description) lines.push(`Intent: ${run.description}`);
+  lines.push(`Phases: ${phaseLine}`);
+  lines.push(`Verified by: ${run.verifyCommand}`);
+  lines.push(
+    "",
+    "Replace this with the concrete steps, preconditions, and gotchas before promoting —",
+    "the phase outline is the skeleton, not the full recipe.",
+  );
+  return {
+    id: `draft-workflow-${slug}`,
+    trigger: `Auto-detected from a verified workflow run: ${run.name}${run.description ? ` — ${run.description}` : ""}`,
+    body: lines.join("\n"),
+    confidence: DRAFT_CONFIDENCE,
+    domain: "workflow",
+    ngram: run.phases.length > 0 ? run.phases : [run.name],
+    occurrences: 1,
+    sessions: 1,
+    outcome: "workflow-verified",
+  };
+}

--- a/src/test/mcp-server.test.mts
+++ b/src/test/mcp-server.test.mts
@@ -415,7 +415,7 @@ describe("MCP server — expert mode", () => {
     }
   });
 
-  it("lists all expert tools (18) in expert mode", async () => {
+  it("lists all expert tools (19) in expert mode", async () => {
     await client.send({ jsonrpc: "2.0", id: 10, method: "initialize", params: {} });
     const response = await client.send({ jsonrpc: "2.0", id: 11, method: "tools/list", params: {} });
     const names = response.result.tools.map((tool: { name: string }) => tool.name);

--- a/src/test/skill-distill.test.mts
+++ b/src/test/skill-distill.test.mts
@@ -9,12 +9,15 @@ import { describe, it } from "node:test";
 
 import {
   draftFromCandidate,
+  draftFromWorkflowRun,
   extractTrajectories,
   findCandidates,
   formatCandidates,
   serializeDraft,
+  workflowRunFromObservations,
   type DistillObservation,
   type Trajectory,
+  type WorkflowRun,
 } from "../lib/skill-distill.mjs";
 
 let clock = Date.parse("2026-05-28T12:00:00Z");
@@ -262,5 +265,87 @@ describe("findCandidates — id path-safety (audit #7)", () => {
         `candidate id must not contain path separators or traversal: ${candidate.id}`,
       );
     }
+  });
+});
+
+describe("workflowRunFromObservations + draftFromWorkflowRun (workflow bridge)", () => {
+  const goodScript = [
+    "export const meta = {",
+    "  name: 'fix-flaky-tests',",
+    "  description: 'Find flaky tests and propose fixes',",
+    "  phases: [{ title: 'Scan' }, { title: 'Fix' }],",
+    "}",
+    "phase('Scan')",
+    "const x = await agent('do it')",
+  ].join("\n");
+
+  // input_summary on a real Workflow row is the script wrapped as {"script":"..."}.
+  function wfRow(script: string): DistillObservation {
+    return obs("Workflow", { input_summary: JSON.stringify({ script }) });
+  }
+  function verifyRow(): DistillObservation {
+    return obs("Bash", { input_summary: "npm run verify:all", output_summary: "OK all passing" });
+  }
+
+  it("returns null when there is no Workflow row", () => {
+    assert.equal(workflowRunFromObservations([obs("Read"), obs("Edit"), verifyRow()]), null);
+  });
+
+  it("returns null when the Workflow row has an empty input_summary", () => {
+    assert.equal(
+      workflowRunFromObservations([obs("Workflow", { input_summary: "" }), verifyRow()]),
+      null,
+    );
+  });
+
+  it("returns null for a launched workflow with no following verify (async_launched is not success)", () => {
+    assert.equal(workflowRunFromObservations([obs("Read"), wfRow(goodScript), obs("Read")]), null);
+  });
+
+  it("returns the run when a Workflow row is followed by a passing verify", () => {
+    const run = workflowRunFromObservations([obs("Read"), wfRow(goodScript), verifyRow()]);
+    assert.ok(run, "expected a workflow run");
+    assert.equal(run!.name, "fix-flaky-tests");
+    assert.equal(run!.description, "Find flaky tests and propose fixes");
+    assert.deepEqual(run!.phases, ["Scan", "Fix"]);
+    assert.match(run!.verifyCommand, /verify:all/);
+  });
+
+  it("fails closed on a truncated script whose meta name was cut off", () => {
+    assert.equal(workflowRunFromObservations([wfRow("export const meta = {\n  "), verifyRow()]), null);
+  });
+
+  it("parses meta when the script is truncated after the phases (real feed shape)", () => {
+    const truncated = goodScript.slice(0, goodScript.indexOf("phase('Scan')") + 5);
+    const run = workflowRunFromObservations([wfRow(truncated), verifyRow()]);
+    assert.ok(run);
+    assert.equal(run!.name, "fix-flaky-tests");
+    assert.deepEqual(run!.phases, ["Scan", "Fix"]);
+  });
+
+  it("draftFromWorkflowRun emits a filesystem-safe id and a low-confidence non-empty body", () => {
+    const draft = draftFromWorkflowRun({
+      name: "../../etc/passwd",
+      description: "hostile",
+      phases: ["A", "B"],
+      verifyCommand: "npm test",
+    });
+    assert.doesNotMatch(draft.id, /[\\/]|\.\./, `id must be path-safe: ${draft.id}`);
+    assert.equal(draft.confidence, 0.4);
+    assert.ok(draft.body.length > 0);
+  });
+
+  it("serializeDraft round-trips a workflow draft to instinct YAML with a body", () => {
+    const run: WorkflowRun = {
+      name: "ship-release",
+      description: "cut a release",
+      phases: ["Plan", "Build", "Verify"],
+      verifyCommand: "npm run verify:all",
+    };
+    const yaml = serializeDraft(draftFromWorkflowRun(run));
+    assert.match(yaml, /^id: draft-workflow-ship-release/m);
+    assert.match(yaml, /status: draft/);
+    assert.match(yaml, /\n---\n/);
+    assert.match(yaml, /Plan → Build → Verify/);
   });
 });

--- a/src/test/skill-distill.test.mts
+++ b/src/test/skill-distill.test.mts
@@ -348,4 +348,30 @@ describe("workflowRunFromObservations + draftFromWorkflowRun (workflow bridge)",
     assert.match(yaml, /\n---\n/);
     assert.match(yaml, /Plan → Build → Verify/);
   });
+
+  it("scopes phase titles to the phases array, ignoring inline agent/step title fields", () => {
+    const scriptWithNestedTitle = [
+      "export const meta = {",
+      "  name: 'scoped-wf',",
+      "  description: 'real intent',",
+      "  phases: [{ title: 'Scan' }],",
+      "}",
+      "phase('Scan')",
+      "const r = await agent('x', { title: 'inline-label' })",
+    ].join("\n");
+    const run = workflowRunFromObservations([wfRow(scriptWithNestedTitle), verifyRow()]);
+    assert.ok(run);
+    assert.equal(run!.description, "real intent");
+    assert.deepEqual(run!.phases, ["Scan"], "an inline agent title: must not be captured as a phase");
+  });
+
+  it("does not count a verify from a different session as proof of the run", () => {
+    const wf = obs("Workflow", { session: "A", input_summary: JSON.stringify({ script: goodScript }) });
+    const otherSessionVerify = obs("Bash", {
+      session: "B",
+      input_summary: "npm run verify:all",
+      output_summary: "OK all passing",
+    });
+    assert.equal(workflowRunFromObservations([wf, otherSessionVerify]), null);
+  });
 });

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -335,7 +335,7 @@ describe("MCP server — expert mode", () => {
             // Windows can briefly keep stdio handles open after the child exits.
         }
     });
-    it("lists all expert tools (18) in expert mode", async () => {
+    it("lists all expert tools (19) in expert mode", async () => {
         await client.send({ jsonrpc: "2.0", id: 10, method: "initialize", params: {} });
         const response = await client.send({ jsonrpc: "2.0", id: 11, method: "tools/list", params: {} });
         const names = response.result.tools.map((tool) => tool.name);

--- a/test/skill-distill.test.mjs
+++ b/test/skill-distill.test.mjs
@@ -5,7 +5,7 @@
 // rule, never edit the .mjs directly.
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { draftFromCandidate, extractTrajectories, findCandidates, formatCandidates, serializeDraft, } from "../lib/skill-distill.mjs";
+import { draftFromCandidate, draftFromWorkflowRun, extractTrajectories, findCandidates, formatCandidates, serializeDraft, workflowRunFromObservations, } from "../lib/skill-distill.mjs";
 let clock = Date.parse("2026-05-28T12:00:00Z");
 function obs(tool, partial = {}) {
     clock += 30_000; // 30s apart — within the gap window
@@ -224,5 +224,74 @@ describe("findCandidates — id path-safety (audit #7)", () => {
         for (const candidate of candidates) {
             assert.doesNotMatch(candidate.id, /[\\/]|\.\./, `candidate id must not contain path separators or traversal: ${candidate.id}`);
         }
+    });
+});
+describe("workflowRunFromObservations + draftFromWorkflowRun (workflow bridge)", () => {
+    const goodScript = [
+        "export const meta = {",
+        "  name: 'fix-flaky-tests',",
+        "  description: 'Find flaky tests and propose fixes',",
+        "  phases: [{ title: 'Scan' }, { title: 'Fix' }],",
+        "}",
+        "phase('Scan')",
+        "const x = await agent('do it')",
+    ].join("\n");
+    // input_summary on a real Workflow row is the script wrapped as {"script":"..."}.
+    function wfRow(script) {
+        return obs("Workflow", { input_summary: JSON.stringify({ script }) });
+    }
+    function verifyRow() {
+        return obs("Bash", { input_summary: "npm run verify:all", output_summary: "OK all passing" });
+    }
+    it("returns null when there is no Workflow row", () => {
+        assert.equal(workflowRunFromObservations([obs("Read"), obs("Edit"), verifyRow()]), null);
+    });
+    it("returns null when the Workflow row has an empty input_summary", () => {
+        assert.equal(workflowRunFromObservations([obs("Workflow", { input_summary: "" }), verifyRow()]), null);
+    });
+    it("returns null for a launched workflow with no following verify (async_launched is not success)", () => {
+        assert.equal(workflowRunFromObservations([obs("Read"), wfRow(goodScript), obs("Read")]), null);
+    });
+    it("returns the run when a Workflow row is followed by a passing verify", () => {
+        const run = workflowRunFromObservations([obs("Read"), wfRow(goodScript), verifyRow()]);
+        assert.ok(run, "expected a workflow run");
+        assert.equal(run.name, "fix-flaky-tests");
+        assert.equal(run.description, "Find flaky tests and propose fixes");
+        assert.deepEqual(run.phases, ["Scan", "Fix"]);
+        assert.match(run.verifyCommand, /verify:all/);
+    });
+    it("fails closed on a truncated script whose meta name was cut off", () => {
+        assert.equal(workflowRunFromObservations([wfRow("export const meta = {\n  "), verifyRow()]), null);
+    });
+    it("parses meta when the script is truncated after the phases (real feed shape)", () => {
+        const truncated = goodScript.slice(0, goodScript.indexOf("phase('Scan')") + 5);
+        const run = workflowRunFromObservations([wfRow(truncated), verifyRow()]);
+        assert.ok(run);
+        assert.equal(run.name, "fix-flaky-tests");
+        assert.deepEqual(run.phases, ["Scan", "Fix"]);
+    });
+    it("draftFromWorkflowRun emits a filesystem-safe id and a low-confidence non-empty body", () => {
+        const draft = draftFromWorkflowRun({
+            name: "../../etc/passwd",
+            description: "hostile",
+            phases: ["A", "B"],
+            verifyCommand: "npm test",
+        });
+        assert.doesNotMatch(draft.id, /[\\/]|\.\./, `id must be path-safe: ${draft.id}`);
+        assert.equal(draft.confidence, 0.4);
+        assert.ok(draft.body.length > 0);
+    });
+    it("serializeDraft round-trips a workflow draft to instinct YAML with a body", () => {
+        const run = {
+            name: "ship-release",
+            description: "cut a release",
+            phases: ["Plan", "Build", "Verify"],
+            verifyCommand: "npm run verify:all",
+        };
+        const yaml = serializeDraft(draftFromWorkflowRun(run));
+        assert.match(yaml, /^id: draft-workflow-ship-release/m);
+        assert.match(yaml, /status: draft/);
+        assert.match(yaml, /\n---\n/);
+        assert.match(yaml, /Plan → Build → Verify/);
     });
 });

--- a/test/skill-distill.test.mjs
+++ b/test/skill-distill.test.mjs
@@ -294,4 +294,28 @@ describe("workflowRunFromObservations + draftFromWorkflowRun (workflow bridge)",
         assert.match(yaml, /\n---\n/);
         assert.match(yaml, /Plan → Build → Verify/);
     });
+    it("scopes phase titles to the phases array, ignoring inline agent/step title fields", () => {
+        const scriptWithNestedTitle = [
+            "export const meta = {",
+            "  name: 'scoped-wf',",
+            "  description: 'real intent',",
+            "  phases: [{ title: 'Scan' }],",
+            "}",
+            "phase('Scan')",
+            "const r = await agent('x', { title: 'inline-label' })",
+        ].join("\n");
+        const run = workflowRunFromObservations([wfRow(scriptWithNestedTitle), verifyRow()]);
+        assert.ok(run);
+        assert.equal(run.description, "real intent");
+        assert.deepEqual(run.phases, ["Scan"], "an inline agent title: must not be captured as a phase");
+    });
+    it("does not count a verify from a different session as proof of the run", () => {
+        const wf = obs("Workflow", { session: "A", input_summary: JSON.stringify({ script: goodScript }) });
+        const otherSessionVerify = obs("Bash", {
+            session: "B",
+            input_summary: "npm run verify:all",
+            output_summary: "OK all passing",
+        });
+        assert.equal(workflowRunFromObservations([wf, otherSessionVerify]), null);
+    });
 });


### PR DESCRIPTION
## Why

The payoff of PR #225's repositioning: make a native **Workflow** run (Opus 4.8 orchestration / ultracode) leave a durable trace in the Mulahazah engine, so an expensive multi-agent run's lessons survive the run instead of evaporating when the turn ends. This is the one thing a per-turn orchestration primitive structurally cannot do for itself.

## Grounded by live-feed probes (not assumed)

Two probes against `observations.jsonl` settled the design:
- A Workflow's **sub-agent tool calls are captured** in the same feed, under the **parent** session id (no journal parsing, no trajectory-split).
- The `Workflow` row's `input_summary` carries the script as `{"script":"..."}`, **truncated ~500 chars** — `meta.name`/`description`/`phases` sit at the head and survive.
- `output_summary` reports `status: async_launched` with the runId — the feed records the **launch, not the result**, so success is inferred from a following verify-exit-0, never from the Workflow row.

## What it does

Two pure functions in `src/lib/skill-distill.mts` (reusing the existing `serializeDraft` + `drafts/` ladder):
- `workflowRunFromObservations` — finds the most recent Workflow row with a parseable script + a **same-session** following verify-exit-0; fail-closed otherwise.
- `draftFromWorkflowRun` — drafts an instinct whose body is the phase outline + the verify command.

Exposed as the **`ci_distill_from_workflow`** MCP tool (expert; tool count 18 to 19). Drafts stay under `drafts/` and require `ci_distill_promote` — nothing auto-applies. Unlike `ci_distill_candidates` (needs a pattern across multiple sessions), a single verified run drafts, because a Workflow script is an authored recipe.

## Fail-closed (the 2026-06-03 audit lesson)

No Workflow row / unparseable meta / no following same-session verify / truncated-past-the-name returns null, never a fabricated draft. Draft id slugified + length-capped (path-safety, long-path guard); capture classes exclude quotes and newlines (draft-YAML injection); local try/catch on the write.

## Reviewed

Three parallel adversarial reviewers (correctness, security/fail-closed, invariant/build-pipeline). All findings addressed in commit 2: meta-scoped parsing (no nested title/description capture), same-session verify gate, YAML-injection close, slug cap, id guard + try/catch, and a plan-doc deferral fix. New tests pin the meta-scoping and same-session behaviors.

## Scope

- **In:** the pure functions + MCP tool + tool-count bump + plan doc.
- **Deferred (fast-follow):** the `workflow-distill.mjs` Stop-hook auto-nudge — kept out to make this PR single-concern.
- **Separate follow-up (logged in the plan doc):** three gateguard defects found while unblocking — raw-key cap count, naive destructive-substring matching that false-trips on benign prose, and the project-scoped session dir that never resets.

## Verification

- `npm run verify:all` green (13 invariants incl. tool-count expert=19, typecheck).
- `npm run verify:generated` clean.
- `skill-distill` 27/0; full suite 771 passing. The `observe.sh` hook tests are the documented wall-clock flake under concurrent load (15/15 in isolation), not a regression.

Plan: `docs/plans/2026-06-08-workflow-instinct-bridge.md`