### PR TITLE
feat(install): 7-Laws skill installs into 7 more agent platforms via --target

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,26 @@ The framework has documented operator-level modes that change hook behavior with
 | `CLAUDE_GOAL_DRIFT_GATE` | `goal-drift-stop.mjs` (a `Stop` hook) scores each turn's activity against the `## Goal` in `task_plan.md` and acts on drift. `warn` (default) prints a one-line stderr notice and never blocks; `block` re-prompts a substantive wrap-up that has drifted off-goal so the goal gates the close; `off` disables it. Reads the same observation feed as Mulahazah; fails open on any error. | bash/zsh: `export CLAUDE_GOAL_DRIFT_GATE=block` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_GOAL_DRIFT_GATE='block'` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_GOAL_DRIFT_GATE','block','User')` (persistent). |
 | `CLAUDE_RECALL_BRIEFING=1` | `hooks/recall-briefing.mjs` (a UserPromptSubmit hook) makes episodic memory proactive: on the first substantive prompt of a session it searches this project's past observations (BM25) and injects a one-time `<system-reminder>` with the most relevant prior activity, so the agent reuses a past fix instead of re-deriving it. Opt-in and default off; it is an amplifier, never a gate — it cannot block a prompt and fails open. The `ci_recall` MCP tool stays available for explicit, deeper searches. | bash/zsh: `export CLAUDE_RECALL_BRIEFING=1` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_RECALL_BRIEFING=1` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_RECALL_BRIEFING','1','User')` (persistent). |
 
+### Works with other agents
+
+Claude Code gets the full install (hooks, MCP server, instinct learning). Every other agent platform can still run the 7 Laws as a rules file — one flag writes the skill text into the file that platform reads, at your project root:
+
+```bash
+npx continuous-improvement install --target gemini,codex
+```
+
+| Target | File written |
+|---|---|
+| `gemini` | `GEMINI.md` (Gemini CLI context file) |
+| `codex` | `AGENTS.md` (agents.md standard — also read by opencode, Jules, Cursor ≥0.50) |
+| `cursor` | `.cursor/rules/continuous-improvement.mdc` (`alwaysApply: true`) |
+| `windsurf` | `.windsurf/rules/continuous-improvement.md` |
+| `zed` | `.rules` |
+| `aider` | `CONVENTIONS.md` + a minimal `.aider.conf.yml` if none exists |
+| `copilot` | `.github/copilot-instructions.md` |
+
+Shared files (`GEMINI.md`, `AGENTS.md`, `.rules`, `CONVENTIONS.md`, `copilot-instructions.md`) are merged through a managed marker block — your existing content is preserved and reinstalls are idempotent. Targets can be combined freely (`--target claude,gemini,codex` runs the full Claude Code install plus the rules files).
+
 ---
 
 ## The 7 Laws

--- a/bin/install.mjs
+++ b/bin/install.mjs
@@ -6,6 +6,7 @@
  *   npx continuous-improvement install                # beginner mode (default)
  *   npx continuous-improvement install --mode expert  # + MCP server + session hooks
  *   npx continuous-improvement install --pack react   # load starter instinct pack
+ *   npx continuous-improvement install --target gemini,codex  # skill into other agents' rules files
  *   npx continuous-improvement install --uninstall    # remove everything
  */
 import { chmodSync, copyFileSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync, } from "node:fs";
@@ -15,6 +16,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 import { getToolNames } from "../lib/plugin-metadata.mjs";
+import { TARGET_IDS, planTargetWrites, resolveTargets } from "../lib/install-targets.mjs";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const SKILL_SOURCE = join(__dirname, "..", "SKILL.md");
@@ -493,6 +495,17 @@ Options for 'install':
                       beginner  — hooks + skill + commands (default)
                       expert    — beginner + MCP server + session hooks
   --pack <name>     Load a starter instinct pack (react, python, go, meta)
+  --target <names>  Comma-separated platform list (default: claude):
+                      claude    — full install: hooks + skill + commands
+                      gemini    — GEMINI.md (Gemini CLI)
+                      codex     — AGENTS.md (Codex CLI / agents.md standard)
+                      cursor    — .cursor/rules/continuous-improvement.mdc
+                      windsurf  — .windsurf/rules/continuous-improvement.md
+                      zed       — .rules
+                      aider     — CONVENTIONS.md + .aider.conf.yml
+                      copilot   — .github/copilot-instructions.md
+                    Non-claude targets write the 7-Laws skill text into the
+                    current project; hooks/MCP/instincts stay Claude Code-only.
   --help            Show this help
 
 Options for 'backfill':
@@ -503,6 +516,7 @@ Examples:
   npx continuous-improvement install                # beginner (default)
   npx continuous-improvement install --mode expert  # full power
   npx continuous-improvement install --pack react   # load React instincts
+  npx continuous-improvement install --target gemini,codex  # other agents' rules files
   npx continuous-improvement backfill --dry-run     # report thin/rich row counts
   npx continuous-improvement backfill               # tag rows in place
   npx continuous-improvement install --uninstall    # remove everything
