### PR TITLE
chore(release): cut v3.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.3",
+      "version": "3.13.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this skill are documented here.
 
 ---
 
-## [Unreleased]
+## [3.13.0] — 2026-06-10
+
+### Added
+
+- **model-forward ships as a default tier-1 skill** — the standing stance that skills are scaffolding which merges into the model over time; durable core = goal-driven execution + guardrails. (#229)
+- **`distill` turns a verified Workflow run into a draft instinct** — the ultracode-to-memory bridge: a completed multi-agent Workflow's verified trajectory becomes a reviewable instinct draft instead of evaporating with the session. (#226)
+
+### Fixed
+
+- **PreToolUse hooks no longer flood every session with `Hook JSON output validation failed — (root): Invalid input` errors (twice per tool call)** — `gateguard.mjs` and `companion-preference.mjs` emitted `{"decision":"allow"}` on every allowed call, which was never schema-valid PreToolUse output (the deprecated `decision` enum is `approve | block`), and current Claude Code clients surface the validation failure instead of silently discarding it. Allow is now empty stdout + exit 0; block uses the documented `hookSpecificOutput.permissionDecision: "deny"` shape. (#230)
+- **goal-state keyword extraction works for Korean goals** — a script-aware minimum keyword length (2 for Hangul tokens, 4 elsewhere) stops Korean goal statements from extracting zero keywords and scoring all work as drift.
 
 ### Removed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.3",
+  "version": "3.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.12.3",
+      "version": "3.13.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.3",
+  "version": "3.13.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.3",
+  "version": "3.13.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles four grounding skills (gateguard, para-memory-files, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.12.3",
+      "version": "3.13.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.3",
+  "version": "3.13.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.3",
+  "version": "3.13.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
Release bump for 3.13.0.

Ships since v3.12.3: model-forward tier-1 skill (#229), distill Workflow→instinct bridge (#226), **PreToolUse hook-output schema fix (#230)** — the headline for plugin users, stops the per-tool-call `Hook JSON output validation failed` errors — Hangul keyword floor for goal-state, and the ci CLI slim to CLI-Anything (#220; minor bump per the explicit decision in `docs/plans/2026-06-08-slim-ci-to-cli-anything.md`).

Version bump + 5 regenerated manifests + lockfile + CHANGELOG roll. `verify:all` green locally.

After squash-merge: tag `v3.13.0` on the merge commit → `release.yml` publishes to npm via OIDC (first tag to exercise the #217 `npx npm@latest` publish path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)