### PR TITLE
feat(plan-pack): turn a plan doc into a commentable review packet for colleague review

### DIFF
--- a/bin/plan-pack.mjs
+++ b/bin/plan-pack.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * plan-pack (`ci-plan-pack`).
+ *
+ * Turn a plan doc into a commentable review packet a colleague can mark up.
+ *
+ *   node bin/plan-pack.mjs <plan.md>            write <plan>.review.md
+ *   node bin/plan-pack.mjs <plan.md> --stdout   print the packet to stdout
+ *   node bin/plan-pack.mjs <plan.md> --gh-issue write the packet, then print a
+ *                                               ready-to-run `gh issue create`
+ *                                               command (does NOT auto-post)
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { extname } from "node:path";
+import { pathToFileURL } from "node:url";
+import { buildReviewPacket } from "../lib/plan-review-packet.mjs";
+function getErrorMessage(error) {
+    return error instanceof Error ? error.message : String(error);
+}
+function reviewPathFor(source) {
+    const ext = extname(source);
+    return ext ? `${source.slice(0, -ext.length)}.review${ext}` : `${source}.review.md`;
+}
+function packetTitle(packet) {
+    const match = /^# Review packet: (.*)$/m.exec(packet);
+    return match ? match[1].trim() : "Plan review";
+}
+const HELP = `
+plan-pack (ci-plan-pack) - turn a plan doc into a commentable review packet
+
+Usage: ci-plan-pack <plan.md> [--stdout] [--gh-issue]
+
+Options:
+  --stdout      Print the packet to stdout instead of writing a file
+  --gh-issue    Write the packet, then print a 'gh issue create' command
+                (does not post anything - you run it)
+
+Examples:
+  ci-plan-pack docs/plans/2026-06-15-plan-pack.md
+  ci-plan-pack docs/plans/2026-06-15-plan-pack.md --stdout
+`;
+function main() {
+    const args = process.argv.slice(2);
+    if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+        console.log(HELP);
+        process.exit(args.length === 0 ? 1 : 0);
+    }
+    const toStdout = args.includes("--stdout");
+    const ghIssue = args.includes("--gh-issue");
+    const source = args.find((a) => !a.startsWith("-"));
+    if (!source) {
+        throw new Error("Usage: ci-plan-pack <plan.md> [--stdout] [--gh-issue]");
+    }
+    const markdown = readFileSync(source, "utf8");
+    const packet = buildReviewPacket(markdown, { source });
+    if (toStdout) {
+        process.stdout.write(packet.endsWith("\n") ? packet : `${packet}\n`);
+        return;
+    }
+    const outPath = reviewPathFor(source);
+    writeFileSync(outPath, packet.endsWith("\n") ? packet : `${packet}\n`);
+    console.log(`Wrote review packet: ${outPath}`);
+    if (ghIssue) {
+        const title = packetTitle(packet);
+        console.log("\nTo open it for comments on GitHub, run:");
+        console.log(`  gh issue create --title "${title}" --body-file "${outPath}"`);
+    }
+}
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    try {
+        main();
+    }
+    catch (error) {
+        console.error(`Error: ${getErrorMessage(error)}`);
+        process.exit(1);
+    }
+}