@@ -510,7 +524,12 @@ Examples:
 }
 function getProjectHashSync() {
     try {
-        const root = execSync("git rev-parse --show-toplevel 2>/dev/null", { encoding: "utf8" }).trim();
+        // No shell redirect — `2>/dev/null` breaks under cmd.exe (tries to open a
+        // file literally named /dev/null); ignore stderr via stdio instead.
+        const root = execSync("git rev-parse --show-toplevel", {
+            encoding: "utf8",
+            stdio: ["ignore", "pipe", "ignore"],
+        }).trim();
         const hash = createHash("sha256").update(root).digest("hex").slice(0, 12);
         return { root, hash };
     }
@@ -546,6 +565,60 @@ if (command === "backfill") {
 if (args.includes("--uninstall")) {
     uninstallAll();
     process.exit(0);
+}
+// --target <names>: comma-separated platform list, default claude-only.
+// Non-claude targets receive the skill text in their platform's rules file
+// (project-level); the full hook/MCP/instinct install stays Claude Code-only.
+const targetFlagIndex = rawArgs.indexOf("--target");
+let requestedTargets = ["claude"];
+if (targetFlagIndex !== -1) {
+    const targetCsv = rawArgs[targetFlagIndex + 1];
+    if (!targetCsv || targetCsv.startsWith("--")) {
+        console.error(`--target requires a value. Valid targets: ${TARGET_IDS.join(", ")}`);
+        process.exit(1);
+    }
+    const resolved = resolveTargets(targetCsv);
+    if (resolved.unknown.length > 0) {
+        console.error(`Unknown --target name(s): ${resolved.unknown.join(", ")}. Valid targets: ${TARGET_IDS.join(", ")}`);
+        process.exit(1);
+    }
+    if (resolved.targets.length === 0) {
+        console.error(`--target requires at least one name. Valid targets: ${TARGET_IDS.join(", ")}`);
+        process.exit(1);
+    }
+    requestedTargets = resolved.targets;
+}
+function installNonClaudeTargets(targetIds) {
+    const skillMd = readFileSync(SKILL_SOURCE, "utf8");
+    const project = getProjectHashSync();
+    const projectRoot = project.root === "global" ? process.cwd() : project.root;
+    const readExisting = (relPath) => {
+        const absPath = join(projectRoot, relPath);
+        return existsSync(absPath) ? readFileSync(absPath, "utf8") : null;
+    };
+    const notes = new Set();
+    for (const targetId of targetIds) {
+        const plan = planTargetWrites(targetId, skillMd, readExisting);
+        for (const write of plan.writes) {
+            const absPath = join(projectRoot, write.relPath);
+            mkdirSync(dirname(absPath), { recursive: true });
+            writeFileSync(absPath, write.content);
+            console.log(`  ✓ ${targetId} → ${write.relPath}`);
+        }
+        for (const note of plan.notes)
+            notes.add(note);
+    }
+    for (const note of notes)
+        console.log(`  ℹ ${note}`);
+}
+const nonClaudeTargets = requestedTargets.filter((targetId) => targetId !== "claude");
+if (nonClaudeTargets.length > 0) {
+    console.log("\ncontinuous-improvement multi-platform install\n");
+    installNonClaudeTargets(nonClaudeTargets);
+    if (!requestedTargets.includes("claude")) {
+        console.log("\nDone. Claude Code install skipped (not in --target list).");
+        process.exit(0);
+    }
 }
 console.log(`
 continuous-improvement (mode: ${INSTALL_MODE})

--- a/docs/plans/2026-06-11-multi-platform-installer.md
+++ b/docs/plans/2026-06-11-multi-platform-installer.md
@@ -1,0 +1,45 @@
+# Multi-platform installer — `--target <platform>`
+
+Date: 2026-06-11 · Branch: `feat/multi-platform-installer` · Issues: #9 (Gemini CLI), #14 (Aider), #15 (Windsurf/Zed)
+
+## Goal (one sentence)
+
+`npx continuous-improvement install --target <names>` installs the 7-Laws skill content into the rules file of other AI agent platforms, so the framework can be used by agents beyond Claude Code.
+
+## Assumptions
+
+- Non-Claude platforms consume plain-markdown rules files; none of them run our hooks, MCP server, or instinct learning. Non-Claude targets get the **skill text only**, and the installer says so explicitly.
+- Project-level install (repo root via `git rev-parse --show-toplevel`, falling back to cwd) is the v1 contract for non-Claude targets. Global per-tool paths (`~/.gemini/GEMINI.md`, `~/.codex/AGENTS.md`) are deferred until someone asks.
+- Platform file contracts (stable, pre-2026 conventions):
+  - `gemini` → `GEMINI.md` (Gemini CLI default context file)
+  - `codex` → `AGENTS.md` (agents.md standard; also read by opencode, Jules, Cursor ≥0.50)
+  - `cursor` → `.cursor/rules/continuous-improvement.mdc` (mdc frontmatter, `alwaysApply: true`)
+  - `windsurf` → `.windsurf/rules/continuous-improvement.md`
+  - `zed` → `.rules`
+  - `aider` → `CONVENTIONS.md` + `.aider.conf.yml` `read:` entry
+  - `copilot` → `.github/copilot-instructions.md`
+
+## Design
+
+- New `src/lib/install-targets.mts` — target registry + pure functions (no fs):
+  - `resolveTargets(csv)` → `{ targets, unknown }`
+  - `stripFrontmatter(skillMd)` — drop the Claude skill frontmatter block
+  - `renderForTarget(skillMd, target)` — per-target wrapping (mdc frontmatter for cursor; managed-block markers for shared files)
+  - `mergeManagedBlock(existing, block)` — create / append / replace between `<!-- continuous-improvement:begin -->` and `<!-- continuous-improvement:end -->` markers; idempotent (second run is a no-op)
+  - `planTargetWrites(target, skillMd, readExisting)` — returns `{ relPath, content }[]`; fs injected so it stays testable
+- Shared files (`GEMINI.md`, `AGENTS.md`, `.rules`, `CONVENTIONS.md`, `copilot-instructions.md`) use the managed block so existing user content is never clobbered. Own-file targets (`cursor`, `windsurf`) are written whole.
+- Aider conf: if `.aider.conf.yml` is absent, write a minimal one (`read: [CONVENTIONS.md]`). If present, do **not** mutate it (no YAML dependency, no risky string surgery) — print the one line the user should add.
+- `src/bin/install.mts` wiring: parse `--target a,b,c` (default `claude`). `claude` keeps the existing flow untouched; other targets run the file plan against the project root with `✓` log lines and a Claude-only-features note. Unknown target → error listing valid names, exit 1. `--help` and examples updated.
+
+## Out of scope (deferred, logged here per Law 6)
+
+- Gemini CLI hook/observation support (#9 step 4) — needs Gemini-side research.
+- Global (`--global`) per-tool install paths.
+- Auto-merging an existing `.aider.conf.yml`.
+
+## Verification
+
+1. RED: `src/test/install-targets.test.mts` written first (registry, frontmatter strip, managed-block create/append/replace idempotency, cursor mdc shape, aider conf plan, unknown target) — fails before the lib exists.
+2. GREEN: `npm test` (existing suite + new) passes.
+3. `npm run verify:all` (12 invariants + typecheck) passes.
+4. Manual smoke: run the built installer with `--target gemini,codex` in a temp dir, confirm files + rerun idempotency.

--- a/lib/install-targets.mjs
+++ b/lib/install-targets.mjs
@@ -1,0 +1,121 @@
+/**
+ * Multi-platform install targets for the 7-Laws skill.
+ *
+ * Pure planning layer — no filesystem access. The installer
+ * (src/bin/install.mts) feeds in the SKILL.md text plus a reader callback and
+ * executes the returned write plan against the project root. Keeping this
+ * pure lets the per-target contracts be unit-tested without temp dirs.
+ *
+ * v1 contract (docs/plans/2026-06-11-multi-platform-installer.md):
+ * - Non-Claude targets receive the skill text only; hooks, the MCP server,
+ *   and instinct learning stay Claude Code-only and every plan says so.
+ * - Shared files (GEMINI.md, AGENTS.md, .rules, CONVENTIONS.md,
+ *   copilot-instructions.md) are merged through a managed block so existing
+ *   user content is never clobbered and reinstalls are idempotent.
+ * - Own-file targets (cursor, windsurf) are written whole.
+ */
+export const MANAGED_BEGIN = "<!-- continuous-improvement:begin (managed block — reinstall via `npx continuous-improvement install --target <name>`; edits inside are overwritten) -->";
+export const MANAGED_END = "<!-- continuous-improvement:end -->";
+const TARGET_SPECS = {
+    gemini: { label: "Gemini CLI", mode: "managed", relPath: "GEMINI.md" },
+    codex: { label: "Codex CLI (agents.md standard)", mode: "managed", relPath: "AGENTS.md" },
+    cursor: { label: "Cursor", mode: "whole", relPath: ".cursor/rules/continuous-improvement.mdc" },
+    windsurf: { label: "Windsurf", mode: "whole", relPath: ".windsurf/rules/continuous-improvement.md" },
+    zed: { label: "Zed", mode: "managed", relPath: ".rules" },
+    aider: { label: "Aider", mode: "managed", relPath: "CONVENTIONS.md" },
+    copilot: { label: "GitHub Copilot", mode: "managed", relPath: ".github/copilot-instructions.md" },
+};
+export const TARGET_IDS = ["claude", ...Object.keys(TARGET_SPECS)];
+export function resolveTargets(csv) {
+    const targets = [];
+    const unknown = [];
+    for (const raw of csv.split(",")) {
+        const name = raw.trim().toLowerCase();
+        if (name === "")
+            continue;
+        if (!TARGET_IDS.includes(name)) {
+            if (!unknown.includes(name))
+                unknown.push(name);
+            continue;
+        }
+        if (!targets.includes(name))
+            targets.push(name);
+    }
+    return { targets, unknown };
+}
+export function stripFrontmatter(skillMd) {
+    if (!skillMd.startsWith("---\n") && !skillMd.startsWith("---\r\n"))
+        return skillMd;
+    const close = skillMd.indexOf("\n---", 3);
+    if (close === -1)
+        return skillMd;
+    const afterClose = skillMd.indexOf("\n", close + 1);
+    if (afterClose === -1)
+        return "";
+    return skillMd.slice(afterClose + 1).replace(/^\s*\n/, "");
+}
+export function mergeManagedBlock(existing, block) {
+    if (existing === null || existing.trim() === "") {
+        return `${block}\n`;
+    }
+    const beginAt = existing.indexOf(MANAGED_BEGIN);
+    const endAt = existing.indexOf(MANAGED_END);
+    if (beginAt !== -1 && endAt !== -1 && endAt > beginAt) {
+        const before = existing.slice(0, beginAt);
+        const after = existing.slice(endAt + MANAGED_END.length);
+        return `${before}${block}${after}`;
+    }
+    return `${existing.trimEnd()}\n\n${block}\n`;
+}
+function renderManagedBlock(skillMd) {
+    return `${MANAGED_BEGIN}\n${stripFrontmatter(skillMd).trim()}\n${MANAGED_END}`;
+}
+function renderCursorRule(skillMd) {
+    return [
+        "---",
+        "description: 7 Laws of AI Agent Discipline — continuous-improvement framework",
+        "alwaysApply: true",
+        "---",
+        "",
+        stripFrontmatter(skillMd).trim(),
+        "",
+    ].join("\n");
+}
+const AIDER_CONF_PATH = ".aider.conf.yml";
+const AIDER_MINIMAL_CONF = [
+    "# Written by `npx continuous-improvement install --target aider`.",
+    "# Loads the 7 Laws conventions into every Aider session.",
+    "read: [CONVENTIONS.md]",
+    "",
+].join("\n");
+export function planTargetWrites(targetId, skillMd, readExisting) {
+    if (targetId === "claude") {
+        throw new Error("claude is handled by the standard installer flow, not planTargetWrites");
+    }
+    const spec = TARGET_SPECS[targetId];
+    if (!spec) {
+        throw new Error(`Unknown install target: ${targetId}. Valid: ${TARGET_IDS.join(", ")}`);
+    }
+    const writes = [];
+    const notes = [
+        `${spec.label} gets the 7-Laws skill text only — hooks, the MCP server, and instinct learning are Claude Code-only.`,
+    ];
+    if (spec.mode === "whole") {
+        const content = targetId === "cursor" ? renderCursorRule(skillMd) : `${stripFrontmatter(skillMd).trim()}\n`;
+        writes.push({ relPath: spec.relPath, content });
+    }
+    else {
+        const block = renderManagedBlock(skillMd);
+        writes.push({ relPath: spec.relPath, content: mergeManagedBlock(readExisting(spec.relPath), block) });
+    }
+    if (targetId === "aider") {
+        const existingConf = readExisting(AIDER_CONF_PATH);
+        if (existingConf === null) {
+            writes.push({ relPath: AIDER_CONF_PATH, content: AIDER_MINIMAL_CONF });
+        }
+        else {
+            notes.push(`${AIDER_CONF_PATH} already exists — add CONVENTIONS.md to its \`read:\` list yourself (e.g. \`read: [CONVENTIONS.md]\`); the installer never rewrites an existing conf.`);
+        }
+    }
+    return { notes, writes };
+}

