### PR TITLE
docs(reports): sync test counts 773→795 after PR #239 install-targets tests

### DIFF
--- a/reports/assets/update-card.html
+++ b/reports/assets/update-card.html
@@ -166,11 +166,11 @@
   <div class="stats">
     <div class="stat">
       <div class="stat-label"><i data-lucide="check-circle-2" width="14" height="14"></i> Tests Passing</div>
-      <div class="stat-value green">773</div>
+      <div class="stat-value green">795</div>
     </div>
     <div class="stat">
       <div class="stat-label"><i data-lucide="flask-conical" width="14" height="14"></i> Total Tests</div>
-      <div class="stat-value">773</div>
+      <div class="stat-value">795</div>
     </div>
     <div class="stat">
       <div class="stat-label"><i data-lucide="shield-check" width="14" height="14"></i> Pass Rate</div>
@@ -196,7 +196,7 @@
 
   <div class="badge">
     <i data-lucide="trophy" width="18" height="18"></i>
-    ALL TESTS PASSING — 773 / 773
+    ALL TESTS PASSING — 795 / 795
   </div>
 
   <div class="footer">

--- a/reports/daily-improvement.md
+++ b/reports/daily-improvement.md
@@ -5,6 +5,11 @@
 - Updated the card date from June 10 to June 11, the Tests Passing / Total Tests stats from `771` to `773`, and the badge from `771 / 771` to `773 / 773`. Updated the Project Snapshot table at the bottom of this report from `771 pass / 0 fail` to `773 pass / 0 fail`.
 - Verified with `npm run verify:all` (all 13 content invariants + typecheck pass) and `npm test` (773 pass / 0 fail). Working tree clean.
 
+## 2026-06-11 — Sync stale test-count surfaces from 773 to 795
+- While the prior hourly cycle was in flight, PR #239 (`feat(install): 7-Laws skill installs into 7 more agent platforms via --target`) landed on `origin/main`, adding `src/lib/install-targets.mts` with 22 new regression tests. The test suite is now 795 pass / 0 fail, but the HTML summary card and Project Snapshot still advertised `773`.
+- Updated the Tests Passing / Total Tests stats from `773` to `795` and the badge from `773 / 773` to `795 / 795` in `reports/assets/update-card.html`. Updated the Project Snapshot table at the bottom of this report from `773 pass / 0 fail` to `795 pass / 0 fail`.
+- Verified with `npm run verify:all` (all 13 content invariants + typecheck pass) and `npm test` (795 pass / 0 fail). Working tree clean.
+
 ## 2026-06-10 — Sync stale v3.12.3 references in landing-page blueprint plan to v3.13.0
 - `docs/plans/2026-06-07-landing-page-blueprint-rebuild.md` is an open build-spec plan (no `Status: complete` line) that still advertised `v3.12.3` and `25 bundled skills` on its "Real numbers" summary line and footer example. The project released `v3.13.0` on 2026-06-10 and now ships 26 skills. If this plan were executed today, the rebuilt landing page would immediately need another version-sync cycle.
 - Updated both occurrences from `v3.12.3` / `REV 3.12.3` to `v3.13.0` / `REV 3.13.0` and from `25 bundled skills` to `26 bundled skills` so the open plan stays internally consistent with current reality.
@@ -756,7 +761,7 @@
 | Project | continuous-improvement v3.13.0 |
 | Stack | Node.js (ESM), MCP server, GitHub Action, CLI tools |
 | Stage | Published npm package, active development |
-| Tests (current) | 773 pass / 0 fail |
+| Tests (current) | 795 pass / 0 fail |
 
 ## Changes Implemented
 


### PR DESCRIPTION
Follow-up to the 771→773 sync: PR #239 landed on main while the prior hourly cycle was in flight, adding 22 new regression tests in \`src/lib/install-targets.mts\`. The test suite is now 795 pass / 0 fail.

- Updated \`reports/assets/update-card.html\` stats and badge
- Updated \`reports/daily-improvement.md\` Project Snapshot table and added a new June 11 entry

Verified: \`npm run verify:all\` (all invariants + typecheck pass) and \`npm test\` (795 pass / 0 fail). Doc-only diff.