### PR TITLE
fix(gateguard): scope clearance cap per session so it stops bleeding across concurrent sessions

### DIFF
--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -13,7 +13,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
@@ -21,7 +21,7 @@ import { PACKAGE_NAME, VERSION, getToolDefinitions, isPluginMode, } from "../lib
 import { formatDriftReport, parseGoalFromPlan, scoreObservations, } from "../lib/goal-state.mjs";
 import { buildIndex, formatRecallHits, parseSince, query as queryRecall, } from "../lib/recall-index.mjs";
 import { draftFromCandidate, draftFromWorkflowRun, extractTrajectories, findCandidates, formatCandidates, serializeDraft, workflowRunFromObservations, } from "../lib/skill-distill.mjs";
-import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, clearFiles, resolveInstinctsRoot, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 function getHomeDir() {
     return process.env.HOME || process.env.USERPROFILE || homedir();
 }
@@ -508,10 +508,11 @@ function handleTool(name, params) {
         }
         case "ci_gateguard_clear": {
             // Beginner-available on purpose: the GateGuard hook fires for every
-            // install, so the clearance action must too. Resolves the session dir via
-            // gateguard-state (canonical), the same way the hook does, so the marker
-            // lands where the hook looks regardless of how each process spelled the
-            // project root.
+            // install, so the clearance action must too. The hook's block reason now
+            // prints state_path (the session-scoped state file); honoring it writes
+            // the marker exactly where the hook looks. Without it the MCP server can't
+            // know the caller's session, so it falls back to the canonical session dir
+            // — correct only on the legacy unscoped path.
             const rawList = Array.isArray(params.file_paths) ? params.file_paths : [];
             const listPaths = rawList.filter((value) => typeof value === "string" && value.length > 0);
             const single = getString(params.file_path).trim();
@@ -519,7 +520,24 @@ function handleTool(name, params) {
             if (paths.length === 0) {
                 return error("file_paths is required — pass the file path(s) named in the GateGuard block reason, e.g. { file_paths: [\"src/x.ts\"] }.");
             }
-            const sessionDir = resolveSessionDir();
+            // state_path is a model-controlled argument, so it could be a traversal
+            // string (`../../etc/...`). dirname leaves `..` segments for the OS to
+            // resolve at write time, so without a bound this is an arbitrary-write
+            // primitive. Resolve + canonicalize, then require containment within the
+            // instincts root (the only tree the hook ever prints a state_path inside).
+            const rawStatePath = getString(params.state_path).trim();
+            let sessionDir;
+            if (rawStatePath) {
+                const resolvedKey = canonicalizeFileKey(resolve(rawStatePath));
+                const rootKey = canonicalizeFileKey(resolveInstinctsRoot());
+                if (resolvedKey !== rootKey && !resolvedKey.startsWith(`${rootKey}/`)) {
+                    return error("state_path must resolve inside ~/.claude/instincts/. Pass it verbatim from the GateGuard block reason.");
+                }
+                sessionDir = dirname(resolve(rawStatePath));
+            }
+            else {
+                sessionDir = resolveSessionDir();
+            }
             const { cleared, skippedForCap } = clearFiles(sessionDir, paths);
             const lines = [
                 "## GateGuard clearance",

--- a/docs/plans/2026-06-14-gateguard-session-scoped-cap.md
+++ b/docs/plans/2026-06-14-gateguard-session-scoped-cap.md
@@ -1,0 +1,46 @@
+# Gateguard cap: session-scoped + self-healing
+
+Date: 2026-06-14
+Branch: `fix/gateguard-session-scoped-cap`
+Goal: stop the gateguard clearance cap from bleeding across concurrent same-day sessions and from requiring a manual `rm` to reset.
+
+## Problem (root cause, verified in code)
+
+The gateguard "per-session" clearance state is **not** session-scoped and **never** resets:
+
+- `resolveSessionDir()` ([src/lib/gateguard-state.mts](../../src/lib/gateguard-state.mts)) keys the state dir on the **project hash only** — `~/.claude/instincts/<projectHash>/gateguard-session.json`. No session identifier anywhere. Every Claude session on the repo — sequential or concurrent — reads and writes the same file.
+- `loadState` records `created_at` but never reads it for expiry. The 50-distinct-file counter (`MAX_CLEARED_FILES`) only grows until something deletes the file.
+- On a multi-Claude host the shared counter fills from other sessions' work; every later session inherits a near-full gate and must prune by hand.
+- The cap-reached block message tells the user "Start a new Claude Code session to reset the gate" ([src/hooks/gateguard.mts](../../src/hooks/gateguard.mts) `buildCapReachedReason`) — which does nothing, because a new session resolves to the same project-hash file. The documented intent ("the session itself is the trust boundary", gateguard.md) and the implementation disagree. That mismatch is the bug.
+
+## Fix
+
+1. **Session-scope the state dir.** `resolveSessionDir(sessionId?)`:
+   - `GATEGUARD_SESSION_DIR` env override wins (tests) — unchanged.
+   - else if `sessionId` present → `~/.claude/instincts/<projectHash>/sessions/<sanitizedSessionId>/`.
+   - else → `~/.claude/instincts/<projectHash>/` (legacy fallback, unchanged path → back-compat).
+   - `sessionId` is sanitized (`[^A-Za-z0-9_-]` → `_`, length-capped) so a hostile id cannot traverse.
+2. **Hook reads `session_id` from stdin** (already a standard hook field — see recall-briefing.mts, observe-event.mts) and passes it to `resolveSessionDir`. Makes "start a new session to reset" true.
+3. **TTL self-heal.** `loadState` returns a fresh empty state when `created_at` is older than `STATE_TTL_MS` (12h). Removes the manual-`rm` requirement on the fallback path; generous enough not to reset an active session mid-work.
+4. **Fix the third caller (MCP `ci_gateguard_clear`).** It resolves the dir with no session context, so once the hook is session-scoped this route would write to the wrong file. Add an optional `state_path` param; when present the handler writes to `dirname(state_path)` (mirrors the `--state` CLI route). The hook prints `state_path` in the route-B instructions. Omitted → legacy `resolveSessionDir()` fallback.
+5. **Align docs** in skills/gateguard.md so the reset story matches the code.
+
+## Files
+
+- `src/lib/gateguard-state.mts` — `resolveSessionDir(sessionId?)`, `STATE_TTL_MS`, TTL in `loadState`, header comment.
+- `src/hooks/gateguard.mts` — read `session_id`, pass through, route-B `state_path` in block reason, accurate cap message.
+- `src/bin/mcp-server.mts` — `ci_gateguard_clear` honors `state_path`.
+- `src/lib/plugin-metadata.mts` — add `state_path` to the tool input schema.
+- `skills/gateguard.md` — reset/cap wording.
+- Tests: `gateguard-state.test.mts` (scoping + TTL), `gateguard-hook.test.mts` (session isolation end-to-end), `mcp-server.test.mts` (`state_path` routing).
+- `npm run build` regenerates the `.mjs` mirror + plugin manifests; commit both.
+
+## Verification
+
+- RED first: new tests fail against current code.
+- `npm run build` then `npm run verify:all` green.
+- Cap-bounds-rogue-loop invariant preserved: within one session the 50-file cap still applies; only cross-session bleed and stale-file accumulation are removed.
+
+## Out of scope (deferred, not dropped)
+
+- Background GC of old `sessions/<id>/` dirs. TTL handles staleness on read; dir cleanup is cosmetic. Logged here, not implemented.

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -138,7 +138,7 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "",
         "Then clear the gate and retry the same call. Either route works:",
         `  A. Bash (always works — run verbatim): node ${quotePath(CLEAR_CLI_PATH)} --state ${quotePath(stateFilePath)} ${quoted.join(" ")}`,
-        `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}]}`,
+        `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}], state_path: ${quotePath(stateFilePath)}}`,
         "  Both canonicalize paths — drive-letter case and separators don't matter.",
         "  (Harnesses that forward unknown tool params may instead retry the call with",
         "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
@@ -157,9 +157,10 @@ function buildDestructiveBashReason(command) {
 }
 function buildCapReachedReason() {
     return [
-        `Gateguard session clearance cap reached (${MAX_CLEARED_FILES} distinct files).`,
-        "Start a new Claude Code session to reset the gate. The cap exists to bound",
-        "stuck-loop or rogue-agent clearance from compounding within a single session.",
+        `Gateguard clearance cap reached (${MAX_CLEARED_FILES} distinct files this session).`,
+        "The cap is per-session: start a new Claude Code session to reset it, or wait",
+        "for the state file to self-heal. It bounds stuck-loop or rogue-agent clearance",
+        "from compounding within one session without affecting your other sessions.",
     ].join("\n");
 }
 // Allow = empty stdout + exit 0. Emitting JSON here is wrong: PreToolUse has
@@ -207,8 +208,11 @@ function main() {
         emitDeny(buildDestructiveBashReason(cmd));
         return;
     }
-    // mutating-file
-    const sessionDir = resolveSessionDir();
+    // mutating-file — scope state to THIS session so the clearance cap never
+    // bleeds across concurrent same-day sessions. session_id is the standard hook
+    // stdin field (see recall-briefing / observe-event); absent → legacy dir.
+    const sessionId = typeof payload.session_id === "string" ? payload.session_id : undefined;
+    const sessionDir = resolveSessionDir(sessionId);
     const stateFilePath = join(sessionDir, "gateguard-session.json");
     const state = loadState(sessionDir);
     const filePaths = extractFilePaths(toolInput);

--- a/lib/gateguard-state.mjs
+++ b/lib/gateguard-state.mjs
@@ -2,20 +2,25 @@
  * Gateguard per-session state.
  *
  * State file: <sessionDir>/gateguard-session.json. sessionDir resolves to
- * GATEGUARD_SESSION_DIR (env override, used by tests) or
- * ~/.claude/instincts/<projectHash>/ in production.
+ * GATEGUARD_SESSION_DIR (env override, used by tests), or in production to
+ * ~/.claude/instincts/<projectHash>/sessions/<sessionId>/ when the hook passes
+ * the stdin session_id, falling back to ~/.claude/instincts/<projectHash>/ when
+ * no session id is available. Per-session scoping is what stops the clearance
+ * cap from bleeding across concurrent same-day sessions on a multi-Claude host.
  *
- * V1 limitations (documented for honesty, not mitigated in code):
+ * Limitations and guarantees:
  * - Honor system: clearance is granted whenever the agent sets
  *   `_gateguard_facts_presented: true` in tool_input or has a prior per-file
  *   marker. The hook cannot verify that real investigation occurred.
  * - State-file deletion: rm'ing the state file resets every gate in the
- *   session. Defensible because the session itself is the trust boundary;
- *   the cap below limits cumulative damage.
+ *   session. Defensible because the session is the trust boundary — and with
+ *   per-session scoping that boundary is now real, not just asserted.
+ * - Self-heal: loadState treats a file older than STATE_TTL_MS (or one with an
+ *   unparseable created_at) as empty, so a stale gate never needs a manual rm.
  * - Concurrency: two parallel hook invocations can race the read+write.
  *   Acceptable trade-off vs OS-specific atomic-rename complexity on Windows.
- * - Cap: MAX_CLEARED_FILES caps the number of distinct files a single
- *   session can clear, bounding stuck-loop / rogue-agent damage.
+ * - Cap: MAX_CLEARED_FILES caps the distinct files ONE session can clear,
+ *   bounding stuck-loop / rogue-agent damage without affecting other sessions.
  */
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -23,14 +28,36 @@ import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 export const MAX_CLEARED_FILES = 50;
-export function resolveSessionDir() {
+// A clearance file whose created_at is older than this self-heals to empty on
+// the next load, so a stale gate never needs a manual rm. Long enough not to
+// reset an active session mid-work; the real cross-session fix is the
+// per-session dir in resolveSessionDir below.
+export const STATE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+// The root that holds every project's gateguard + instinct state. The MCP
+// clearance route uses this to bound a caller-supplied state_path to this tree
+// so a hostile argument can't turn the clear into an arbitrary-write primitive.
+export function resolveInstinctsRoot() {
+    const home = process.env.HOME || process.env.USERPROFILE || homedir();
+    return join(home, ".claude", "instincts");
+}
+export function resolveSessionDir(sessionId) {
     const fromEnv = process.env.GATEGUARD_SESSION_DIR;
     if (fromEnv)
         return fromEnv;
-    const home = process.env.HOME || process.env.USERPROFILE || homedir();
     const projectRoot = resolveProjectRoot();
     const projectHash = createHash("sha256").update(canonicalizeProjectRoot(projectRoot)).digest("hex").slice(0, 12);
-    return join(home, ".claude", "instincts", projectHash);
+    const base = join(resolveInstinctsRoot(), projectHash);
+    const scoped = sanitizeSessionId(sessionId);
+    return scoped ? join(base, "sessions", scoped) : base;
+}
+// A session id flows into a directory name. Strip anything outside a safe
+// alphabet so a hostile or malformed id can't traverse (`../`) or break the
+// path, and cap the length. Returns "" for an absent/empty id, which the caller
+// treats as "no session" — the legacy unscoped dir, preserving back-compat.
+function sanitizeSessionId(sessionId) {
+    if (!sessionId)
+        return "";
+    return sessionId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
 }
 function resolveProjectRoot() {
     const fromEnv = process.env.CLAUDE_PROJECT_DIR;
@@ -49,21 +76,43 @@ function resolveProjectRoot() {
     }
     return "global";
 }
+function freshState() {
+    return { created_at: new Date().toISOString(), cleared_files: {} };
+}
+// A clearance file self-heals to empty once it ages out of STATE_TTL_MS, so a
+// stale gate never needs a manual rm. An unparseable created_at fails closed
+// (treated as expired) rather than living forever as a never-resetting gate.
+function isExpired(createdAt) {
+    const created = Date.parse(createdAt);
+    if (Number.isNaN(created))
+        return true;
+    return Date.now() - created > STATE_TTL_MS;
+}
 export function loadState(sessionDir) {
     const path = join(sessionDir, "gateguard-session.json");
     if (!existsSync(path)) {
-        return { created_at: new Date().toISOString(), cleared_files: {} };
+        return freshState();
     }
     try {
         const raw = readFileSync(path, "utf8");
         const parsed = JSON.parse(raw);
+        // Absent created_at is treated as expired (fail closed), like an unparseable
+        // one — never a never-resetting gate. On expiry we persist the new epoch
+        // immediately so the cap re-applies from zero on the very next load;
+        // otherwise every load before the next clear would independently reset and a
+        // TTL-crossing session could clear well past MAX_CLEARED_FILES.
+        if (!parsed.created_at || isExpired(parsed.created_at)) {
+            const reset = freshState();
+            saveState(sessionDir, reset);
+            return reset;
+        }
         return {
-            created_at: parsed.created_at ?? new Date().toISOString(),
+            created_at: parsed.created_at,
             cleared_files: parsed.cleared_files ?? {},
         };
     }
     catch {
-        return { created_at: new Date().toISOString(), cleared_files: {} };
+        return freshState();
     }
 }
 export function saveState(sessionDir, state) {

--- a/lib/plugin-metadata.mjs
+++ b/lib/plugin-metadata.mjs
@@ -143,6 +143,10 @@ const BEGINNER_TOOL_ENTRIES = [
                     type: "string",
                     description: "A single file path to clear (alternative to file_paths)",
                 },
+                state_path: {
+                    type: "string",
+                    description: "State-file path from the GateGuard block reason (the session-scoped gateguard-session.json). Pass it verbatim so the clearance lands in the session the hook is reading; it must resolve inside ~/.claude/instincts/. Omitting it falls back to the unscoped canonical dir — safe only in legacy (no session id) contexts; when the hook is session-scoped, omitting it writes to the wrong dir and the retry will still block.",
+                },
             },
             required: [],
         },

--- a/plugins/continuous-improvement/bin/mcp-server.mjs
+++ b/plugins/continuous-improvement/bin/mcp-server.mjs
@@ -13,7 +13,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
@@ -21,7 +21,7 @@ import { PACKAGE_NAME, VERSION, getToolDefinitions, isPluginMode, } from "../lib
 import { formatDriftReport, parseGoalFromPlan, scoreObservations, } from "../lib/goal-state.mjs";
 import { buildIndex, formatRecallHits, parseSince, query as queryRecall, } from "../lib/recall-index.mjs";
 import { draftFromCandidate, draftFromWorkflowRun, extractTrajectories, findCandidates, formatCandidates, serializeDraft, workflowRunFromObservations, } from "../lib/skill-distill.mjs";
-import { MAX_CLEARED_FILES, clearFiles, resolveSessionDir, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, clearFiles, resolveInstinctsRoot, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 function getHomeDir() {
     return process.env.HOME || process.env.USERPROFILE || homedir();
 }
@@ -508,10 +508,11 @@ function handleTool(name, params) {
         }
         case "ci_gateguard_clear": {
             // Beginner-available on purpose: the GateGuard hook fires for every
-            // install, so the clearance action must too. Resolves the session dir via
-            // gateguard-state (canonical), the same way the hook does, so the marker
-            // lands where the hook looks regardless of how each process spelled the
-            // project root.
+            // install, so the clearance action must too. The hook's block reason now
+            // prints state_path (the session-scoped state file); honoring it writes
+            // the marker exactly where the hook looks. Without it the MCP server can't
+            // know the caller's session, so it falls back to the canonical session dir
+            // — correct only on the legacy unscoped path.
             const rawList = Array.isArray(params.file_paths) ? params.file_paths : [];
             const listPaths = rawList.filter((value) => typeof value === "string" && value.length > 0);
             const single = getString(params.file_path).trim();
@@ -519,7 +520,24 @@ function handleTool(name, params) {
             if (paths.length === 0) {
                 return error("file_paths is required — pass the file path(s) named in the GateGuard block reason, e.g. { file_paths: [\"src/x.ts\"] }.");
             }
-            const sessionDir = resolveSessionDir();
+            // state_path is a model-controlled argument, so it could be a traversal
+            // string (`../../etc/...`). dirname leaves `..` segments for the OS to
+            // resolve at write time, so without a bound this is an arbitrary-write
+            // primitive. Resolve + canonicalize, then require containment within the
+            // instincts root (the only tree the hook ever prints a state_path inside).
+            const rawStatePath = getString(params.state_path).trim();
+            let sessionDir;
+            if (rawStatePath) {
+                const resolvedKey = canonicalizeFileKey(resolve(rawStatePath));
+                const rootKey = canonicalizeFileKey(resolveInstinctsRoot());
+                if (resolvedKey !== rootKey && !resolvedKey.startsWith(`${rootKey}/`)) {
+                    return error("state_path must resolve inside ~/.claude/instincts/. Pass it verbatim from the GateGuard block reason.");
+                }
+                sessionDir = dirname(resolve(rawStatePath));
+            }
+            else {
+                sessionDir = resolveSessionDir();
+            }
             const { cleared, skippedForCap } = clearFiles(sessionDir, paths);
             const lines = [
                 "## GateGuard clearance",

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -138,7 +138,7 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "",
         "Then clear the gate and retry the same call. Either route works:",
         `  A. Bash (always works — run verbatim): node ${quotePath(CLEAR_CLI_PATH)} --state ${quotePath(stateFilePath)} ${quoted.join(" ")}`,
-        `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}]}`,
+        `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}], state_path: ${quotePath(stateFilePath)}}`,
         "  Both canonicalize paths — drive-letter case and separators don't matter.",
         "  (Harnesses that forward unknown tool params may instead retry the call with",
         "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
@@ -157,9 +157,10 @@ function buildDestructiveBashReason(command) {
 }
 function buildCapReachedReason() {
     return [
-        `Gateguard session clearance cap reached (${MAX_CLEARED_FILES} distinct files).`,
-        "Start a new Claude Code session to reset the gate. The cap exists to bound",
-        "stuck-loop or rogue-agent clearance from compounding within a single session.",
+        `Gateguard clearance cap reached (${MAX_CLEARED_FILES} distinct files this session).`,
+        "The cap is per-session: start a new Claude Code session to reset it, or wait",
+        "for the state file to self-heal. It bounds stuck-loop or rogue-agent clearance",
+        "from compounding within one session without affecting your other sessions.",
     ].join("\n");
 }
 // Allow = empty stdout + exit 0. Emitting JSON here is wrong: PreToolUse has
@@ -207,8 +208,11 @@ function main() {
         emitDeny(buildDestructiveBashReason(cmd));
         return;
     }
-    // mutating-file
-    const sessionDir = resolveSessionDir();
+    // mutating-file — scope state to THIS session so the clearance cap never
+    // bleeds across concurrent same-day sessions. session_id is the standard hook
+    // stdin field (see recall-briefing / observe-event); absent → legacy dir.
+    const sessionId = typeof payload.session_id === "string" ? payload.session_id : undefined;
+    const sessionDir = resolveSessionDir(sessionId);
     const stateFilePath = join(sessionDir, "gateguard-session.json");
     const state = loadState(sessionDir);
     const filePaths = extractFilePaths(toolInput);

--- a/plugins/continuous-improvement/lib/gateguard-state.mjs
+++ b/plugins/continuous-improvement/lib/gateguard-state.mjs
@@ -2,20 +2,25 @@
  * Gateguard per-session state.
  *
  * State file: <sessionDir>/gateguard-session.json. sessionDir resolves to
- * GATEGUARD_SESSION_DIR (env override, used by tests) or
- * ~/.claude/instincts/<projectHash>/ in production.
+ * GATEGUARD_SESSION_DIR (env override, used by tests), or in production to
+ * ~/.claude/instincts/<projectHash>/sessions/<sessionId>/ when the hook passes
+ * the stdin session_id, falling back to ~/.claude/instincts/<projectHash>/ when
+ * no session id is available. Per-session scoping is what stops the clearance
+ * cap from bleeding across concurrent same-day sessions on a multi-Claude host.
  *
- * V1 limitations (documented for honesty, not mitigated in code):
+ * Limitations and guarantees:
  * - Honor system: clearance is granted whenever the agent sets
  *   `_gateguard_facts_presented: true` in tool_input or has a prior per-file
  *   marker. The hook cannot verify that real investigation occurred.
  * - State-file deletion: rm'ing the state file resets every gate in the
- *   session. Defensible because the session itself is the trust boundary;
- *   the cap below limits cumulative damage.
+ *   session. Defensible because the session is the trust boundary — and with
+ *   per-session scoping that boundary is now real, not just asserted.
+ * - Self-heal: loadState treats a file older than STATE_TTL_MS (or one with an
+ *   unparseable created_at) as empty, so a stale gate never needs a manual rm.
  * - Concurrency: two parallel hook invocations can race the read+write.
  *   Acceptable trade-off vs OS-specific atomic-rename complexity on Windows.
- * - Cap: MAX_CLEARED_FILES caps the number of distinct files a single
- *   session can clear, bounding stuck-loop / rogue-agent damage.
+ * - Cap: MAX_CLEARED_FILES caps the distinct files ONE session can clear,
+ *   bounding stuck-loop / rogue-agent damage without affecting other sessions.
  */
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -23,14 +28,36 @@ import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
 import { join } from "node:path";
 export const MAX_CLEARED_FILES = 50;
-export function resolveSessionDir() {
+// A clearance file whose created_at is older than this self-heals to empty on
+// the next load, so a stale gate never needs a manual rm. Long enough not to
+// reset an active session mid-work; the real cross-session fix is the
+// per-session dir in resolveSessionDir below.
+export const STATE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+// The root that holds every project's gateguard + instinct state. The MCP
+// clearance route uses this to bound a caller-supplied state_path to this tree
+// so a hostile argument can't turn the clear into an arbitrary-write primitive.
+export function resolveInstinctsRoot() {
+    const home = process.env.HOME || process.env.USERPROFILE || homedir();
+    return join(home, ".claude", "instincts");
+}
+export function resolveSessionDir(sessionId) {
     const fromEnv = process.env.GATEGUARD_SESSION_DIR;
     if (fromEnv)
         return fromEnv;
-    const home = process.env.HOME || process.env.USERPROFILE || homedir();
     const projectRoot = resolveProjectRoot();
     const projectHash = createHash("sha256").update(canonicalizeProjectRoot(projectRoot)).digest("hex").slice(0, 12);
-    return join(home, ".claude", "instincts", projectHash);
+    const base = join(resolveInstinctsRoot(), projectHash);
+    const scoped = sanitizeSessionId(sessionId);
+    return scoped ? join(base, "sessions", scoped) : base;
+}
+// A session id flows into a directory name. Strip anything outside a safe
+// alphabet so a hostile or malformed id can't traverse (`../`) or break the
+// path, and cap the length. Returns "" for an absent/empty id, which the caller
+// treats as "no session" — the legacy unscoped dir, preserving back-compat.
+function sanitizeSessionId(sessionId) {
+    if (!sessionId)
+        return "";
+    return sessionId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
 }
 function resolveProjectRoot() {
     const fromEnv = process.env.CLAUDE_PROJECT_DIR;
@@ -49,21 +76,43 @@ function resolveProjectRoot() {
     }
     return "global";
 }
+function freshState() {
+    return { created_at: new Date().toISOString(), cleared_files: {} };
+}
+// A clearance file self-heals to empty once it ages out of STATE_TTL_MS, so a
+// stale gate never needs a manual rm. An unparseable created_at fails closed
+// (treated as expired) rather than living forever as a never-resetting gate.
+function isExpired(createdAt) {
+    const created = Date.parse(createdAt);
+    if (Number.isNaN(created))
+        return true;
+    return Date.now() - created > STATE_TTL_MS;
+}
 export function loadState(sessionDir) {
     const path = join(sessionDir, "gateguard-session.json");
     if (!existsSync(path)) {
-        return { created_at: new Date().toISOString(), cleared_files: {} };
+        return freshState();
     }
     try {
         const raw = readFileSync(path, "utf8");
         const parsed = JSON.parse(raw);
+        // Absent created_at is treated as expired (fail closed), like an unparseable
+        // one — never a never-resetting gate. On expiry we persist the new epoch
+        // immediately so the cap re-applies from zero on the very next load;
+        // otherwise every load before the next clear would independently reset and a
+        // TTL-crossing session could clear well past MAX_CLEARED_FILES.
+        if (!parsed.created_at || isExpired(parsed.created_at)) {
+            const reset = freshState();
+            saveState(sessionDir, reset);
+            return reset;
+        }
         return {
-            created_at: parsed.created_at ?? new Date().toISOString(),
+            created_at: parsed.created_at,
             cleared_files: parsed.cleared_files ?? {},
         };
     }
     catch {
-        return { created_at: new Date().toISOString(), cleared_files: {} };
+        return freshState();
     }
 }
 export function saveState(sessionDir, state) {

--- a/plugins/continuous-improvement/lib/plugin-metadata.mjs
+++ b/plugins/continuous-improvement/lib/plugin-metadata.mjs
@@ -143,6 +143,10 @@ const BEGINNER_TOOL_ENTRIES = [
                     type: "string",
                     description: "A single file path to clear (alternative to file_paths)",
                 },
+                state_path: {
+                    type: "string",
+                    description: "State-file path from the GateGuard block reason (the session-scoped gateguard-session.json). Pass it verbatim so the clearance lands in the session the hook is reading; it must resolve inside ~/.claude/instincts/. Omitting it falls back to the unscoped canonical dir — safe only in legacy (no session id) contexts; when the hook is session-scoped, omitting it writes to the wrong dir and the retry will still block.",
+                },
             },
             required: [],
         },

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -136,7 +136,7 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 ### Today: runtime hook + skill (zero install beyond the plugin)
 
-`hooks/gateguard.mjs` is bundled with this plugin and wired as the first PreToolUse hook in `plugins/continuous-improvement/hooks/hooks.json`. When you install the plugin, the runtime gate is live — no extra config, no opt-in. The hook reads tool input from stdin, classifies it through a data-driven routing table (Read/Grep/Glob → allow, Write/Edit/MultiEdit → mutating-file gate, Bash → destructive-pattern check), and emits `{decision, reason?}` on stdout. Per-session state lives at `~/.claude/instincts/<project-hash>/gateguard-session.json` (override via `GATEGUARD_SESSION_DIR` for tests) and caps cumulative clearances at `MAX_CLEARED_FILES = 50`.
+`hooks/gateguard.mjs` is bundled with this plugin and wired as the first PreToolUse hook in `plugins/continuous-improvement/hooks/hooks.json`. When you install the plugin, the runtime gate is live — no extra config, no opt-in. The hook reads tool input from stdin, classifies it through a data-driven routing table (Read/Grep/Glob → allow, Write/Edit/MultiEdit → mutating-file gate, Bash → destructive-pattern check), and emits `{decision, reason?}` on stdout. Per-session state lives at `~/.claude/instincts/<project-hash>/sessions/<session-id>/gateguard-session.json` — scoped by the stdin `session_id` so the cap never bleeds across concurrent sessions (it falls back to the unscoped `<project-hash>/` dir when no session id is present, and `GATEGUARD_SESSION_DIR` overrides it for tests). The cap is `MAX_CLEARED_FILES = 50` per session, and the state self-heals after `STATE_TTL_MS` so a stale gate never needs a manual `rm`.
 
 Smoke-test the runtime gate after install: ask Claude to write a throwaway file with no research first. The hook should return a `block` decision with a fact-list reason; Claude should pause rather than write.
 
@@ -150,10 +150,10 @@ The block reason prints the exact `gateguard-session.json` path and the clearanc
 
 The inline `_gateguard_facts_presented: true` retry still works on harnesses that forward unknown tool params, but Claude Code's strict tool schema (`additionalProperties: false`) rejects it with `InputValidationError` — use one of the above on Claude Code.
 
-### V1 honest limitations (not mitigated, documented)
+### Limitations and guarantees
 
-- **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
-- **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
+- **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap — counted per session — bounds damage from stuck loops or rogue agents.
+- **State-file deletion / self-heal.** `rm`-ing the session state resets every gate. Because state is scoped per session (`sessions/<session-id>/`), the session is a real trust boundary, not one shared across concurrent runs. A stale state file also self-heals once its `created_at` ages past `STATE_TTL_MS`, so a manual `rm` is rarely needed.
 - **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
 
 **MultiEdit per-file gating.** The hook clears and checks every `edits[]` path individually, so a mixed-clearance batch blocks until *all* edited files are cleared or facts are presented. The block reason now names the whole batch, not just the first uncleared path.

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -136,7 +136,7 @@ This gate is what catches the squash-merge / ahead-of-origin trap recorded in th
 
 ### Today: runtime hook + skill (zero install beyond the plugin)
 
-`hooks/gateguard.mjs` is bundled with this plugin and wired as the first PreToolUse hook in `plugins/continuous-improvement/hooks/hooks.json`. When you install the plugin, the runtime gate is live — no extra config, no opt-in. The hook reads tool input from stdin, classifies it through a data-driven routing table (Read/Grep/Glob → allow, Write/Edit/MultiEdit → mutating-file gate, Bash → destructive-pattern check), and emits `{decision, reason?}` on stdout. Per-session state lives at `~/.claude/instincts/<project-hash>/gateguard-session.json` (override via `GATEGUARD_SESSION_DIR` for tests) and caps cumulative clearances at `MAX_CLEARED_FILES = 50`.
+`hooks/gateguard.mjs` is bundled with this plugin and wired as the first PreToolUse hook in `plugins/continuous-improvement/hooks/hooks.json`. When you install the plugin, the runtime gate is live — no extra config, no opt-in. The hook reads tool input from stdin, classifies it through a data-driven routing table (Read/Grep/Glob → allow, Write/Edit/MultiEdit → mutating-file gate, Bash → destructive-pattern check), and emits `{decision, reason?}` on stdout. Per-session state lives at `~/.claude/instincts/<project-hash>/sessions/<session-id>/gateguard-session.json` — scoped by the stdin `session_id` so the cap never bleeds across concurrent sessions (it falls back to the unscoped `<project-hash>/` dir when no session id is present, and `GATEGUARD_SESSION_DIR` overrides it for tests). The cap is `MAX_CLEARED_FILES = 50` per session, and the state self-heals after `STATE_TTL_MS` so a stale gate never needs a manual `rm`.
 
 Smoke-test the runtime gate after install: ask Claude to write a throwaway file with no research first. The hook should return a `block` decision with a fact-list reason; Claude should pause rather than write.
 
@@ -150,10 +150,10 @@ The block reason prints the exact `gateguard-session.json` path and the clearanc
 
 The inline `_gateguard_facts_presented: true` retry still works on harnesses that forward unknown tool params, but Claude Code's strict tool schema (`additionalProperties: false`) rejects it with `InputValidationError` — use one of the above on Claude Code.
 
-### V1 honest limitations (not mitigated, documented)
+### Limitations and guarantees
 
-- **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap bounds damage from stuck loops or rogue agents.
-- **State-file deletion.** `rm`-ing the session state resets every gate. Acceptable because the session itself is the trust boundary.
+- **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap — counted per session — bounds damage from stuck loops or rogue agents.
+- **State-file deletion / self-heal.** `rm`-ing the session state resets every gate. Because state is scoped per session (`sessions/<session-id>/`), the session is a real trust boundary, not one shared across concurrent runs. A stale state file also self-heals once its `created_at` ages past `STATE_TTL_MS`, so a manual `rm` is rarely needed.
 - **Parallel-hook race.** Two simultaneous hook invocations can race the read+write of the state file. Acceptable trade-off vs Windows atomic-rename complexity.
 
 **MultiEdit per-file gating.** The hook clears and checks every `edits[]` path individually, so a mixed-clearance batch blocks until *all* edited files are cleared or facts are presented. The block reason now names the whole batch, not just the first uncleared path.

--- a/src/bin/mcp-server.mts
+++ b/src/bin/mcp-server.mts
@@ -15,7 +15,7 @@
 import { execSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve } from "node:path";
 import { createInterface } from "node:readline";
 import { fileURLToPath } from "node:url";
 import { createHash } from "node:crypto";
@@ -52,7 +52,9 @@ import {
 } from "../lib/skill-distill.mjs";
 import {
   MAX_CLEARED_FILES,
+  canonicalizeFileKey,
   clearFiles,
+  resolveInstinctsRoot,
   resolveSessionDir,
 } from "../lib/gateguard-state.mjs";
 
@@ -666,10 +668,11 @@ function handleTool(name: string, params: Record<string, unknown>): ToolResult {
 
     case "ci_gateguard_clear": {
       // Beginner-available on purpose: the GateGuard hook fires for every
-      // install, so the clearance action must too. Resolves the session dir via
-      // gateguard-state (canonical), the same way the hook does, so the marker
-      // lands where the hook looks regardless of how each process spelled the
-      // project root.
+      // install, so the clearance action must too. The hook's block reason now
+      // prints state_path (the session-scoped state file); honoring it writes
+      // the marker exactly where the hook looks. Without it the MCP server can't
+      // know the caller's session, so it falls back to the canonical session dir
+      // — correct only on the legacy unscoped path.
       const rawList = Array.isArray(params.file_paths) ? params.file_paths : [];
       const listPaths = rawList.filter((value): value is string => typeof value === "string" && value.length > 0);
       const single = getString(params.file_path).trim();
@@ -680,7 +683,25 @@ function handleTool(name: string, params: Record<string, unknown>): ToolResult {
         );
       }
 
-      const sessionDir = resolveSessionDir();
+      // state_path is a model-controlled argument, so it could be a traversal
+      // string (`../../etc/...`). dirname leaves `..` segments for the OS to
+      // resolve at write time, so without a bound this is an arbitrary-write
+      // primitive. Resolve + canonicalize, then require containment within the
+      // instincts root (the only tree the hook ever prints a state_path inside).
+      const rawStatePath = getString(params.state_path).trim();
+      let sessionDir: string;
+      if (rawStatePath) {
+        const resolvedKey = canonicalizeFileKey(resolve(rawStatePath));
+        const rootKey = canonicalizeFileKey(resolveInstinctsRoot());
+        if (resolvedKey !== rootKey && !resolvedKey.startsWith(`${rootKey}/`)) {
+          return error(
+            "state_path must resolve inside ~/.claude/instincts/. Pass it verbatim from the GateGuard block reason.",
+          );
+        }
+        sessionDir = dirname(resolve(rawStatePath));
+      } else {
+        sessionDir = resolveSessionDir();
+      }
       const { cleared, skippedForCap } = clearFiles(sessionDir, paths);
       const lines = [
         "## GateGuard clearance",

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -61,6 +61,7 @@ interface ToolInput {
 interface Payload {
   tool_name?: unknown;
   tool_input?: ToolInput;
+  session_id?: unknown;
 }
 
 const TOOL_ROUTE: Record<string, GateType> = {
@@ -171,7 +172,7 @@ function buildMutatingFileReason(toolName: string, filePaths: string[], stateFil
     "",
     "Then clear the gate and retry the same call. Either route works:",
     `  A. Bash (always works — run verbatim): node ${quotePath(CLEAR_CLI_PATH)} --state ${quotePath(stateFilePath)} ${quoted.join(" ")}`,
-    `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}]}`,
+    `  B. MCP tool (when the continuous-improvement server is connected): ci_gateguard_clear  {file_paths: [${quoted.join(", ")}], state_path: ${quotePath(stateFilePath)}}`,
     "  Both canonicalize paths — drive-letter case and separators don't matter.",
     "  (Harnesses that forward unknown tool params may instead retry the call with",
     "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
@@ -192,9 +193,10 @@ function buildDestructiveBashReason(command: string): string {
 
 function buildCapReachedReason(): string {
   return [
-    `Gateguard session clearance cap reached (${MAX_CLEARED_FILES} distinct files).`,
-    "Start a new Claude Code session to reset the gate. The cap exists to bound",
-    "stuck-loop or rogue-agent clearance from compounding within a single session.",
+    `Gateguard clearance cap reached (${MAX_CLEARED_FILES} distinct files this session).`,
+    "The cap is per-session: start a new Claude Code session to reset it, or wait",
+    "for the state file to self-heal. It bounds stuck-loop or rogue-agent clearance",
+    "from compounding within one session without affecting your other sessions.",
   ].join("\n");
 }
 
@@ -248,8 +250,11 @@ function main(): void {
     return;
   }
 
-  // mutating-file
-  const sessionDir = resolveSessionDir();
+  // mutating-file — scope state to THIS session so the clearance cap never
+  // bleeds across concurrent same-day sessions. session_id is the standard hook
+  // stdin field (see recall-briefing / observe-event); absent → legacy dir.
+  const sessionId = typeof payload.session_id === "string" ? payload.session_id : undefined;
+  const sessionDir = resolveSessionDir(sessionId);
   const stateFilePath = join(sessionDir, "gateguard-session.json");
   const state = loadState(sessionDir);
   const filePaths = extractFilePaths(toolInput);

--- a/src/lib/gateguard-state.mts
+++ b/src/lib/gateguard-state.mts
@@ -2,20 +2,25 @@
  * Gateguard per-session state.
  *
  * State file: <sessionDir>/gateguard-session.json. sessionDir resolves to
- * GATEGUARD_SESSION_DIR (env override, used by tests) or
- * ~/.claude/instincts/<projectHash>/ in production.
+ * GATEGUARD_SESSION_DIR (env override, used by tests), or in production to
+ * ~/.claude/instincts/<projectHash>/sessions/<sessionId>/ when the hook passes
+ * the stdin session_id, falling back to ~/.claude/instincts/<projectHash>/ when
+ * no session id is available. Per-session scoping is what stops the clearance
+ * cap from bleeding across concurrent same-day sessions on a multi-Claude host.
  *
- * V1 limitations (documented for honesty, not mitigated in code):
+ * Limitations and guarantees:
  * - Honor system: clearance is granted whenever the agent sets
  *   `_gateguard_facts_presented: true` in tool_input or has a prior per-file
  *   marker. The hook cannot verify that real investigation occurred.
  * - State-file deletion: rm'ing the state file resets every gate in the
- *   session. Defensible because the session itself is the trust boundary;
- *   the cap below limits cumulative damage.
+ *   session. Defensible because the session is the trust boundary — and with
+ *   per-session scoping that boundary is now real, not just asserted.
+ * - Self-heal: loadState treats a file older than STATE_TTL_MS (or one with an
+ *   unparseable created_at) as empty, so a stale gate never needs a manual rm.
  * - Concurrency: two parallel hook invocations can race the read+write.
  *   Acceptable trade-off vs OS-specific atomic-rename complexity on Windows.
- * - Cap: MAX_CLEARED_FILES caps the number of distinct files a single
- *   session can clear, bounding stuck-loop / rogue-agent damage.
+ * - Cap: MAX_CLEARED_FILES caps the distinct files ONE session can clear,
+ *   bounding stuck-loop / rogue-agent damage without affecting other sessions.
  */
 
 import { createHash } from "node:crypto";
@@ -26,18 +31,42 @@ import { join } from "node:path";
 
 export const MAX_CLEARED_FILES = 50;
 
+// A clearance file whose created_at is older than this self-heals to empty on
+// the next load, so a stale gate never needs a manual rm. Long enough not to
+// reset an active session mid-work; the real cross-session fix is the
+// per-session dir in resolveSessionDir below.
+export const STATE_TTL_MS = 12 * 60 * 60 * 1000; // 12h
+
 export interface GateguardState {
   created_at: string;
   cleared_files: Record<string, { cleared_at: string }>;
 }
 
-export function resolveSessionDir(): string {
+// The root that holds every project's gateguard + instinct state. The MCP
+// clearance route uses this to bound a caller-supplied state_path to this tree
+// so a hostile argument can't turn the clear into an arbitrary-write primitive.
+export function resolveInstinctsRoot(): string {
+  const home = process.env.HOME || process.env.USERPROFILE || homedir();
+  return join(home, ".claude", "instincts");
+}
+
+export function resolveSessionDir(sessionId?: string): string {
   const fromEnv = process.env.GATEGUARD_SESSION_DIR;
   if (fromEnv) return fromEnv;
-  const home = process.env.HOME || process.env.USERPROFILE || homedir();
   const projectRoot = resolveProjectRoot();
   const projectHash = createHash("sha256").update(canonicalizeProjectRoot(projectRoot)).digest("hex").slice(0, 12);
-  return join(home, ".claude", "instincts", projectHash);
+  const base = join(resolveInstinctsRoot(), projectHash);
+  const scoped = sanitizeSessionId(sessionId);
+  return scoped ? join(base, "sessions", scoped) : base;
+}
+
+// A session id flows into a directory name. Strip anything outside a safe
+// alphabet so a hostile or malformed id can't traverse (`../`) or break the
+// path, and cap the length. Returns "" for an absent/empty id, which the caller
+// treats as "no session" — the legacy unscoped dir, preserving back-compat.
+function sanitizeSessionId(sessionId?: string): string {
+  if (!sessionId) return "";
+  return sessionId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
 }
 
 function resolveProjectRoot(): string {
@@ -55,20 +84,43 @@ function resolveProjectRoot(): string {
   return "global";
 }
 
+function freshState(): GateguardState {
+  return { created_at: new Date().toISOString(), cleared_files: {} };
+}
+
+// A clearance file self-heals to empty once it ages out of STATE_TTL_MS, so a
+// stale gate never needs a manual rm. An unparseable created_at fails closed
+// (treated as expired) rather than living forever as a never-resetting gate.
+function isExpired(createdAt: string): boolean {
+  const created = Date.parse(createdAt);
+  if (Number.isNaN(created)) return true;
+  return Date.now() - created > STATE_TTL_MS;
+}
+
 export function loadState(sessionDir: string): GateguardState {
   const path = join(sessionDir, "gateguard-session.json");
   if (!existsSync(path)) {
-    return { created_at: new Date().toISOString(), cleared_files: {} };
+    return freshState();
   }
   try {
     const raw = readFileSync(path, "utf8");
     const parsed = JSON.parse(raw) as Partial<GateguardState>;
+    // Absent created_at is treated as expired (fail closed), like an unparseable
+    // one — never a never-resetting gate. On expiry we persist the new epoch
+    // immediately so the cap re-applies from zero on the very next load;
+    // otherwise every load before the next clear would independently reset and a
+    // TTL-crossing session could clear well past MAX_CLEARED_FILES.
+    if (!parsed.created_at || isExpired(parsed.created_at)) {
+      const reset = freshState();
+      saveState(sessionDir, reset);
+      return reset;
+    }
     return {
-      created_at: parsed.created_at ?? new Date().toISOString(),
+      created_at: parsed.created_at,
       cleared_files: parsed.cleared_files ?? {},
     };
   } catch {
-    return { created_at: new Date().toISOString(), cleared_files: {} };
+    return freshState();
   }
 }
 

--- a/src/lib/plugin-metadata.mts
+++ b/src/lib/plugin-metadata.mts
@@ -275,6 +275,11 @@ const BEGINNER_TOOL_ENTRIES: ToolCatalogEntry[] = [
           type: "string",
           description: "A single file path to clear (alternative to file_paths)",
         },
+        state_path: {
+          type: "string",
+          description:
+            "State-file path from the GateGuard block reason (the session-scoped gateguard-session.json). Pass it verbatim so the clearance lands in the session the hook is reading; it must resolve inside ~/.claude/instincts/. Omitting it falls back to the unscoped canonical dir — safe only in legacy (no session id) contexts; when the hook is session-scoped, omitting it writes to the wrong dir and the retry will still block.",
+        },
       },
       required: [],
     },

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -293,6 +293,10 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         const decision = runHook("Write", { file_path: "fresh-file.ts", content: "x" }, dir);
         assert.equal(decision.decision, "block");
         assert.match(decision.reason ?? "", /ci_gateguard_clear|gateguard-clear\.mjs/);
+        // Route B must advertise state_path so the agent passes the session-scoped
+        // path to ci_gateguard_clear; without it the MCP clear falls back to the
+        // unscoped canonical dir and misses the session state.
+        assert.match(decision.reason ?? "", /state_path:/);
       } finally {
         rmSync(dir, { recursive: true, force: true });
       }
@@ -329,5 +333,61 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         rmSync(dir, { recursive: true, force: true });
       }
     });
+  });
+});
+
+// Session isolation: the cap and clearance state must NOT bleed across
+// concurrent same-day sessions. Drives the production path (no
+// GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so
+// the hook resolves its own session-scoped dir from the stdin session_id.
+describe("hooks/gateguard.mjs — per-session isolation (no shared cap)", () => {
+  let tempHome = "";
+
+  before(() => {
+    tempHome = mkdtempSync(join(tmpdir(), "gg-session-iso-"));
+  });
+
+  after(() => {
+    rmSync(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+  });
+
+  function runScoped(sessionId: string, toolInput: Record<string, unknown>): HookDecision {
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      HOME: tempHome,
+      USERPROFILE: tempHome,
+      CLAUDE_PROJECT_DIR: "d:/proj/iso",
+    };
+    delete env.GATEGUARD_SESSION_DIR;
+    const payload = JSON.stringify({ tool_name: "Edit", tool_input: toolInput, session_id: sessionId });
+    const result = spawnSync(process.execPath, [HOOK_PATH], { input: payload, encoding: "utf8", env });
+    assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`);
+    const stdout = result.stdout.trim();
+    if (stdout === "") return { decision: "allow" };
+    const parsed = JSON.parse(stdout) as PreToolUseHookOutput;
+    return { decision: "block", reason: parsed.hookSpecificOutput?.permissionDecisionReason };
+  }
+
+  it("clearing a file in session A does not clear it in session B", () => {
+    const file = "d:/proj/iso/a.ts";
+    // Session A presents facts → file cleared and recorded in A's session dir.
+    assert.equal(
+      runScoped("session-A", { file_path: file, _gateguard_facts_presented: true }).decision,
+      "allow",
+      "facts-flagged clear in session A must be allowed",
+    );
+    // Session A retry without facts → allowed (A already cleared it).
+    assert.equal(
+      runScoped("session-A", { file_path: file }).decision,
+      "allow",
+      "session A retry must see its own clearance",
+    );
+    // Session B never cleared it → blocked. (Current shared-dir code wrongly allows.)
+    const blockResult = runScoped("session-B", { file_path: file });
+    assert.equal(blockResult.decision, "block", "session B must NOT inherit session A's clearance");
+    // The block reason must carry the session-scoped state_path so route B clears
+    // the right dir — pinned to session-B so a regression in scoping is visible.
+    assert.match(blockResult.reason ?? "", /state_path:/, "block reason advertises the MCP state_path");
+    assert.match(blockResult.reason ?? "", /session-B/, "state_path references the session-B scoped dir");
   });
 });

--- a/src/test/gateguard-state.test.mts
+++ b/src/test/gateguard-state.test.mts
@@ -6,13 +6,14 @@
  */
 
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
 
 import {
   MAX_CLEARED_FILES,
+  STATE_TTL_MS,
   canonicalizeFileKey,
   canonicalizeProjectRoot,
   clearFiles,
@@ -84,6 +85,134 @@ describe("resolveSessionDir canonical hashing", () => {
       if (prevSess === undefined) delete process.env.GATEGUARD_SESSION_DIR;
       else process.env.GATEGUARD_SESSION_DIR = prevSess;
     }
+  });
+});
+
+describe("resolveSessionDir session scoping", () => {
+  let prevProj: string | undefined;
+  let prevSess: string | undefined;
+
+  before(() => {
+    prevProj = process.env.CLAUDE_PROJECT_DIR;
+    prevSess = process.env.GATEGUARD_SESSION_DIR;
+    delete process.env.GATEGUARD_SESSION_DIR;
+    process.env.CLAUDE_PROJECT_DIR = "d:/Ai/continuous-improvement";
+  });
+
+  after(() => {
+    if (prevProj === undefined) delete process.env.CLAUDE_PROJECT_DIR;
+    else process.env.CLAUDE_PROJECT_DIR = prevProj;
+    if (prevSess === undefined) delete process.env.GATEGUARD_SESSION_DIR;
+    else process.env.GATEGUARD_SESSION_DIR = prevSess;
+  });
+
+  it("nests a session id under a sessions/ subdir of the legacy project dir", () => {
+    const legacy = resolveSessionDir();
+    assert.equal(resolveSessionDir("sess-A"), join(legacy, "sessions", "sess-A"));
+  });
+
+  it("gives different session ids different dirs", () => {
+    assert.notEqual(resolveSessionDir("sess-A"), resolveSessionDir("sess-B"));
+  });
+
+  it("is deterministic for the same session id", () => {
+    assert.equal(resolveSessionDir("sess-A"), resolveSessionDir("sess-A"));
+  });
+
+  it("falls back to the legacy unscoped dir with no session id (back-compat)", () => {
+    const legacy = resolveSessionDir();
+    assert.ok(!legacy.split(/[\\/]/).includes("sessions"), "legacy dir has no sessions/ segment");
+    assert.notEqual(resolveSessionDir("sess-A"), legacy);
+  });
+
+  it("treats an empty session id as no session id", () => {
+    assert.equal(resolveSessionDir(""), resolveSessionDir());
+  });
+
+  it("sanitizes a traversal session id so it cannot escape the sessions/ dir", () => {
+    const base = join(resolveSessionDir(), "sessions");
+    const scoped = resolveSessionDir("../../etc/passwd");
+    assert.ok(scoped.startsWith(base), "stays under sessions/");
+    assert.ok(!scoped.split(/[\\/]/).includes(".."), "no .. segment survives sanitization");
+  });
+
+  it("maps an all-unsafe session id to a pure-underscore segment (degenerate input)", () => {
+    const base = join(resolveSessionDir(), "sessions");
+    assert.equal(resolveSessionDir("@@@"), join(base, "___"));
+  });
+
+  it("caps the session id at 64 chars with replace happening before slice", () => {
+    const base = join(resolveSessionDir(), "sessions");
+    assert.equal(resolveSessionDir("a".repeat(65)), join(base, "a".repeat(64)));
+    // 65 unsafe chars: every one is replaced first, then sliced to 64 — no
+    // traversal sequence can survive the order of operations.
+    const scopedUnsafe = resolveSessionDir("/".repeat(65));
+    assert.equal(scopedUnsafe, join(base, "_".repeat(64)));
+    assert.ok(!scopedUnsafe.split(/[\\/]/).includes(".."), "no .. survives");
+  });
+
+  it("env override wins and ignores the session id", () => {
+    const override = join(tmpdir(), "gg-override");
+    process.env.GATEGUARD_SESSION_DIR = override;
+    try {
+      assert.equal(resolveSessionDir("sess-A"), override);
+    } finally {
+      delete process.env.GATEGUARD_SESSION_DIR;
+    }
+  });
+});
+
+describe("loadState TTL self-heal", () => {
+  let dir = "";
+
+  before(() => {
+    dir = mkdtempSync(join(tmpdir(), "gg-ttl-"));
+  });
+
+  after(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeState(createdAt: string): void {
+    writeFileSync(
+      join(dir, "gateguard-session.json"),
+      `${JSON.stringify({ created_at: createdAt, cleared_files: { "d:/x.ts": { cleared_at: createdAt } } }, null, 2)}\n`,
+    );
+  }
+
+  it("resets cleared_files when created_at is older than STATE_TTL_MS", () => {
+    writeState(new Date(Date.now() - STATE_TTL_MS - 60_000).toISOString());
+    assert.deepEqual(loadState(dir).cleared_files, {});
+  });
+
+  it("preserves cleared_files within the TTL window", () => {
+    writeState(new Date(Date.now() - 60_000).toISOString());
+    assert.ok("d:/x.ts" in loadState(dir).cleared_files);
+  });
+
+  it("treats an unparseable created_at as expired (fail-closed)", () => {
+    writeState("not-a-date");
+    assert.deepEqual(loadState(dir).cleared_files, {});
+  });
+
+  it("treats a missing created_at field as expired (fail-closed)", () => {
+    writeFileSync(
+      join(dir, "gateguard-session.json"),
+      `${JSON.stringify({ cleared_files: { "d:/x.ts": { cleared_at: "2020-01-01T00:00:00.000Z" } } }, null, 2)}\n`,
+    );
+    assert.deepEqual(loadState(dir).cleared_files, {});
+  });
+
+  it("persists a fresh epoch on expiry so the cap re-applies immediately", () => {
+    writeState(new Date(Date.now() - STATE_TTL_MS - 60_000).toISOString());
+    const first = loadState(dir);
+    const second = loadState(dir);
+    assert.deepEqual(first.cleared_files, {});
+    assert.deepEqual(second.cleared_files, {});
+    // Without persistence the second load would re-read the still-expired file
+    // and mint a NEW epoch; equality proves the first load wrote the reset, so
+    // the cap counts from zero on the next call instead of resetting every load.
+    assert.equal(first.created_at, second.created_at, "new epoch persisted, not regenerated each load");
   });
 });
 

--- a/src/test/mcp-server.test.mts
+++ b/src/test/mcp-server.test.mts
@@ -226,6 +226,49 @@ describe("MCP server — beginner mode", () => {
     assert.match(response.result.content[0].text, /file_paths/);
   });
 
+  it("ci_gateguard_clear honors an in-root state_path and writes to that exact dir (session-scoped routing)", async () => {
+    // Inside the instincts root (HOME=tempHome for the server), mirroring the
+    // session-scoped path the hook prints. saveState mkdir's it recursively.
+    const statePath = join(tempHome, ".claude", "instincts", "scoped-test", "sessions", "sess-statepath", "gateguard-session.json");
+    const response = await client.send({
+      jsonrpc: "2.0",
+      id: 43,
+      method: "tools/call",
+      params: {
+        name: "ci_gateguard_clear",
+        arguments: { file_paths: ["D:\\proj\\z.ts"], state_path: statePath },
+      },
+    });
+    assert.ok(!response.result.isError, "clear with an in-root state_path should succeed");
+    assert.match(response.result.content[0].text, /gateguard-session\.json/);
+    // The marker must land at the supplied state_path, not the default session
+    // dir — this is what keeps the MCP clear route session-correct once the hook
+    // is session-scoped.
+    assert.ok(existsSync(statePath), "state file written at the supplied state_path");
+    const state = JSON.parse(readFileSync(statePath, "utf8")) as {
+      cleared_files?: Record<string, unknown>;
+    };
+    assert.ok(state.cleared_files && "d:/proj/z.ts" in state.cleared_files, "canonical key recorded at state_path");
+  });
+
+  it("ci_gateguard_clear rejects a state_path that resolves outside the instincts root (no arbitrary write)", async () => {
+    // A traversal/arbitrary path outside ~/.claude/instincts must be refused so
+    // the clear can't be turned into an arbitrary-write primitive.
+    const evil = join(tmpdir(), "ci-gg-evil", "gateguard-session.json");
+    const response = await client.send({
+      jsonrpc: "2.0",
+      id: 44,
+      method: "tools/call",
+      params: {
+        name: "ci_gateguard_clear",
+        arguments: { file_paths: ["D:\\proj\\z.ts"], state_path: evil },
+      },
+    });
+    assert.ok(response.result.isError, "a state_path outside ~/.claude/instincts must be rejected");
+    assert.match(response.result.content[0].text, /instincts/);
+    assert.ok(!existsSync(evil), "must not write the state file outside the instincts root");
+  });
+
   it("ci_status returns project info", async () => {
     const response = await client.send({
       jsonrpc: "2.0",

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -205,6 +205,10 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
                 const decision = runHook("Write", { file_path: "fresh-file.ts", content: "x" }, dir);
                 assert.equal(decision.decision, "block");
                 assert.match(decision.reason ?? "", /ci_gateguard_clear|gateguard-clear\.mjs/);
+                // Route B must advertise state_path so the agent passes the session-scoped
+                // path to ci_gateguard_clear; without it the MCP clear falls back to the
+                // unscoped canonical dir and misses the session state.
+                assert.match(decision.reason ?? "", /state_path:/);
             }
             finally {
                 rmSync(dir, { recursive: true, force: true });
@@ -238,5 +242,49 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
                 rmSync(dir, { recursive: true, force: true });
             }
         });
+    });
+});
+// Session isolation: the cap and clearance state must NOT bleed across
+// concurrent same-day sessions. Drives the production path (no
+// GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so
+// the hook resolves its own session-scoped dir from the stdin session_id.
+describe("hooks/gateguard.mjs — per-session isolation (no shared cap)", () => {
+    let tempHome = "";
+    before(() => {
+        tempHome = mkdtempSync(join(tmpdir(), "gg-session-iso-"));
+    });
+    after(() => {
+        rmSync(tempHome, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+    });
+    function runScoped(sessionId, toolInput) {
+        const env = {
+            ...process.env,
+            HOME: tempHome,
+            USERPROFILE: tempHome,
+            CLAUDE_PROJECT_DIR: "d:/proj/iso",
+        };
+        delete env.GATEGUARD_SESSION_DIR;
+        const payload = JSON.stringify({ tool_name: "Edit", tool_input: toolInput, session_id: sessionId });
+        const result = spawnSync(process.execPath, [HOOK_PATH], { input: payload, encoding: "utf8", env });
+        assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`);
+        const stdout = result.stdout.trim();
+        if (stdout === "")
+            return { decision: "allow" };
+        const parsed = JSON.parse(stdout);
+        return { decision: "block", reason: parsed.hookSpecificOutput?.permissionDecisionReason };
+    }
+    it("clearing a file in session A does not clear it in session B", () => {
+        const file = "d:/proj/iso/a.ts";
+        // Session A presents facts → file cleared and recorded in A's session dir.
+        assert.equal(runScoped("session-A", { file_path: file, _gateguard_facts_presented: true }).decision, "allow", "facts-flagged clear in session A must be allowed");
+        // Session A retry without facts → allowed (A already cleared it).
+        assert.equal(runScoped("session-A", { file_path: file }).decision, "allow", "session A retry must see its own clearance");
+        // Session B never cleared it → blocked. (Current shared-dir code wrongly allows.)
+        const blockResult = runScoped("session-B", { file_path: file });
+        assert.equal(blockResult.decision, "block", "session B must NOT inherit session A's clearance");
+        // The block reason must carry the session-scoped state_path so route B clears
+        // the right dir — pinned to session-B so a regression in scoping is visible.
+        assert.match(blockResult.reason ?? "", /state_path:/, "block reason advertises the MCP state_path");
+        assert.match(blockResult.reason ?? "", /session-B/, "state_path references the session-B scoped dir");
     });
 });

--- a/test/gateguard-state.test.mjs
+++ b/test/gateguard-state.test.mjs
@@ -5,11 +5,11 @@
  * path separator — the root cause of the marker-seeding fragility.
  */
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { after, before, describe, it } from "node:test";
-import { MAX_CLEARED_FILES, canonicalizeFileKey, canonicalizeProjectRoot, clearFiles, isFileCleared, loadState, markFileCleared, resolveSessionDir, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, STATE_TTL_MS, canonicalizeFileKey, canonicalizeProjectRoot, clearFiles, isFileCleared, loadState, markFileCleared, resolveSessionDir, } from "../lib/gateguard-state.mjs";
 describe("canonicalizeProjectRoot", () => {
     it("lowercases a Windows drive letter", () => {
         assert.equal(canonicalizeProjectRoot("D:/Ai/x"), "d:/Ai/x");
@@ -67,6 +67,112 @@ describe("resolveSessionDir canonical hashing", () => {
             else
                 process.env.GATEGUARD_SESSION_DIR = prevSess;
         }
+    });
+});
+describe("resolveSessionDir session scoping", () => {
+    let prevProj;
+    let prevSess;
+    before(() => {
+        prevProj = process.env.CLAUDE_PROJECT_DIR;
+        prevSess = process.env.GATEGUARD_SESSION_DIR;
+        delete process.env.GATEGUARD_SESSION_DIR;
+        process.env.CLAUDE_PROJECT_DIR = "d:/Ai/continuous-improvement";
+    });
+    after(() => {
+        if (prevProj === undefined)
+            delete process.env.CLAUDE_PROJECT_DIR;
+        else
+            process.env.CLAUDE_PROJECT_DIR = prevProj;
+        if (prevSess === undefined)
+            delete process.env.GATEGUARD_SESSION_DIR;
+        else
+            process.env.GATEGUARD_SESSION_DIR = prevSess;
+    });
+    it("nests a session id under a sessions/ subdir of the legacy project dir", () => {
+        const legacy = resolveSessionDir();
+        assert.equal(resolveSessionDir("sess-A"), join(legacy, "sessions", "sess-A"));
+    });
+    it("gives different session ids different dirs", () => {
+        assert.notEqual(resolveSessionDir("sess-A"), resolveSessionDir("sess-B"));
+    });
+    it("is deterministic for the same session id", () => {
+        assert.equal(resolveSessionDir("sess-A"), resolveSessionDir("sess-A"));
+    });
+    it("falls back to the legacy unscoped dir with no session id (back-compat)", () => {
+        const legacy = resolveSessionDir();
+        assert.ok(!legacy.split(/[\\/]/).includes("sessions"), "legacy dir has no sessions/ segment");
+        assert.notEqual(resolveSessionDir("sess-A"), legacy);
+    });
+    it("treats an empty session id as no session id", () => {
+        assert.equal(resolveSessionDir(""), resolveSessionDir());
+    });
+    it("sanitizes a traversal session id so it cannot escape the sessions/ dir", () => {
+        const base = join(resolveSessionDir(), "sessions");
+        const scoped = resolveSessionDir("../../etc/passwd");
+        assert.ok(scoped.startsWith(base), "stays under sessions/");
+        assert.ok(!scoped.split(/[\\/]/).includes(".."), "no .. segment survives sanitization");
+    });
+    it("maps an all-unsafe session id to a pure-underscore segment (degenerate input)", () => {
+        const base = join(resolveSessionDir(), "sessions");
+        assert.equal(resolveSessionDir("@@@"), join(base, "___"));
+    });
+    it("caps the session id at 64 chars with replace happening before slice", () => {
+        const base = join(resolveSessionDir(), "sessions");
+        assert.equal(resolveSessionDir("a".repeat(65)), join(base, "a".repeat(64)));
+        // 65 unsafe chars: every one is replaced first, then sliced to 64 — no
+        // traversal sequence can survive the order of operations.
+        const scopedUnsafe = resolveSessionDir("/".repeat(65));
+        assert.equal(scopedUnsafe, join(base, "_".repeat(64)));
+        assert.ok(!scopedUnsafe.split(/[\\/]/).includes(".."), "no .. survives");
+    });
+    it("env override wins and ignores the session id", () => {
+        const override = join(tmpdir(), "gg-override");
+        process.env.GATEGUARD_SESSION_DIR = override;
+        try {
+            assert.equal(resolveSessionDir("sess-A"), override);
+        }
+        finally {
+            delete process.env.GATEGUARD_SESSION_DIR;
+        }
+    });
+});
+describe("loadState TTL self-heal", () => {
+    let dir = "";
+    before(() => {
+        dir = mkdtempSync(join(tmpdir(), "gg-ttl-"));
+    });
+    after(() => {
+        rmSync(dir, { recursive: true, force: true });
+    });
+    function writeState(createdAt) {
+        writeFileSync(join(dir, "gateguard-session.json"), `${JSON.stringify({ created_at: createdAt, cleared_files: { "d:/x.ts": { cleared_at: createdAt } } }, null, 2)}\n`);
+    }
+    it("resets cleared_files when created_at is older than STATE_TTL_MS", () => {
+        writeState(new Date(Date.now() - STATE_TTL_MS - 60_000).toISOString());
+        assert.deepEqual(loadState(dir).cleared_files, {});
+    });
+    it("preserves cleared_files within the TTL window", () => {
+        writeState(new Date(Date.now() - 60_000).toISOString());
+        assert.ok("d:/x.ts" in loadState(dir).cleared_files);
+    });
+    it("treats an unparseable created_at as expired (fail-closed)", () => {
+        writeState("not-a-date");
+        assert.deepEqual(loadState(dir).cleared_files, {});
+    });
+    it("treats a missing created_at field as expired (fail-closed)", () => {
+        writeFileSync(join(dir, "gateguard-session.json"), `${JSON.stringify({ cleared_files: { "d:/x.ts": { cleared_at: "2020-01-01T00:00:00.000Z" } } }, null, 2)}\n`);
+        assert.deepEqual(loadState(dir).cleared_files, {});
+    });
+    it("persists a fresh epoch on expiry so the cap re-applies immediately", () => {
+        writeState(new Date(Date.now() - STATE_TTL_MS - 60_000).toISOString());
+        const first = loadState(dir);
+        const second = loadState(dir);
+        assert.deepEqual(first.cleared_files, {});
+        assert.deepEqual(second.cleared_files, {});
+        // Without persistence the second load would re-read the still-expired file
+        // and mint a NEW epoch; equality proves the first load wrote the reset, so
+        // the cap counts from zero on the next call instead of resetting every load.
+        assert.equal(first.created_at, second.created_at, "new epoch persisted, not regenerated each load");
     });
 });
 describe("markFileCleared / isFileCleared canonical matching", () => {

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -167,6 +167,45 @@ describe("MCP server — beginner mode", () => {
         assert.ok(response.result.isError, "empty clear request must error");
         assert.match(response.result.content[0].text, /file_paths/);
     });
+    it("ci_gateguard_clear honors an in-root state_path and writes to that exact dir (session-scoped routing)", async () => {
+        // Inside the instincts root (HOME=tempHome for the server), mirroring the
+        // session-scoped path the hook prints. saveState mkdir's it recursively.
+        const statePath = join(tempHome, ".claude", "instincts", "scoped-test", "sessions", "sess-statepath", "gateguard-session.json");
+        const response = await client.send({
+            jsonrpc: "2.0",
+            id: 43,
+            method: "tools/call",
+            params: {
+                name: "ci_gateguard_clear",
+                arguments: { file_paths: ["D:\\proj\\z.ts"], state_path: statePath },
+            },
+        });
+        assert.ok(!response.result.isError, "clear with an in-root state_path should succeed");
+        assert.match(response.result.content[0].text, /gateguard-session\.json/);
+        // The marker must land at the supplied state_path, not the default session
+        // dir — this is what keeps the MCP clear route session-correct once the hook
+        // is session-scoped.
+        assert.ok(existsSync(statePath), "state file written at the supplied state_path");
+        const state = JSON.parse(readFileSync(statePath, "utf8"));
+        assert.ok(state.cleared_files && "d:/proj/z.ts" in state.cleared_files, "canonical key recorded at state_path");
+    });
+    it("ci_gateguard_clear rejects a state_path that resolves outside the instincts root (no arbitrary write)", async () => {
+        // A traversal/arbitrary path outside ~/.claude/instincts must be refused so
+        // the clear can't be turned into an arbitrary-write primitive.
+        const evil = join(tmpdir(), "ci-gg-evil", "gateguard-session.json");
+        const response = await client.send({
+            jsonrpc: "2.0",
+            id: 44,
+            method: "tools/call",
+            params: {
+                name: "ci_gateguard_clear",
+                arguments: { file_paths: ["D:\\proj\\z.ts"], state_path: evil },
+            },
+        });
+        assert.ok(response.result.isError, "a state_path outside ~/.claude/instincts must be rejected");
+        assert.match(response.result.content[0].text, /instincts/);
+        assert.ok(!existsSync(evil), "must not write the state file outside the instincts root");
+    });
     it("ci_status returns project info", async () => {
         const response = await client.send({
             jsonrpc: "2.0",


### PR DESCRIPTION
## Why

"Why always like this?" — the gateguard clearance cap kept exhausting and needing a manual `rm` every session. Root cause: the "per-session" state was **never session-scoped and never reset**.

- `resolveSessionDir()` keyed the state dir on the **project hash only** (`~/.claude/instincts/<projectHash>/gateguard-session.json`). Every Claude session on the repo — concurrent or sequential — shared one file. On a multi-Claude host the 50-distinct-file cap filled from *other* sessions' work, and every later session inherited a full gate.
- `loadState` recorded `created_at` but never read it, so the counter only ever grew.
- The cap-reached message said *"Start a new Claude Code session to reset the gate"* — which did nothing, because a new session resolved the same file. Doc intent ("the session is the trust boundary") and implementation disagreed. That mismatch was the bug.

## What changed

- **Session-scoped state.** `resolveSessionDir(sessionId?)` nests state under `<projectHash>/sessions/<sanitizedSessionId>/` using the stdin `session_id` (already a standard hook field). `GATEGUARD_SESSION_DIR` override still wins; no id → legacy unscoped dir (back-compat). The hook reads `session_id` and passes it, so the cap message is now true.
- **Self-heal TTL.** `loadState` returns empty when `created_at` is older than `STATE_TTL_MS` (12h), or absent/unparseable (fail-closed), and **persists the fresh epoch** so the cap re-applies from zero — closing a window where a session crossing the TTL could clear up to 2× the cap.
- **Third caller fixed.** `ci_gateguard_clear` gains an optional `state_path` (the hook prints it in the block reason) so the MCP clear route lands where the session-scoped hook reads. The path is **contained to `~/.claude/instincts/`** to prevent an arbitrary-write-via-traversal primitive from a model-controlled argument.
- Docs aligned (`skills/gateguard.md`); plan in `docs/plans/2026-06-14-gateguard-session-scoped-cap.md`.

## How it was built

TDD (RED confirmed → GREEN), then a 6-lens adversarial multi-agent review with per-finding verification: **19 raised, 9 confirmed, 10 refuted**. All 9 confirmed findings are fixed in this PR — including the HIGH `state_path` traversal, the absent-`created_at` TTL bypass, the TTL-boundary 2×-cap window, and contract-pin test gaps.

## Test plan

- `node --test test/gateguard-*.test.mjs test/mcp-server.test.mjs` → 84/84.
- New tests: session scoping (nest / distinct / fallback / empty-id / traversal / all-unsafe / 64-char cap), TTL (expired / within-window / unparseable / absent / persist-on-expiry), hook session isolation end-to-end, hook block-reason carries `state_path:`, MCP `state_path` honored in-root + rejected out-of-root.
- `npm run verify:all` → EXIT 0 (12 invariants + typecheck).
- `npm run verify:generated` → EXIT 0 (committed `.mjs` mirror matches a fresh build).
- Full suite 811/812 — the single failure is the documented `observe.sh` bash-spawn load flake (untouched pipeline; 12/12 in isolation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)