### PR TITLE
fix(verify): skill-count covers .cloudplugin manifest + landing-page stat block

### DIFF
--- a/bin/check-skill-count.mjs
+++ b/bin/check-skill-count.mjs
@@ -24,6 +24,11 @@
  *   - plugins/continuous-improvement/.claude-plugin/plugin.json
  *   - package.json
  *   - llms.txt
+ *   - .cloudplugin/marketplace.json   (hand-maintained, not generator-owned)
+ *
+ * Stat-block files (count lives in a split HTML stat, not the phrase):
+ *   - docs/landing/index.html — `<span class="v">N</span><span class="k">Bundled skills</span>`
+ *     (PR #229 found this surface stale at 25 while every phrase file said 26)
  *
  * Usage:
  *   node bin/check-skill-count.mjs              # Check the current repo
@@ -42,7 +47,9 @@ const CHECKED_FILES = [
     "plugins/continuous-improvement/.claude-plugin/plugin.json",
     "package.json",
     "llms.txt",
+    ".cloudplugin/marketplace.json",
 ];
+const STAT_CHECKED_FILES = ["docs/landing/index.html"];
 export function countSkills(repoRoot) {
     const skillsDir = join(repoRoot, BUNDLE_SKILLS_DIR);
     const entries = readdirSync(skillsDir);
@@ -75,6 +82,24 @@ function checkFile(repoRoot, relPath, expected) {
         found: staleMatch ? staleMatch[0] : undefined,
     };
 }
+function checkStatFile(repoRoot, relPath, expected) {
+    let content;
+    try {
+        content = readFileSync(join(repoRoot, relPath), "utf8");
+    }
+    catch {
+        return { file: relPath, reason: "missing" };
+    }
+    const expectedPattern = new RegExp(`class="v">${expected}</span><span class="k">Bundled skills`);
+    if (expectedPattern.test(content))
+        return null;
+    const staleMatch = content.match(/class="v">(\d+)<\/span><span class="k">Bundled skills/);
+    return {
+        file: relPath,
+        reason: staleMatch ? "stale" : "missing",
+        found: staleMatch ? `${staleMatch[1]} Bundled skills (stat block)` : undefined,
+    };
+}
 function main() {
     const repoRoot = argv[2] ?? cwd();
     const expected = countSkills(repoRoot);
@@ -84,8 +109,14 @@ function main() {
         if (v)
             violations.push(v);
     }
+    for (const file of STAT_CHECKED_FILES) {
+        const v = checkStatFile(repoRoot, file, expected);
+        if (v)
+            violations.push(v);
+    }
+    const totalChecked = CHECKED_FILES.length + STAT_CHECKED_FILES.length;
     if (violations.length === 0) {
-        console.log(`OK skill-count: all ${CHECKED_FILES.length} description string(s) state "${expected} bundled skills" (matches skills/ source-of-truth).`);
+        console.log(`OK skill-count: all ${totalChecked} description string(s) state "${expected} bundled skills" (matches skills/ source-of-truth).`);
         exit(0);
     }
     console.error(`FAIL skill-count: ${violations.length} description string(s) do not state the actual bundled-skill count of ${expected}.`);

--- a/src/bin/check-skill-count.mts
+++ b/src/bin/check-skill-count.mts
@@ -25,6 +25,11 @@
  *   - plugins/continuous-improvement/.claude-plugin/plugin.json
  *   - package.json
  *   - llms.txt
+ *   - .cloudplugin/marketplace.json   (hand-maintained, not generator-owned)
+ *
+ * Stat-block files (count lives in a split HTML stat, not the phrase):
+ *   - docs/landing/index.html — `<span class="v">N</span><span class="k">Bundled skills</span>`
+ *     (PR #229 found this surface stale at 25 while every phrase file said 26)
  *
  * Usage:
  *   node bin/check-skill-count.mjs              # Check the current repo
@@ -45,7 +50,10 @@ const CHECKED_FILES: ReadonlyArray<string> = [
   "plugins/continuous-improvement/.claude-plugin/plugin.json",
   "package.json",
   "llms.txt",
+  ".cloudplugin/marketplace.json",
 ];
+
+const STAT_CHECKED_FILES: ReadonlyArray<string> = ["docs/landing/index.html"];
 
 export function countSkills(repoRoot: string): number {
   const skillsDir = join(repoRoot, BUNDLE_SKILLS_DIR);
@@ -86,6 +94,27 @@ function checkFile(repoRoot: string, relPath: string, expected: number): CountVi
   };
 }
 
+function checkStatFile(repoRoot: string, relPath: string, expected: number): CountViolation | null {
+  let content: string;
+  try {
+    content = readFileSync(join(repoRoot, relPath), "utf8");
+  } catch {
+    return { file: relPath, reason: "missing" };
+  }
+
+  const expectedPattern = new RegExp(
+    `class="v">${expected}</span><span class="k">Bundled skills`,
+  );
+  if (expectedPattern.test(content)) return null;
+
+  const staleMatch = content.match(/class="v">(\d+)<\/span><span class="k">Bundled skills/);
+  return {
+    file: relPath,
+    reason: staleMatch ? "stale" : "missing",
+    found: staleMatch ? `${staleMatch[1]} Bundled skills (stat block)` : undefined,
+  };
+}
+
 function main(): void {
   const repoRoot = argv[2] ?? cwd();
   const expected = countSkills(repoRoot);
@@ -95,10 +124,15 @@ function main(): void {
     const v = checkFile(repoRoot, file, expected);
     if (v) violations.push(v);
   }
+  for (const file of STAT_CHECKED_FILES) {
+    const v = checkStatFile(repoRoot, file, expected);
+    if (v) violations.push(v);
+  }
 
+  const totalChecked = CHECKED_FILES.length + STAT_CHECKED_FILES.length;
   if (violations.length === 0) {
     console.log(
-      `OK skill-count: all ${CHECKED_FILES.length} description string(s) state "${expected} bundled skills" (matches skills/ source-of-truth).`,
+      `OK skill-count: all ${totalChecked} description string(s) state "${expected} bundled skills" (matches skills/ source-of-truth).`,
     );
     exit(0);
   }

--- a/src/test/check-skill-count.test.mts
+++ b/src/test/check-skill-count.test.mts
@@ -18,6 +18,8 @@ function setupRepo(skillNames: string[], descriptions: Record<string, string>): 
   mkdirSync(bundleSkillsDir, { recursive: true });
   mkdirSync(join(root, ".claude-plugin"), { recursive: true });
   mkdirSync(join(root, "plugins", "continuous-improvement", ".claude-plugin"), { recursive: true });
+  mkdirSync(join(root, ".cloudplugin"), { recursive: true });
+  mkdirSync(join(root, "docs", "landing"), { recursive: true });
   for (const name of skillNames) {
     mkdirSync(join(bundleSkillsDir, name), { recursive: true });
     writeFileSync(join(bundleSkillsDir, name, "SKILL.md"), `---\nname: ${name}\n---\n# ${name}\n`);
@@ -38,6 +40,16 @@ function setupRepo(skillNames: string[], descriptions: Record<string, string>): 
     join(root, "llms.txt"),
     descriptions.llms ?? "",
   );
+  writeFileSync(
+    join(root, ".cloudplugin", "marketplace.json"),
+    JSON.stringify({ description: descriptions.cloudplugin ?? descriptions.marketplace ?? "" }),
+  );
+  const count = skillNames.length;
+  writeFileSync(
+    join(root, "docs", "landing", "index.html"),
+    descriptions.landing ??
+      `<li><span class="v">${count}</span><span class="k">Bundled skills</span></li>`,
+  );
   return root;
 }
 
@@ -57,7 +69,7 @@ describe("check-skill-count — unit", () => {
 });
 
 describe("check-skill-count — integration", () => {
-  it("CLI exits 0 when all four descriptions state the correct count", () => {
+  it("CLI exits 0 when all six checked files state the correct count", () => {
     const phrase = "2 bundled skills";
     const root = setupRepo(["alpha", "beta"], {
       marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
@@ -67,7 +79,57 @@ describe("check-skill-count — integration", () => {
     });
     try {
       const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
-      assert.match(out, /OK skill-count: all 4 description string\(s\) state "2 bundled skills"/);
+      assert.match(out, /OK skill-count: all 6 description string\(s\) state "2 bundled skills"/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 when the landing-page stat block states a stale count", () => {
+    const phrase = "2 bundled skills";
+    const root = setupRepo(["alpha", "beta"], {
+      marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
+      plugin: `The 7 Laws — ${phrase}, gating hooks.`,
+      package: `The 7 Laws — ${phrase}, gating hooks.`,
+      llms: `The 7 Laws — ${phrase}, gating hooks.`,
+      landing: `<li><span class="v">25</span><span class="k">Bundled skills</span></li>`,
+    });
+    try {
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /docs\/landing\/index\.html/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero when the landing stat drifts");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 when .cloudplugin/marketplace.json states a stale count", () => {
+    const phrase = "2 bundled skills";
+    const root = setupRepo(["alpha", "beta"], {
+      marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
+      plugin: `The 7 Laws — ${phrase}, gating hooks.`,
+      package: `The 7 Laws — ${phrase}, gating hooks.`,
+      llms: `The 7 Laws — ${phrase}, gating hooks.`,
+      cloudplugin: "The 7 Laws — 13 bundled skills, gating hooks.",
+    });
+    try {
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /\.cloudplugin\/marketplace\.json — states "13 bundled skills"/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero when the cloudplugin count drifts");
     } finally {
       rmSync(root, { recursive: true, force: true });
     }

--- a/test/check-skill-count.test.mjs
+++ b/test/check-skill-count.test.mjs
@@ -15,6 +15,8 @@ function setupRepo(skillNames, descriptions) {
     mkdirSync(bundleSkillsDir, { recursive: true });
     mkdirSync(join(root, ".claude-plugin"), { recursive: true });
     mkdirSync(join(root, "plugins", "continuous-improvement", ".claude-plugin"), { recursive: true });
+    mkdirSync(join(root, ".cloudplugin"), { recursive: true });
+    mkdirSync(join(root, "docs", "landing"), { recursive: true });
     for (const name of skillNames) {
         mkdirSync(join(bundleSkillsDir, name), { recursive: true });
         writeFileSync(join(bundleSkillsDir, name, "SKILL.md"), `---\nname: ${name}\n---\n# ${name}\n`);
@@ -23,6 +25,10 @@ function setupRepo(skillNames, descriptions) {
     writeFileSync(join(root, "plugins", "continuous-improvement", ".claude-plugin", "plugin.json"), JSON.stringify({ description: descriptions.plugin ?? "" }));
     writeFileSync(join(root, "package.json"), JSON.stringify({ description: descriptions.package ?? "" }));
     writeFileSync(join(root, "llms.txt"), descriptions.llms ?? "");
+    writeFileSync(join(root, ".cloudplugin", "marketplace.json"), JSON.stringify({ description: descriptions.cloudplugin ?? descriptions.marketplace ?? "" }));
+    const count = skillNames.length;
+    writeFileSync(join(root, "docs", "landing", "index.html"), descriptions.landing ??
+        `<li><span class="v">${count}</span><span class="k">Bundled skills</span></li>`);
     return root;
 }
 describe("check-skill-count — unit", () => {
@@ -38,7 +44,7 @@ describe("check-skill-count — unit", () => {
     });
 });
 describe("check-skill-count — integration", () => {
-    it("CLI exits 0 when all four descriptions state the correct count", () => {
+    it("CLI exits 0 when all six checked files state the correct count", () => {
         const phrase = "2 bundled skills";
         const root = setupRepo(["alpha", "beta"], {
             marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
@@ -48,7 +54,59 @@ describe("check-skill-count — integration", () => {
         });
         try {
             const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
-            assert.match(out, /OK skill-count: all 4 description string\(s\) state "2 bundled skills"/);
+            assert.match(out, /OK skill-count: all 6 description string\(s\) state "2 bundled skills"/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 when the landing-page stat block states a stale count", () => {
+        const phrase = "2 bundled skills";
+        const root = setupRepo(["alpha", "beta"], {
+            marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
+            plugin: `The 7 Laws — ${phrase}, gating hooks.`,
+            package: `The 7 Laws — ${phrase}, gating hooks.`,
+            llms: `The 7 Laws — ${phrase}, gating hooks.`,
+            landing: `<li><span class="v">25</span><span class="k">Bundled skills</span></li>`,
+        });
+        try {
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /docs\/landing\/index\.html/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero when the landing stat drifts");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 when .cloudplugin/marketplace.json states a stale count", () => {
+        const phrase = "2 bundled skills";
+        const root = setupRepo(["alpha", "beta"], {
+            marketplace: `The 7 Laws — ${phrase}, gating hooks.`,
+            plugin: `The 7 Laws — ${phrase}, gating hooks.`,
+            package: `The 7 Laws — ${phrase}, gating hooks.`,
+            llms: `The 7 Laws — ${phrase}, gating hooks.`,
+            cloudplugin: "The 7 Laws — 13 bundled skills, gating hooks.",
+        });
+        try {
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /\.cloudplugin\/marketplace\.json — states "13 bundled skills"/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero when the cloudplugin count drifts");
         }
         finally {
             rmSync(root, { recursive: true, force: true });


### PR DESCRIPTION
## What

Closes the deferred tooling item from `docs/plans/2026-06-10-model-forward-default-skill.md`: PR #229's review found `docs/landing/index.html` stating **25** bundled skills while every checked surface said 26 — the landing stat block and the hand-maintained `.cloudplugin/marketplace.json` were both invisible to `verify:skill-count`.

- `.cloudplugin/marketplace.json` added to `CHECKED_FILES` (standard phrase pattern)
- `docs/landing/index.html` checked via a new stat-block pattern (`<span class="v">N</span><span class="k">Bundled skills</span>`)
- Tooling-only PR, ships alone per the no-bundled-concerns rule

## Verification

- TDD: 3 new tests written first, RED against the old checker, GREEN after — 6/6 pass incl. the live-repo check
- `npm run verify:all` 13/13 green (`skill-count` now reports "all 6 description string(s)")
- typecheck clean; `.mts` source + generated `.mjs` committed together

🤖 Generated with [Claude Code](https://claude.com/claude-code)