--- a/src/bin/install.mts
+++ b/src/bin/install.mts
@@ -7,6 +7,7 @@
  *   npx continuous-improvement install                # beginner mode (default)
  *   npx continuous-improvement install --mode expert  # + MCP server + session hooks
  *   npx continuous-improvement install --pack react   # load starter instinct pack
+ *   npx continuous-improvement install --target gemini,codex  # skill into other agents' rules files
  *   npx continuous-improvement install --uninstall    # remove everything
  */
 
@@ -27,6 +28,7 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
 import { getToolNames } from "../lib/plugin-metadata.mjs";
+import { TARGET_IDS, planTargetWrites, resolveTargets } from "../lib/install-targets.mjs";
 
 type InstallMode = "beginner" | "expert";
 type HookType = "PreToolUse" | "PostToolUse" | "SessionStart" | "SessionEnd";
@@ -610,6 +612,17 @@ Options for 'install':
                       beginner  — hooks + skill + commands (default)
                       expert    — beginner + MCP server + session hooks
   --pack <name>     Load a starter instinct pack (react, python, go, meta)
+  --target <names>  Comma-separated platform list (default: claude):
+                      claude    — full install: hooks + skill + commands
+                      gemini    — GEMINI.md (Gemini CLI)
+                      codex     — AGENTS.md (Codex CLI / agents.md standard)
+                      cursor    — .cursor/rules/continuous-improvement.mdc
+                      windsurf  — .windsurf/rules/continuous-improvement.md
+                      zed       — .rules
+                      aider     — CONVENTIONS.md + .aider.conf.yml
+                      copilot   — .github/copilot-instructions.md
+                    Non-claude targets write the 7-Laws skill text into the
+                    current project; hooks/MCP/instincts stay Claude Code-only.
   --help            Show this help
 
 Options for 'backfill':
