### PR TITLE
chore(release): cut 3.14.0 — ship the session-scoped gateguard fix to the runtime

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this skill are documented here.
 
 ---
 
+## [3.14.0] — 2026-06-14
+
+### Fixed
+
+- **Gateguard clearance cap no longer bleeds across concurrent sessions and self-heals instead of needing a manual `rm`** — the per-session clearance state was keyed on the project hash only, so every Claude session on a repo (sequential or concurrent) shared one 50-file counter that only grew; on a multi-Claude host later sessions inherited a near-full gate, and the "start a new session to reset" message did nothing because a new session resolved to the same file. State is now scoped to `~/.claude/instincts/<projectHash>/sessions/<sessionId>/` (the hook reads `session_id` from stdin; ids are sanitized against path traversal), a 12h TTL self-heals a stale state file to empty on load, and the MCP `ci_gateguard_clear` route accepts a `state_path` so it writes to the session-scoped file. The `MAX_CLEARED_FILES` rogue-loop cap still bounds a single session. Plan: `docs/plans/2026-06-14-gateguard-session-scoped-cap.md`. (#242)
+
 ## [3.13.0] — 2026-06-10
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles three grounding skills (gateguard, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.13.0",
+      "version": "3.14.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.13.0",
+  "version": "3.14.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## Why

PR #242 fixed the gateguard cross-session clearance-cap bleed in source, but it merged **without a version bump**. The published plugin version stayed `3.13.0`, identical to what was already installed — and the plugin cache only re-copies files when the version changes. Net effect: the fix is on `main` but never reaches any installed runtime. On this host the live hook was still the pre-fix code (the global state file sat at 28/50, 8 days old, never self-healing — the exact symptom #242 removed).

This PR bumps the version so the fix actually ships.

## What

- `package.json` version `3.13.0` → `3.14.0`.
- `npm run build` propagates the bump into the generated manifests: `plugin.json`, `.claude-plugin/marketplace.json` (+ mirror), `beginner.json`, `expert.json`.
- `CHANGELOG.md` documents the #242 gateguard fix under a new `3.14.0` entry.

No source/logic changes — single-concern release commit. The `.mjs` mirror is unchanged (build is idempotent against the post-#242 tree).

## Verification

- `npm run verify:all` — all 12 invariants + typecheck green.
- `node --test test/gateguard-state.test.mjs test/gateguard-hook.test.mjs` — 50/50 pass.
- Version propagation confirmed across all 4 generated manifests + package.json.

## Test plan

- [ ] CI green on `chore/release-3.14.0`.
- [ ] After merge, cut the `3.14.0` release/tag so npm + plugin marketplace publish; a plugin resync then pulls the session-scoped gateguard fix into installed caches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)