### PR TITLE
docs: sync stale v3.12.3 references to v3.13.0

### DIFF
--- a/.cloudplugin/marketplace.json
+++ b/.cloudplugin/marketplace.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.12.3",
+  "version": "3.13.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": "naimkatiman",
   "license": "MIT",

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -203,7 +203,7 @@
           <rect x="13" y="13" width="6" height="6" rx="1.5" fill="currentColor"/>
         </svg>
         <span class="name">continuous-improvement</span>
-        <span class="ver">v3.12.3</span>
+        <span class="ver">v3.13.0</span>
       </a>
       <div class="nav-links">
         <a href="#laws">The 7 Laws</a>
@@ -218,7 +218,7 @@
     <section class="hero">
       <div class="container hero-grid">
         <div class="hero-lead">
-          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.12.3</span>
+          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.13.0</span>
           <h1 class="display reveal" style="--i:1">Claude Code that gets <span class="belt draw">sharper every session</span></h1>
           <p class="hero-sub reveal" style="--i:2">continuous-improvement makes the agent research before it edits, prove every completion before it reports done, and turn each fix into an instinct it reuses next time. Seven laws run the loop; the Mulahazah engine compounds what it learns.</p>
           <div class="install reveal" style="--i:3">
@@ -255,7 +255,7 @@
         <li><span class="v">7</span><span class="k">Laws in force</span></li>
         <li><span class="v">0</span><span class="k">Runtime deps</span></li>
         <li><span class="v">MIT</span><span class="k">License</span></li>
-        <li><span class="v">v3.12.3</span><span class="k">Current rev</span></li>
+        <li><span class="v">v3.13.0</span><span class="k">Current rev</span></li>
       </ul>
     </div>
 
@@ -443,7 +443,7 @@
 
   <footer>
     <div class="container foot-grid">
-      <span class="foot-doc">DOC. CI-7L &middot; REV 3.12.3 &middot; MIT LICENSE</span>
+      <span class="foot-doc">DOC. CI-7L &middot; REV 3.13.0 &middot; MIT LICENSE</span>
       <div class="foot-links">
         <a href="https://github.com/naimkatiman/continuous-improvement">GitHub</a>
         <a href="https://www.npmjs.com/package/continuous-improvement">npm</a>

--- a/reports/assets/update-card.html
+++ b/reports/assets/update-card.html
@@ -161,7 +161,7 @@
     <i data-lucide="trending-up" style="color:#58a6ff" width="22" height="22"></i>
     <h1>Daily Improvement</h1>
   </div>
-  <div class="date">June 10, 2026 — continuous-improvement v3.12.3</div>
+  <div class="date">June 10, 2026 — continuous-improvement v3.13.0</div>
 
   <div class="stats">
     <div class="stat">

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -1,5 +1,10 @@
 # Daily Improvement Report — 2026-06-10
 
+## 2026-06-10 — Sync stale v3.12.3 references to v3.13.0
+- PR #231 (`chore(release): cut v3.13.0`) bumped `package.json`, `package-lock.json`, the generated plugin manifests, and `CHANGELOG.md` to v3.13.0, but four hand-maintained surfaces still advertised v3.12.3: `.cloudplugin/marketplace.json` (version field), `docs/landing/index.html` (nav badge, hero kicker, current-rev stat, footer REV), `reports/assets/update-card.html` (visible date line), and the Project Snapshot in this report.
+- Updated all five occurrences from `v3.12.3` / `REV 3.12.3` to `v3.13.0` / `REV 3.13.0` so user-facing version references match the current release.
+- Verified with `npm run verify:all` (all 13 content invariants + typecheck pass, 771 pass / 0 fail). Working tree has a doc-only diff.
+
 ## 2026-06-10 — Add verification date to model-forward plan status
 - `docs/plans/2026-06-10-model-forward-default-skill.md` listed `Status: complete` without a verification date, while every other recently completed plan (`gateguard-canonical-clearance`, `verify-tool-count-invariant`, `reposition-copy-under-orchestration`, `slim-ci-to-cli-anything`, `workflow-instinct-bridge`) uses the consistent pattern `Status: complete (verified YYYY-MM-DD)`.
 - Updated the status line from `Status: complete` to `Status: complete (verified 2026-06-10)` so the plans directory stays internally consistent.
@@ -738,7 +743,7 @@
 
 | Field | Value |
 |-------|-------|
-| Project | continuous-improvement v3.12.3 |
+| Project | continuous-improvement v3.13.0 |
 | Stack | Node.js (ESM), MCP server, GitHub Action, CLI tools |
 | Stage | Published npm package, active development |
 | Tests (current) | 771 pass / 0 fail |


### PR DESCRIPTION
PR #231 cut v3.13.0 but left four hand-maintained surfaces on v3.12.3: .cloudplugin/marketplace.json, docs/landing/index.html (4 occurrences), reports/assets/update-card.html, and the Project Snapshot. This doc-only change aligns them with the current release and records the entry in reports/daily-improvement.md. Verified with npm run verify:all (13 invariants + typecheck pass, 771/0).