@@ -620,6 +633,7 @@ Examples:
   npx continuous-improvement install                # beginner (default)
   npx continuous-improvement install --mode expert  # full power
   npx continuous-improvement install --pack react   # load React instincts
+  npx continuous-improvement install --target gemini,codex  # other agents' rules files
   npx continuous-improvement backfill --dry-run     # report thin/rich row counts
   npx continuous-improvement backfill               # tag rows in place
   npx continuous-improvement install --uninstall    # remove everything
@@ -628,7 +642,12 @@ Examples:
 
 function getProjectHashSync(): ProjectHash {
   try {
-    const root = execSync("git rev-parse --show-toplevel 2>/dev/null", { encoding: "utf8" }).trim();
+    // No shell redirect — `2>/dev/null` breaks under cmd.exe (tries to open a
+    // file literally named /dev/null); ignore stderr via stdio instead.
+    const root = execSync("git rev-parse --show-toplevel", {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
     const hash = createHash("sha256").update(root).digest("hex").slice(0, 12);
     return { root, hash };
   } catch {
@@ -667,6 +686,63 @@ if (command === "backfill") {
 if (args.includes("--uninstall")) {
   uninstallAll();
   process.exit(0);
+}
+
+// --target <names>: comma-separated platform list, default claude-only.
+// Non-claude targets receive the skill text in their platform's rules file
+// (project-level); the full hook/MCP/instinct install stays Claude Code-only.
+const targetFlagIndex = rawArgs.indexOf("--target");
+let requestedTargets: string[] = ["claude"];
+if (targetFlagIndex !== -1) {
+  const targetCsv = rawArgs[targetFlagIndex + 1];
+  if (!targetCsv || targetCsv.startsWith("--")) {
+    console.error(`--target requires a value. Valid targets: ${TARGET_IDS.join(", ")}`);
+    process.exit(1);
+  }
+  const resolved = resolveTargets(targetCsv);
+  if (resolved.unknown.length > 0) {
+    console.error(
+      `Unknown --target name(s): ${resolved.unknown.join(", ")}. Valid targets: ${TARGET_IDS.join(", ")}`,
+    );
+    process.exit(1);
+  }
+  if (resolved.targets.length === 0) {
+    console.error(`--target requires at least one name. Valid targets: ${TARGET_IDS.join(", ")}`);
+    process.exit(1);
+  }
+  requestedTargets = resolved.targets;
+}
+
+function installNonClaudeTargets(targetIds: string[]): void {
+  const skillMd = readFileSync(SKILL_SOURCE, "utf8");
+  const project = getProjectHashSync();
+  const projectRoot = project.root === "global" ? process.cwd() : project.root;
+  const readExisting = (relPath: string): string | null => {
+    const absPath = join(projectRoot, relPath);
+    return existsSync(absPath) ? readFileSync(absPath, "utf8") : null;
+  };
+  const notes = new Set<string>();
+  for (const targetId of targetIds) {
+    const plan = planTargetWrites(targetId, skillMd, readExisting);
+    for (const write of plan.writes) {
+      const absPath = join(projectRoot, write.relPath);
+      mkdirSync(dirname(absPath), { recursive: true });
+      writeFileSync(absPath, write.content);
+      console.log(`  ✓ ${targetId} → ${write.relPath}`);
+    }
+    for (const note of plan.notes) notes.add(note);
+  }
+  for (const note of notes) console.log(`  ℹ ${note}`);
+}
+
+const nonClaudeTargets = requestedTargets.filter((targetId) => targetId !== "claude");
+if (nonClaudeTargets.length > 0) {
+  console.log("\ncontinuous-improvement multi-platform install\n");
+  installNonClaudeTargets(nonClaudeTargets);
+  if (!requestedTargets.includes("claude")) {
+    console.log("\nDone. Claude Code install skipped (not in --target list).");
+    process.exit(0);
+  }
 }
 
 console.log(`

--- a/src/lib/install-targets.mts
+++ b/src/lib/install-targets.mts
@@ -1,0 +1,150 @@
+/**
+ * Multi-platform install targets for the 7-Laws skill.
+ *
+ * Pure planning layer — no filesystem access. The installer
+ * (src/bin/install.mts) feeds in the SKILL.md text plus a reader callback and
+ * executes the returned write plan against the project root. Keeping this
+ * pure lets the per-target contracts be unit-tested without temp dirs.
+ *
+ * v1 contract (docs/plans/2026-06-11-multi-platform-installer.md):
+ * - Non-Claude targets receive the skill text only; hooks, the MCP server,
+ *   and instinct learning stay Claude Code-only and every plan says so.
+ * - Shared files (GEMINI.md, AGENTS.md, .rules, CONVENTIONS.md,
+ *   copilot-instructions.md) are merged through a managed block so existing
+ *   user content is never clobbered and reinstalls are idempotent.
+ * - Own-file targets (cursor, windsurf) are written whole.
+ */
+
+export const MANAGED_BEGIN = "<!-- continuous-improvement:begin (managed block — reinstall via `npx continuous-improvement install --target <name>`; edits inside are overwritten) -->";
+export const MANAGED_END = "<!-- continuous-improvement:end -->";
+
+export interface TargetWrite {
+  content: string;
+  relPath: string;
+}
+
+export interface TargetPlan {
+  notes: string[];
+  writes: TargetWrite[];
+}
+
+interface TargetSpec {
+  label: string;
+  /** "managed" merges into a shared file; "whole" owns its file outright. */
+  mode: "managed" | "whole";
+  relPath: string;
+}
+
+const TARGET_SPECS: Record<string, TargetSpec> = {
+  gemini: { label: "Gemini CLI", mode: "managed", relPath: "GEMINI.md" },
+  codex: { label: "Codex CLI (agents.md standard)", mode: "managed", relPath: "AGENTS.md" },
+  cursor: { label: "Cursor", mode: "whole", relPath: ".cursor/rules/continuous-improvement.mdc" },
+  windsurf: { label: "Windsurf", mode: "whole", relPath: ".windsurf/rules/continuous-improvement.md" },
+  zed: { label: "Zed", mode: "managed", relPath: ".rules" },
+  aider: { label: "Aider", mode: "managed", relPath: "CONVENTIONS.md" },
+  copilot: { label: "GitHub Copilot", mode: "managed", relPath: ".github/copilot-instructions.md" },
+};
+
+export const TARGET_IDS: readonly string[] = ["claude", ...Object.keys(TARGET_SPECS)];
+
+export function resolveTargets(csv: string): { targets: string[]; unknown: string[] } {
+  const targets: string[] = [];
+  const unknown: string[] = [];
+  for (const raw of csv.split(",")) {
+    const name = raw.trim().toLowerCase();
+    if (name === "") continue;
+    if (!TARGET_IDS.includes(name)) {
+      if (!unknown.includes(name)) unknown.push(name);
+      continue;
+    }
+    if (!targets.includes(name)) targets.push(name);
+  }
+  return { targets, unknown };
+}
+
+export function stripFrontmatter(skillMd: string): string {
+  if (!skillMd.startsWith("---\n") && !skillMd.startsWith("---\r\n")) return skillMd;
+  const close = skillMd.indexOf("\n---", 3);
+  if (close === -1) return skillMd;
+  const afterClose = skillMd.indexOf("\n", close + 1);
+  if (afterClose === -1) return "";
+  return skillMd.slice(afterClose + 1).replace(/^\s*\n/, "");
+}
+
+export function mergeManagedBlock(existing: string | null, block: string): string {
+  if (existing === null || existing.trim() === "") {
+    return `${block}\n`;
+  }
+  const beginAt = existing.indexOf(MANAGED_BEGIN);
+  const endAt = existing.indexOf(MANAGED_END);
+  if (beginAt !== -1 && endAt !== -1 && endAt > beginAt) {
+    const before = existing.slice(0, beginAt);
+    const after = existing.slice(endAt + MANAGED_END.length);
+    return `${before}${block}${after}`;
+  }
+  return `${existing.trimEnd()}\n\n${block}\n`;
+}
+
+function renderManagedBlock(skillMd: string): string {
+  return `${MANAGED_BEGIN}\n${stripFrontmatter(skillMd).trim()}\n${MANAGED_END}`;
+}
+
+function renderCursorRule(skillMd: string): string {
+  return [
+    "---",
+    "description: 7 Laws of AI Agent Discipline — continuous-improvement framework",
+    "alwaysApply: true",
+    "---",
+    "",
+    stripFrontmatter(skillMd).trim(),
+    "",
+  ].join("\n");
+}
+
+const AIDER_CONF_PATH = ".aider.conf.yml";
+const AIDER_MINIMAL_CONF = [
+  "# Written by `npx continuous-improvement install --target aider`.",
+  "# Loads the 7 Laws conventions into every Aider session.",
+  "read: [CONVENTIONS.md]",
+  "",
+].join("\n");
+
+export function planTargetWrites(
+  targetId: string,
+  skillMd: string,
+  readExisting: (relPath: string) => string | null,
+): TargetPlan {
+  if (targetId === "claude") {
+    throw new Error("claude is handled by the standard installer flow, not planTargetWrites");
+  }
+  const spec = TARGET_SPECS[targetId];
+  if (!spec) {
+    throw new Error(`Unknown install target: ${targetId}. Valid: ${TARGET_IDS.join(", ")}`);
+  }
+
+  const writes: TargetWrite[] = [];
+  const notes: string[] = [
+    `${spec.label} gets the 7-Laws skill text only — hooks, the MCP server, and instinct learning are Claude Code-only.`,
+  ];
+
+  if (spec.mode === "whole") {
+    const content = targetId === "cursor" ? renderCursorRule(skillMd) : `${stripFrontmatter(skillMd).trim()}\n`;
+    writes.push({ relPath: spec.relPath, content });
+  } else {
+    const block = renderManagedBlock(skillMd);
+    writes.push({ relPath: spec.relPath, content: mergeManagedBlock(readExisting(spec.relPath), block) });
+  }
+
+  if (targetId === "aider") {
+    const existingConf = readExisting(AIDER_CONF_PATH);
+    if (existingConf === null) {
+      writes.push({ relPath: AIDER_CONF_PATH, content: AIDER_MINIMAL_CONF });
+    } else {
+      notes.push(
+        `${AIDER_CONF_PATH} already exists — add CONVENTIONS.md to its \`read:\` list yourself (e.g. \`read: [CONVENTIONS.md]\`); the installer never rewrites an existing conf.`,
+      );
+    }
+  }
+
+  return { notes, writes };
+}

--- a/src/test/install-targets.test.mts
+++ b/src/test/install-targets.test.mts
@@ -1,0 +1,198 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  MANAGED_BEGIN,
+  MANAGED_END,
+  TARGET_IDS,
+  mergeManagedBlock,
+  planTargetWrites,
+  resolveTargets,
+  stripFrontmatter,
+} from "../lib/install-targets.mjs";
+
+const SAMPLE_SKILL = [
+  "---",
+  "name: continuous-improvement",
+  "tier: core",
+  'description: "Install structured self-improvement loops."',
+  "---",
+  "",
+  "# continuous-improvement",
+  "",
+  "## Law 1: Research Before Executing",
+  "",
+  "Before writing code or taking action, research first.",
+  "",
+].join("\n");
+
+function readNothing(): string | null {
+  return null;
+}
+
+describe("TARGET_IDS registry", () => {
+  it("lists claude first and covers all v1 platforms", () => {
+    assert.equal(TARGET_IDS[0], "claude");
+    for (const id of ["gemini", "codex", "cursor", "windsurf", "zed", "aider", "copilot"]) {
+      assert.ok(TARGET_IDS.includes(id), `missing target id: ${id}`);
+    }
+  });
+});
+
+describe("resolveTargets", () => {
+  it("splits a comma list, trims, lowercases, and dedupes preserving order", () => {
+    const result = resolveTargets(" Gemini , codex,gemini ");
+    assert.deepEqual(result.targets, ["gemini", "codex"]);
+    assert.deepEqual(result.unknown, []);
+  });
+
+  it("reports unknown names without dropping valid ones", () => {
+    const result = resolveTargets("gemini,nope,zed");
+    assert.deepEqual(result.targets, ["gemini", "zed"]);
+    assert.deepEqual(result.unknown, ["nope"]);
+  });
+
+  it("returns empty lists for an empty or whitespace-only value", () => {
+    assert.deepEqual(resolveTargets(""), { targets: [], unknown: [] });
+    assert.deepEqual(resolveTargets(" , "), { targets: [], unknown: [] });
+  });
+});
+
+describe("stripFrontmatter", () => {
+  it("drops the leading frontmatter block and leading blank lines", () => {
+    const body = stripFrontmatter(SAMPLE_SKILL);
+    assert.ok(body.startsWith("# continuous-improvement"));
+    assert.ok(!body.includes("tier: core"));
+  });
+
+  it("returns content unchanged when there is no frontmatter", () => {
+    const plain = "# heading\n\nbody\n";
+    assert.equal(stripFrontmatter(plain), plain);
+  });
+
+  it("does not treat a later horizontal rule as frontmatter", () => {
+    const plain = "# heading\n\n---\n\nbody\n";
+    assert.equal(stripFrontmatter(plain), plain);
+  });
+});
+
+describe("mergeManagedBlock", () => {
+  const block = `${MANAGED_BEGIN}\nseven laws body\n${MANAGED_END}`;
+
+  it("creates the file content when nothing exists", () => {
+    const merged = mergeManagedBlock(null, block);
+    assert.ok(merged.startsWith(MANAGED_BEGIN));
+    assert.ok(merged.endsWith("\n"));
+  });
+
+  it("appends after existing user content without clobbering it", () => {
+    const merged = mergeManagedBlock("# My own rules\n\nKeep these.\n", block);
+    assert.ok(merged.startsWith("# My own rules"));
+    assert.ok(merged.includes("Keep these."));
+    assert.ok(merged.includes("seven laws body"));
+  });
+
+  it("replaces only the managed region on reinstall", () => {
+    const existing = `before\n\n${MANAGED_BEGIN}\nold body\n${MANAGED_END}\n\nafter\n`;
+    const updated = mergeManagedBlock(existing, block);
+    assert.ok(updated.includes("before"));
+    assert.ok(updated.includes("after"));
+    assert.ok(updated.includes("seven laws body"));
+    assert.ok(!updated.includes("old body"));
+  });
+
+  it("is idempotent — a second merge with the same block is a no-op", () => {
+    const once = mergeManagedBlock("# Mine\n", block);
+    const twice = mergeManagedBlock(once, block);
+    assert.equal(twice, once);
+  });
+});
+
+describe("planTargetWrites", () => {
+  it("throws for the claude target — that path is the existing installer flow", () => {
+    assert.throws(() => planTargetWrites("claude", SAMPLE_SKILL, readNothing));
+  });
+
+  it("throws for an unknown target", () => {
+    assert.throws(() => planTargetWrites("emacs", SAMPLE_SKILL, readNothing));
+  });
+
+  it("gemini writes a managed block into GEMINI.md without skill frontmatter", () => {
+    const plan = planTargetWrites("gemini", SAMPLE_SKILL, readNothing);
+    assert.equal(plan.writes.length, 1);
+    assert.equal(plan.writes[0].relPath, "GEMINI.md");
+    assert.ok(plan.writes[0].content.includes(MANAGED_BEGIN));
+    assert.ok(plan.writes[0].content.includes("Law 1"));
+    assert.ok(!plan.writes[0].content.includes("tier: core"));
+  });
+
+  it("codex writes the agents.md standard file", () => {
+    const plan = planTargetWrites("codex", SAMPLE_SKILL, readNothing);
+    assert.deepEqual(
+      plan.writes.map((w) => w.relPath),
+      ["AGENTS.md"],
+    );
+  });
+
+  it("gemini preserves existing user content via the managed block", () => {
+    const plan = planTargetWrites("gemini", SAMPLE_SKILL, (relPath) =>
+      relPath === "GEMINI.md" ? "# Project context\n" : null,
+    );
+    assert.ok(plan.writes[0].content.startsWith("# Project context"));
+    assert.ok(plan.writes[0].content.includes(MANAGED_BEGIN));
+  });
+
+  it("cursor writes a whole .mdc rule file with alwaysApply frontmatter", () => {
+    const plan = planTargetWrites("cursor", SAMPLE_SKILL, readNothing);
+    assert.equal(plan.writes[0].relPath, ".cursor/rules/continuous-improvement.mdc");
+    assert.ok(plan.writes[0].content.startsWith("---\n"));
+    assert.ok(plan.writes[0].content.includes("alwaysApply: true"));
+    assert.ok(!plan.writes[0].content.includes(MANAGED_BEGIN));
+  });
+
+  it("windsurf writes its own rule file with the plain body", () => {
+    const plan = planTargetWrites("windsurf", SAMPLE_SKILL, readNothing);
+    assert.equal(plan.writes[0].relPath, ".windsurf/rules/continuous-improvement.md");
+    assert.ok(plan.writes[0].content.startsWith("# continuous-improvement"));
+  });
+
+  it("zed and copilot use managed blocks in shared files", () => {
+    assert.equal(planTargetWrites("zed", SAMPLE_SKILL, readNothing).writes[0].relPath, ".rules");
+    assert.equal(
+      planTargetWrites("copilot", SAMPLE_SKILL, readNothing).writes[0].relPath,
+      ".github/copilot-instructions.md",
+    );
+  });
+
+  it("aider writes CONVENTIONS.md and creates a minimal conf when none exists", () => {
+    const plan = planTargetWrites("aider", SAMPLE_SKILL, readNothing);
+    assert.deepEqual(
+      plan.writes.map((w) => w.relPath),
+      ["CONVENTIONS.md", ".aider.conf.yml"],
+    );
+    const conf = plan.writes[1].content;
+    assert.ok(conf.includes("read:"));
+    assert.ok(conf.includes("CONVENTIONS.md"));
+  });
+
+  it("aider leaves an existing conf untouched and explains the manual step", () => {
+    const plan = planTargetWrites("aider", SAMPLE_SKILL, (relPath) =>
+      relPath === ".aider.conf.yml" ? "model: gpt-5\n" : null,
+    );
+    assert.deepEqual(
+      plan.writes.map((w) => w.relPath),
+      ["CONVENTIONS.md"],
+    );
+    assert.ok(plan.notes.some((note) => note.includes(".aider.conf.yml")));
+  });
+
+  it("every non-claude plan notes that hooks/MCP/instincts stay Claude Code-only", () => {
+    for (const id of ["gemini", "codex", "cursor", "windsurf", "zed", "aider", "copilot"]) {
+      const plan = planTargetWrites(id, SAMPLE_SKILL, readNothing);
+      assert.ok(
+        plan.notes.some((note) => note.includes("Claude Code")),
+        `missing Claude Code-only note for ${id}`,
+      );
+    }
+  });
+});

--- a/test/install-targets.test.mjs
+++ b/test/install-targets.test.mjs
@@ -1,0 +1,145 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { MANAGED_BEGIN, MANAGED_END, TARGET_IDS, mergeManagedBlock, planTargetWrites, resolveTargets, stripFrontmatter, } from "../lib/install-targets.mjs";
+const SAMPLE_SKILL = [
+    "---",
+    "name: continuous-improvement",
+    "tier: core",
+    'description: "Install structured self-improvement loops."',
+    "---",
+    "",
+    "# continuous-improvement",
+    "",
+    "## Law 1: Research Before Executing",
+    "",
+    "Before writing code or taking action, research first.",
+    "",
+].join("\n");
+function readNothing() {
+    return null;
+}
+describe("TARGET_IDS registry", () => {
+    it("lists claude first and covers all v1 platforms", () => {
+        assert.equal(TARGET_IDS[0], "claude");
+        for (const id of ["gemini", "codex", "cursor", "windsurf", "zed", "aider", "copilot"]) {
+            assert.ok(TARGET_IDS.includes(id), `missing target id: ${id}`);
+        }
+    });
+});
+describe("resolveTargets", () => {
+    it("splits a comma list, trims, lowercases, and dedupes preserving order", () => {
+        const result = resolveTargets(" Gemini , codex,gemini ");
+        assert.deepEqual(result.targets, ["gemini", "codex"]);
+        assert.deepEqual(result.unknown, []);
+    });
+    it("reports unknown names without dropping valid ones", () => {
+        const result = resolveTargets("gemini,nope,zed");
+        assert.deepEqual(result.targets, ["gemini", "zed"]);
+        assert.deepEqual(result.unknown, ["nope"]);
+    });
+    it("returns empty lists for an empty or whitespace-only value", () => {
+        assert.deepEqual(resolveTargets(""), { targets: [], unknown: [] });
+        assert.deepEqual(resolveTargets(" , "), { targets: [], unknown: [] });
+    });
+});
+describe("stripFrontmatter", () => {
+    it("drops the leading frontmatter block and leading blank lines", () => {
+        const body = stripFrontmatter(SAMPLE_SKILL);
+        assert.ok(body.startsWith("# continuous-improvement"));
+        assert.ok(!body.includes("tier: core"));
+    });
+    it("returns content unchanged when there is no frontmatter", () => {
+        const plain = "# heading\n\nbody\n";
+        assert.equal(stripFrontmatter(plain), plain);
+    });
+    it("does not treat a later horizontal rule as frontmatter", () => {
+        const plain = "# heading\n\n---\n\nbody\n";
+        assert.equal(stripFrontmatter(plain), plain);
+    });
+});
+describe("mergeManagedBlock", () => {
+    const block = `${MANAGED_BEGIN}\nseven laws body\n${MANAGED_END}`;
+    it("creates the file content when nothing exists", () => {
+        const merged = mergeManagedBlock(null, block);
+        assert.ok(merged.startsWith(MANAGED_BEGIN));
+        assert.ok(merged.endsWith("\n"));
+    });
+    it("appends after existing user content without clobbering it", () => {
+        const merged = mergeManagedBlock("# My own rules\n\nKeep these.\n", block);
+        assert.ok(merged.startsWith("# My own rules"));
+        assert.ok(merged.includes("Keep these."));
+        assert.ok(merged.includes("seven laws body"));
+    });
+    it("replaces only the managed region on reinstall", () => {
+        const existing = `before\n\n${MANAGED_BEGIN}\nold body\n${MANAGED_END}\n\nafter\n`;
+        const updated = mergeManagedBlock(existing, block);
+        assert.ok(updated.includes("before"));
+        assert.ok(updated.includes("after"));
+        assert.ok(updated.includes("seven laws body"));
+        assert.ok(!updated.includes("old body"));
+    });
+    it("is idempotent — a second merge with the same block is a no-op", () => {
+        const once = mergeManagedBlock("# Mine\n", block);
+        const twice = mergeManagedBlock(once, block);
+        assert.equal(twice, once);
+    });
+});
+describe("planTargetWrites", () => {
+    it("throws for the claude target — that path is the existing installer flow", () => {
+        assert.throws(() => planTargetWrites("claude", SAMPLE_SKILL, readNothing));
+    });
+    it("throws for an unknown target", () => {
+        assert.throws(() => planTargetWrites("emacs", SAMPLE_SKILL, readNothing));
+    });
+    it("gemini writes a managed block into GEMINI.md without skill frontmatter", () => {
+        const plan = planTargetWrites("gemini", SAMPLE_SKILL, readNothing);
+        assert.equal(plan.writes.length, 1);
+        assert.equal(plan.writes[0].relPath, "GEMINI.md");
+        assert.ok(plan.writes[0].content.includes(MANAGED_BEGIN));
+        assert.ok(plan.writes[0].content.includes("Law 1"));
+        assert.ok(!plan.writes[0].content.includes("tier: core"));
+    });
+    it("codex writes the agents.md standard file", () => {
+        const plan = planTargetWrites("codex", SAMPLE_SKILL, readNothing);
+        assert.deepEqual(plan.writes.map((w) => w.relPath), ["AGENTS.md"]);
+    });
+    it("gemini preserves existing user content via the managed block", () => {
+        const plan = planTargetWrites("gemini", SAMPLE_SKILL, (relPath) => relPath === "GEMINI.md" ? "# Project context\n" : null);
+        assert.ok(plan.writes[0].content.startsWith("# Project context"));
+        assert.ok(plan.writes[0].content.includes(MANAGED_BEGIN));
+    });
+    it("cursor writes a whole .mdc rule file with alwaysApply frontmatter", () => {
+        const plan = planTargetWrites("cursor", SAMPLE_SKILL, readNothing);
+        assert.equal(plan.writes[0].relPath, ".cursor/rules/continuous-improvement.mdc");
+        assert.ok(plan.writes[0].content.startsWith("---\n"));
+        assert.ok(plan.writes[0].content.includes("alwaysApply: true"));
+        assert.ok(!plan.writes[0].content.includes(MANAGED_BEGIN));
+    });
+    it("windsurf writes its own rule file with the plain body", () => {
+        const plan = planTargetWrites("windsurf", SAMPLE_SKILL, readNothing);
+        assert.equal(plan.writes[0].relPath, ".windsurf/rules/continuous-improvement.md");
+        assert.ok(plan.writes[0].content.startsWith("# continuous-improvement"));
+    });
+    it("zed and copilot use managed blocks in shared files", () => {
+        assert.equal(planTargetWrites("zed", SAMPLE_SKILL, readNothing).writes[0].relPath, ".rules");
+        assert.equal(planTargetWrites("copilot", SAMPLE_SKILL, readNothing).writes[0].relPath, ".github/copilot-instructions.md");
+    });
+    it("aider writes CONVENTIONS.md and creates a minimal conf when none exists", () => {
+        const plan = planTargetWrites("aider", SAMPLE_SKILL, readNothing);
+        assert.deepEqual(plan.writes.map((w) => w.relPath), ["CONVENTIONS.md", ".aider.conf.yml"]);
+        const conf = plan.writes[1].content;
+        assert.ok(conf.includes("read:"));
+        assert.ok(conf.includes("CONVENTIONS.md"));
+    });
+    it("aider leaves an existing conf untouched and explains the manual step", () => {
+        const plan = planTargetWrites("aider", SAMPLE_SKILL, (relPath) => relPath === ".aider.conf.yml" ? "model: gpt-5\n" : null);
+        assert.deepEqual(plan.writes.map((w) => w.relPath), ["CONVENTIONS.md"]);
+        assert.ok(plan.notes.some((note) => note.includes(".aider.conf.yml")));
+    });
+    it("every non-claude plan notes that hooks/MCP/instincts stay Claude Code-only", () => {
+        for (const id of ["gemini", "codex", "cursor", "windsurf", "zed", "aider", "copilot"]) {
+            const plan = planTargetWrites(id, SAMPLE_SKILL, readNothing);
+            assert.ok(plan.notes.some((note) => note.includes("Claude Code")), `missing Claude Code-only note for ${id}`);
+        }
+    });
+});


### PR DESCRIPTION
## What

`npx continuous-improvement install --target gemini,codex,cursor,windsurf,zed,aider,copilot` writes the 7-Laws skill text into each platform's rules file at the project root, so the framework can be used by agents beyond Claude Code.

| Target | File written |
|---|---|
| `gemini` | `GEMINI.md` |
| `codex` | `AGENTS.md` (agents.md standard) |
| `cursor` | `.cursor/rules/continuous-improvement.mdc` (`alwaysApply: true`) |
| `windsurf` | `.windsurf/rules/continuous-improvement.md` |
| `zed` | `.rules` |
| `aider` | `CONVENTIONS.md` + minimal `.aider.conf.yml` if none exists |
| `copilot` | `.github/copilot-instructions.md` |

## Design

- Pure planning layer in `src/lib/install-targets.mts` — no fs, reader callback injected, fully unit-testable.
- Shared files merge through an idempotent managed marker block (`<!-- continuous-improvement:begin/end -->`): existing user content is never clobbered, reinstalls are byte-identical no-ops.
- An existing `.aider.conf.yml` is never rewritten (no YAML dep, no string surgery) — the installer prints the one line to add.
- Hooks, MCP server, and instinct learning stay Claude Code-only; every non-claude install says so explicitly.
- Plan doc: `docs/plans/2026-06-11-multi-platform-installer.md` (Gemini hook support and `--global` paths deferred there per Law 6).

## Test plan

- [x] TDD: 22 new tests in `src/test/install-targets.test.mts` written first (RED confirmed via missing-module typecheck failure), then GREEN.
- [x] `node --test test/install-targets.test.mjs test/install.test.mjs` — 51/51 pass.
- [x] `npm run verify:all` — 12 invariants + typecheck pass.
- [x] Manual smoke in a temp dir: `--target gemini,codex,aider` writes all 4 files, preserves pre-existing `GEMINI.md` content, second run is byte-identical (idempotent), `--target emacs` exits 1 with the valid-target list.
- Known-flaky: `test/hook.test.mjs` failed with `spawnSync bash ETIMEDOUT` (~5s) on the loaded host — the documented environmental flake in CLAUDE.md's Deferred section; this diff touches nothing in the observe path (`git diff --stat main` = installer files only).

Closes #9 (skill install path; Gemini hook research deferred)
Closes #14
Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)