--- a/docs/plans/2026-06-15-plan-pack.md
+++ b/docs/plans/2026-06-15-plan-pack.md
@@ -1,0 +1,59 @@
+# plan-pack — turn a plan doc into a commentable review packet
+
+Date: 2026-06-15
+Status: proposed (awaiting GO)
+
+## Goal
+
+Close gap #7 from the Matt-Pocock agentic-engineering mapping ("Proof: for sending a plan to a colleague — turn plan.md into a doc collaborators can comment on"), off the existing `docs/plans/*.md` flow. Deliver a deterministic transform that takes a plan markdown file and emits a packet a reviewer can comment on, with zero new dependencies.
+
+## Why a CLI tool (not a skill or MCP tool)
+
+The transform is pure and deterministic: markdown in, markdown out. That is testable code, not a prose procedure (skill) and not session-scoped agent state (MCP tool). It mirrors the surviving `cli-anything` precedent and keeps the change surgical — no skill-count / tool-count cascade. A skill or MCP wrapper can be added later as a logged follow-up if the agent needs to call it mid-session.
+
+## What it produces
+
+`buildReviewPacket(markdown, { source })` renders a review packet from a plan doc:
+
+- A header with the plan title, source path, and a **TLDR** line (extracted from a `## Goal` / `## Summary` / `## Overview` section's first paragraph, falling back to the first non-heading paragraph). This directly serves the "skim title + ask for a TLDR" half of the workflow.
+- Each `##` / `###` section gets a stable review anchor `[R1]`, `[R2]`, … and a `> Comment (R#):` placeholder block a colleague fills inline.
+- A trailing "How to comment" footer.
+
+Pure function → deterministic → unit-testable.
+
+## CLI surface
+
+`node bin/plan-pack.mjs <plan.md> [--stdout] [--gh-issue]`
+
+- default: writes `<plan>.review.md` next to the source (local artifact, the only side effect is one local file write).
+- `--stdout`: print the packet to stdout instead of writing a file.
+- `--gh-issue`: print a ready-to-run `gh issue create --title "<title>" --body-file <packet>` command plus the packet body, so the human posts it where colleagues comment via GitHub's native threads. It does **not** auto-post — outward-facing actions stay human-confirmed.
+
+## Files
+
+| Action | File |
+|---|---|
+| new | `src/lib/plan-review-packet.mts` — pure `buildReviewPacket` + `extractTldr` + `splitSections` |
+| new | `src/bin/plan-pack.mts` — thin CLI over the lib (arg parse, file IO, `--gh-issue` emit) |
+| new | `src/test/plan-review-packet.test.mts` — TDD, `node:test`, written first (RED) |
+| update | `package.json` — add `bin` entry `"ci-plan-pack": "bin/plan-pack.mjs"` |
+| generated | `lib/plan-review-packet.mjs`, `bin/plan-pack.mjs`, `test/plan-review-packet.test.mjs` + the `plugins/` mirror — produced by `npm run build`, committed alongside source |
+
+## TDD plan
+
+1. RED: write `plan-review-packet.test.mts` covering: TLDR extraction from `## Goal`; fallback to first paragraph; section anchors increment `[R1]`/`[R2]`; comment placeholders present per section; empty/heading-only input fails closed (returns a packet with a clear "no sections" note, never throws); CRLF and LF inputs produce identical anchors.
+2. GREEN: implement `plan-review-packet.mts` to pass.
+3. CLI: implement `plan-pack.mts`; manually run it against this very plan doc to dogfood.
+4. REFACTOR: tighten.
+
+## Verification
+
+- `npm run build` (regenerates `.mjs` + `plugins/` mirror), then `git update-index --chmod=+x` on the new `bin/`/`lib/` `.mjs` (Windows commits 644; Linux CI flips the mode otherwise).
+- `npm run verify:all` (12 invariants + typecheck) green.
+- `node --test test/*.test.mjs` green, including the new suite.
+- `git diff --exit-code -- bin lib test plugins .claude-plugin` clean (generated tree in sync).
+- Dogfood: run `node bin/plan-pack.mjs docs/plans/2026-06-15-plan-pack.md --stdout` and eyeball the packet.
+
+## Scope guard
+
+One concern: the transform + CLI. Not in this pass (logged, not dropped): a `/plan-pack` slash command or `ci_plan_pack` MCP tool wrapper; Google-Docs/Notion export; auto-posting to GitHub. Add as follow-ups if wanted.

--- a/lib/plan-review-packet.mjs
+++ b/lib/plan-review-packet.mjs
@@ -1,0 +1,96 @@
+/**
+ * plan-review-packet: turn a plan doc into a commentable review packet.
+ *
+ * Pure markdown transform — no IO. Splits a `docs/plans/*.md` plan into
+ * anchored sections, extracts a TLDR, and renders a packet a reviewer can
+ * comment on inline (one `> Comment (R#):` slot per section).
+ */
+const TLDR_HEADINGS = new Set(["goal", "summary", "overview", "tldr"]);
+const HEADING_RE = /^(#{1,6})\s+(.*\S)\s*$/;
+function normalize(markdown) {
+    return markdown.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+/** Split a plan into reviewable level-2/3 sections, each with a stable [R#] anchor. */
+export function splitSections(markdown) {
+    const lines = normalize(markdown).split("\n");
+    const sections = [];
+    let current = null;
+    let counter = 0;
+    const flush = () => {
+        if (!current)
+            return;
+        counter += 1;
+        sections.push({
+            heading: current.heading,
+            level: current.level,
+            anchor: `R${counter}`,
+            body: current.body.join("\n").trim(),
+        });
+        current = null;
+    };
+    for (const line of lines) {
+        const match = HEADING_RE.exec(line);
+        const level = match ? match[1].length : 0;
+        if (level === 1) {
+            flush();
+        }
+        else if (level === 2 || level === 3) {
+            flush();
+            current = { heading: match[2].trim(), level, body: [] };
+        }
+        else if (current) {
+            current.body.push(line);
+        }
+    }
+    flush();
+    return sections;
+}
+/** First non-empty, non-heading paragraph of a block of markdown. */
+function firstParagraph(text) {
+    for (const block of text.split(/\n\s*\n/)) {
+        const kept = block
+            .split("\n")
+            .map((l) => l.trim())
+            .filter((l) => l.length > 0 && !/^#{1,6}(\s|$)/.test(l));
+        if (kept.length > 0)
+            return kept.join("\n");
+    }
+    return "";
+}
+/** Extract a one-glance TLDR: a Goal/Summary/Overview section, else the first paragraph. */
+export function extractTldr(markdown) {
+    const goal = splitSections(markdown).find((s) => TLDR_HEADINGS.has(s.heading.trim().toLowerCase()));
+    if (goal)
+        return firstParagraph(goal.body);
+    return firstParagraph(normalize(markdown));
+}
+function extractTitle(markdown) {
+    for (const line of normalize(markdown).split("\n")) {
+        const match = /^#\s+(.*\S)\s*$/.exec(line);
+        if (match)
+            return match[1].trim();
+    }
+    return "Plan Review";
+}
+/** Render a commentable review packet from a plan doc. */
+export function buildReviewPacket(markdown, options = {}) {
+    const title = extractTitle(markdown);
+    const tldr = extractTldr(markdown);
+    const sections = splitSections(markdown);
+    const out = [`# Review packet: ${title}`, ""];
+    if (options.source)
+        out.push(`Source: ${options.source}`);
+    out.push(`TLDR: ${tldr || "(none — skim the sections below)"}`, "");
+    out.push("> How to comment: reply under each `> Comment (R#):` line. The `[R#]` anchors are stable references you can cite back.", "", "---", "");
+    if (sections.length === 0) {
+        out.push("_No reviewable sections found in this plan._", "");
+        return out.join("\n");
+    }
+    for (const section of sections) {
+        out.push(`${"#".repeat(section.level)} ${section.heading} [${section.anchor}]`, "");
+        if (section.body)
+            out.push(section.body, "");
+        out.push(`> Comment (${section.anchor}):`, "");
+    }
+    return out.join("\n");
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   "bin": {
     "continuous-improvement": "bin/install.mjs",
     "ci-lint-transcript": "bin/lint-transcript.mjs",
-    "ci": "bin/unified-cli.mjs"
+    "ci": "bin/unified-cli.mjs",
+    "ci-plan-pack": "bin/plan-pack.mjs"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && node bin/generate-plugin-manifests.mjs && node -e \"const fs=require('node:fs'); for (const f of fs.readdirSync('bin')) { if (f.endsWith('.mjs')) fs.chmodSync('bin/'+f, 0o755); } for (const f of fs.readdirSync('hooks')) { if (f.endsWith('.mjs')) fs.chmodSync('hooks/'+f, 0o755); } for (const f of fs.readdirSync('lib')) { if (f.endsWith('.mjs')) fs.chmodSync('lib/'+f, 0o755); } for (const f of fs.readdirSync('plugins/continuous-improvement/bin')) { if (f.endsWith('.mjs')) fs.chmodSync('plugins/continuous-improvement/bin/'+f, 0o755); } for (const f of fs.readdirSync('plugins/continuous-improvement/lib')) { if (f.endsWith('.mjs')) fs.chmodSync('plugins/continuous-improvement/lib/'+f, 0o755); } for (const f of fs.readdirSync('plugins/continuous-improvement/hooks')) { if (f.endsWith('.mjs')) fs.chmodSync('plugins/continuous-improvement/hooks/'+f, 0o755); } for (const f of fs.readdirSync('scripts')) { if (f.endsWith('.mjs')) fs.chmodSync('scripts/'+f, 0o755); } for (const f of fs.readdirSync('synthetic-checks')) { if (f.endsWith('.mjs')) fs.chmodSync('synthetic-checks/'+f, 0o755); } \"",

--- a/src/bin/plan-pack.mts
+++ b/src/bin/plan-pack.mts
@@ -1,0 +1,90 @@
+#!/usr/bin/env node
+
+/**
+ * plan-pack (`ci-plan-pack`).
+ *
+ * Turn a plan doc into a commentable review packet a colleague can mark up.
+ *
+ *   node bin/plan-pack.mjs <plan.md>            write <plan>.review.md
+ *   node bin/plan-pack.mjs <plan.md> --stdout   print the packet to stdout
+ *   node bin/plan-pack.mjs <plan.md> --gh-issue write the packet, then print a
+ *                                               ready-to-run `gh issue create`
+ *                                               command (does NOT auto-post)
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { extname } from "node:path";
+import { pathToFileURL } from "node:url";
+
+import { buildReviewPacket } from "../lib/plan-review-packet.mjs";
+
+function getErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function reviewPathFor(source: string): string {
+  const ext = extname(source);
+  return ext ? `${source.slice(0, -ext.length)}.review${ext}` : `${source}.review.md`;
+}
+
+function packetTitle(packet: string): string {
+  const match = /^# Review packet: (.*)$/m.exec(packet);
+  return match ? match[1].trim() : "Plan review";
+}
+
+const HELP = `
+plan-pack (ci-plan-pack) - turn a plan doc into a commentable review packet
+
+Usage: ci-plan-pack <plan.md> [--stdout] [--gh-issue]
+
+Options:
+  --stdout      Print the packet to stdout instead of writing a file
+  --gh-issue    Write the packet, then print a 'gh issue create' command
+                (does not post anything - you run it)
+
+Examples:
+  ci-plan-pack docs/plans/2026-06-15-plan-pack.md
+  ci-plan-pack docs/plans/2026-06-15-plan-pack.md --stdout
+`;
+
+function main(): void {
+  const args = process.argv.slice(2);
+  if (args.length === 0 || args.includes("--help") || args.includes("-h")) {
+    console.log(HELP);
+    process.exit(args.length === 0 ? 1 : 0);
+  }
+
+  const toStdout = args.includes("--stdout");
+  const ghIssue = args.includes("--gh-issue");
+  const source = args.find((a) => !a.startsWith("-"));
+  if (!source) {
+    throw new Error("Usage: ci-plan-pack <plan.md> [--stdout] [--gh-issue]");
+  }
+
+  const markdown = readFileSync(source, "utf8");
+  const packet = buildReviewPacket(markdown, { source });
+
+  if (toStdout) {
+    process.stdout.write(packet.endsWith("\n") ? packet : `${packet}\n`);
+    return;
+  }
+
+  const outPath = reviewPathFor(source);
+  writeFileSync(outPath, packet.endsWith("\n") ? packet : `${packet}\n`);
+  console.log(`Wrote review packet: ${outPath}`);
+
+  if (ghIssue) {
+    const title = packetTitle(packet);
+    console.log("\nTo open it for comments on GitHub, run:");
+    console.log(`  gh issue create --title "${title}" --body-file "${outPath}"`);
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    main();
+  } catch (error: unknown) {
+    console.error(`Error: ${getErrorMessage(error)}`);
+    process.exit(1);
+  }
+}

--- a/src/lib/plan-review-packet.mts
+++ b/src/lib/plan-review-packet.mts
@@ -1,0 +1,122 @@
+/**
+ * plan-review-packet: turn a plan doc into a commentable review packet.
+ *
+ * Pure markdown transform — no IO. Splits a `docs/plans/*.md` plan into
+ * anchored sections, extracts a TLDR, and renders a packet a reviewer can
+ * comment on inline (one `> Comment (R#):` slot per section).
+ */
+
+export interface ReviewPacketOptions {
+  source?: string;
+}
+
+export interface PlanSection {
+  heading: string;
+  level: number;
+  anchor: string;
+  body: string;
+}
+
+const TLDR_HEADINGS = new Set(["goal", "summary", "overview", "tldr"]);
+const HEADING_RE = /^(#{1,6})\s+(.*\S)\s*$/;
+
+function normalize(markdown: string): string {
+  return markdown.replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+}
+
+/** Split a plan into reviewable level-2/3 sections, each with a stable [R#] anchor. */
+export function splitSections(markdown: string): PlanSection[] {
+  const lines = normalize(markdown).split("\n");
+  const sections: PlanSection[] = [];
+  let current: { heading: string; level: number; body: string[] } | null = null;
+  let counter = 0;
+
+  const flush = () => {
+    if (!current) return;
+    counter += 1;
+    sections.push({
+      heading: current.heading,
+      level: current.level,
+      anchor: `R${counter}`,
+      body: current.body.join("\n").trim(),
+    });
+    current = null;
+  };
+
+  for (const line of lines) {
+    const match = HEADING_RE.exec(line);
+    const level = match ? match[1].length : 0;
+    if (level === 1) {
+      flush();
+    } else if (level === 2 || level === 3) {
+      flush();
+      current = { heading: match![2].trim(), level, body: [] };
+    } else if (current) {
+      current.body.push(line);
+    }
+  }
+  flush();
+  return sections;
+}
+
+/** First non-empty, non-heading paragraph of a block of markdown. */
+function firstParagraph(text: string): string {
+  for (const block of text.split(/\n\s*\n/)) {
+    const kept = block
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0 && !/^#{1,6}(\s|$)/.test(l));
+    if (kept.length > 0) return kept.join("\n");
+  }
+  return "";
+}
+
+/** Extract a one-glance TLDR: a Goal/Summary/Overview section, else the first paragraph. */
+export function extractTldr(markdown: string): string {
+  const goal = splitSections(markdown).find((s) =>
+    TLDR_HEADINGS.has(s.heading.trim().toLowerCase()),
+  );
+  if (goal) return firstParagraph(goal.body);
+  return firstParagraph(normalize(markdown));
+}
+
+function extractTitle(markdown: string): string {
+  for (const line of normalize(markdown).split("\n")) {
+    const match = /^#\s+(.*\S)\s*$/.exec(line);
+    if (match) return match[1].trim();
+  }
+  return "Plan Review";
+}
+
+/** Render a commentable review packet from a plan doc. */
+export function buildReviewPacket(
+  markdown: string,
+  options: ReviewPacketOptions = {},
+): string {
+  const title = extractTitle(markdown);
+  const tldr = extractTldr(markdown);
+  const sections = splitSections(markdown);
+
+  const out: string[] = [`# Review packet: ${title}`, ""];
+  if (options.source) out.push(`Source: ${options.source}`);
+  out.push(`TLDR: ${tldr || "(none — skim the sections below)"}`, "");
+  out.push(
+    "> How to comment: reply under each `> Comment (R#):` line. The `[R#]` anchors are stable references you can cite back.",
+    "",
+    "---",
+    "",
+  );
+
+  if (sections.length === 0) {
+    out.push("_No reviewable sections found in this plan._", "");
+    return out.join("\n");
+  }
+
+  for (const section of sections) {
+    out.push(`${"#".repeat(section.level)} ${section.heading} [${section.anchor}]`, "");
+    if (section.body) out.push(section.body, "");
+    out.push(`> Comment (${section.anchor}):`, "");
+  }
+
+  return out.join("\n");
+}

--- a/src/test/plan-review-packet.test.mts
+++ b/src/test/plan-review-packet.test.mts
@@ -1,0 +1,113 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+
+import {
+  buildReviewPacket,
+  extractTldr,
+  splitSections,
+} from "../lib/plan-review-packet.mjs";
+
+const SAMPLE = [
+  "# Slim the ci CLI",
+  "",
+  "Date: 2026-06-08",
+  "",
+  "## Goal",
+  "",
+  "Remove the parts that overlap the core product.",
+  "Keep the one piece that is distinct.",
+  "",
+  "## Changes",
+  "",
+  "Delete three libs and rewrite the CLI.",
+  "",
+  "### Sub-detail",
+  "",
+  "A nested section under Changes.",
+  "",
+  "## Verification",
+  "",
+  "Run the full verify suite.",
+].join("\n");
+
+describe("splitSections", () => {
+  test("numbers each level-2/3 section with an incrementing anchor", () => {
+    const sections = splitSections(SAMPLE);
+    assert.deepEqual(
+      sections.map((s) => s.anchor),
+      ["R1", "R2", "R3", "R4"],
+    );
+    assert.deepEqual(
+      sections.map((s) => s.heading),
+      ["Goal", "Changes", "Sub-detail", "Verification"],
+    );
+  });
+
+  test("does not treat the level-1 title as a reviewable section", () => {
+    const sections = splitSections(SAMPLE);
+    assert.ok(!sections.some((s) => s.heading === "Slim the ci CLI"));
+  });
+
+  test("captures the section body up to the next heading", () => {
+    const goal = splitSections(SAMPLE).find((s) => s.heading === "Goal");
+    assert.ok(goal);
+    assert.match(goal.body, /overlap the core product/);
+    assert.doesNotMatch(goal.body, /Delete three libs/);
+  });
+
+  test("returns no sections for heading-only or empty input", () => {
+    assert.deepEqual(splitSections(""), []);
+    assert.deepEqual(splitSections("# Title only\n"), []);
+  });
+});
+
+describe("extractTldr", () => {
+  test("pulls the first paragraph of a Goal/Summary/Overview section", () => {
+    assert.match(extractTldr(SAMPLE), /Remove the parts that overlap/);
+  });
+
+  test("is case-insensitive on the section heading", () => {
+    const md = "# T\n\n## summary\n\nThe one-line summary.\n\n## Other\n\nx";
+    assert.equal(extractTldr(md), "The one-line summary.");
+  });
+
+  test("falls back to the first non-heading paragraph when no Goal section", () => {
+    const md = "# Title\n\nFirst real paragraph here.\n\n## Body\n\nmore";
+    assert.equal(extractTldr(md), "First real paragraph here.");
+  });
+
+  test("returns an empty string for empty input", () => {
+    assert.equal(extractTldr(""), "");
+  });
+});
+
+describe("buildReviewPacket", () => {
+  test("includes the plan title and a TLDR line", () => {
+    const packet = buildReviewPacket(SAMPLE, { source: "docs/plans/x.md" });
+    assert.match(packet, /Slim the ci CLI/);
+    assert.match(packet, /TLDR/);
+    assert.match(packet, /Remove the parts that overlap/);
+    assert.match(packet, /docs\/plans\/x\.md/);
+  });
+
+  test("emits a comment placeholder per section keyed to its anchor", () => {
+    const packet = buildReviewPacket(SAMPLE);
+    assert.match(packet, /\[R1\]/);
+    assert.match(packet, /\[R4\]/);
+    assert.match(packet, /> Comment \(R1\):/);
+    assert.match(packet, /> Comment \(R4\):/);
+  });
+
+  test("fails closed on input with no reviewable sections", () => {
+    const packet = buildReviewPacket("# Just a title\n");
+    assert.doesNotThrow(() => buildReviewPacket(""));
+    assert.match(packet, /No reviewable sections/i);
+  });
+
+  test("produces identical anchors for CRLF and LF input", () => {
+    const lf = buildReviewPacket(SAMPLE);
+    const crlf = buildReviewPacket(SAMPLE.replace(/\n/g, "\r\n"));
+    const anchorsOf = (s: string) => (s.match(/\[R\d+\]/g) ?? []).join(",");
+    assert.equal(anchorsOf(crlf), anchorsOf(lf));
+  });
+});

--- a/test/plan-review-packet.test.mjs
+++ b/test/plan-review-packet.test.mjs
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { buildReviewPacket, extractTldr, splitSections, } from "../lib/plan-review-packet.mjs";
+const SAMPLE = [
+    "# Slim the ci CLI",
+    "",
+    "Date: 2026-06-08",
+    "",
+    "## Goal",
+    "",
+    "Remove the parts that overlap the core product.",
+    "Keep the one piece that is distinct.",
+    "",
+    "## Changes",
+    "",
+    "Delete three libs and rewrite the CLI.",
+    "",
+    "### Sub-detail",
+    "",
+    "A nested section under Changes.",
+    "",
+    "## Verification",
+    "",
+    "Run the full verify suite.",
+].join("\n");
+describe("splitSections", () => {
+    test("numbers each level-2/3 section with an incrementing anchor", () => {
+        const sections = splitSections(SAMPLE);
+        assert.deepEqual(sections.map((s) => s.anchor), ["R1", "R2", "R3", "R4"]);
+        assert.deepEqual(sections.map((s) => s.heading), ["Goal", "Changes", "Sub-detail", "Verification"]);
+    });
+    test("does not treat the level-1 title as a reviewable section", () => {
+        const sections = splitSections(SAMPLE);
+        assert.ok(!sections.some((s) => s.heading === "Slim the ci CLI"));
+    });
+    test("captures the section body up to the next heading", () => {
+        const goal = splitSections(SAMPLE).find((s) => s.heading === "Goal");
+        assert.ok(goal);
+        assert.match(goal.body, /overlap the core product/);
+        assert.doesNotMatch(goal.body, /Delete three libs/);
+    });
+    test("returns no sections for heading-only or empty input", () => {
+        assert.deepEqual(splitSections(""), []);
+        assert.deepEqual(splitSections("# Title only\n"), []);
+    });
+});
+describe("extractTldr", () => {
+    test("pulls the first paragraph of a Goal/Summary/Overview section", () => {
+        assert.match(extractTldr(SAMPLE), /Remove the parts that overlap/);
+    });
+    test("is case-insensitive on the section heading", () => {
+        const md = "# T\n\n## summary\n\nThe one-line summary.\n\n## Other\n\nx";
+        assert.equal(extractTldr(md), "The one-line summary.");
+    });
+    test("falls back to the first non-heading paragraph when no Goal section", () => {
+        const md = "# Title\n\nFirst real paragraph here.\n\n## Body\n\nmore";
+        assert.equal(extractTldr(md), "First real paragraph here.");
+    });
+    test("returns an empty string for empty input", () => {
+        assert.equal(extractTldr(""), "");
+    });
+});
+describe("buildReviewPacket", () => {
+    test("includes the plan title and a TLDR line", () => {
+        const packet = buildReviewPacket(SAMPLE, { source: "docs/plans/x.md" });
+        assert.match(packet, /Slim the ci CLI/);
+        assert.match(packet, /TLDR/);
+        assert.match(packet, /Remove the parts that overlap/);
+        assert.match(packet, /docs\/plans\/x\.md/);
+    });
+    test("emits a comment placeholder per section keyed to its anchor", () => {
+        const packet = buildReviewPacket(SAMPLE);
+        assert.match(packet, /\[R1\]/);
+        assert.match(packet, /\[R4\]/);
+        assert.match(packet, /> Comment \(R1\):/);
+        assert.match(packet, /> Comment \(R4\):/);
+    });
+    test("fails closed on input with no reviewable sections", () => {
+        const packet = buildReviewPacket("# Just a title\n");
+        assert.doesNotThrow(() => buildReviewPacket(""));
+        assert.match(packet, /No reviewable sections/i);
+    });
+    test("produces identical anchors for CRLF and LF input", () => {
+        const lf = buildReviewPacket(SAMPLE);
+        const crlf = buildReviewPacket(SAMPLE.replace(/\n/g, "\r\n"));
+        const anchorsOf = (s) => (s.match(/\[R\d+\]/g) ?? []).join(",");
+        assert.equal(anchorsOf(crlf), anchorsOf(lf));
+    });
+});


### PR DESCRIPTION
## Summary

Adds `ci-plan-pack`, a deterministic CLI that turns a `docs/plans/*.md` plan into a packet a colleague can comment on — closing gap #7 ("Proof: for sending a plan to a colleague") from the agentic-engineering mapping, off the existing plan-doc flow. Zero new dependencies.

- **`src/lib/plan-review-packet.mts`** — pure transform: `splitSections` (level-2/3 sections → stable `[R#]` anchors), `extractTldr` (pulls the first paragraph of a `## Goal`/`## Summary`/`## Overview` section, else the first paragraph), `buildReviewPacket` (renders title + source + TLDR + one `> Comment (R#):` slot per section). Fails closed on empty/heading-only input.
- **`src/bin/plan-pack.mts`** — `ci-plan-pack <plan.md> [--stdout] [--gh-issue]`. Default writes `<plan>.review.md`; `--stdout` prints; `--gh-issue` emits a ready-to-run `gh issue create` command and does **not** auto-post.
- **`package.json`** — new bin entry `ci-plan-pack`.

## Why a CLI (not a skill / MCP tool)

The transform is pure markdown-in/markdown-out — testable code, not a prose procedure or session state. Mirrors the surviving `cli-anything` precedent and keeps the change surgical (no skill-count / tool-count cascade). A skill/MCP wrapper can follow if wanted.

## Cross-platform fix

The bin uses a `pathToFileURL` main-guard. The `import.meta.url === ` + "`file://${process.argv[1]}`" pattern used in `unified-cli.mts` silently no-ops under `node bin/x.mjs` on Windows (backslash path never equals the forward-slash `file:///` URL). Fixing the same latent bug in `unified-cli.mts` is logged as a separate follow-up.

## Test plan

- [x] `node --test test/plan-review-packet.test.mjs` — 12/12 (TLDR extraction + case-insensitivity + fallback, anchor numbering, level-1 title excluded, per-section comment slots, fail-closed on no sections, CRLF==LF anchors).
- [x] `npm run verify:all` — 12 content invariants + typecheck green.
- [x] `npm run verify:generated` — committed generated tree matches a fresh build (exit 0).
- [x] Dogfood: `node bin/plan-pack.mjs docs/plans/2026-06-15-plan-pack.md --stdout` → correct 8-section packet.
- [ ] CI (Linux) green on the PR.

Pre-existing flakes unrelated to this change: `observe` 500ms wall-clock budget (passes in isolation) and `git-state-snapshot` `node --test`+Git-Bash subprocess interaction (documented in the test; the script runs clean directly).

Plan doc: `docs/plans/2026-06-15-plan-pack.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)