### PR TITLE
feat(ship): add /ship single-defect audit-to-PR command

### DIFF
--- a/commands/ship.md
+++ b/commands/ship.md
@@ -1,0 +1,57 @@
+---
+name: ship
+description: "Single-defect fast path — walk one bug from ground-truth audit through a TDD fix, full verification, a single-concern commit, and an open PR, then stop. Never auto-merges, never deploys. For multi-PR rollouts use /release-train instead."
+---
+
+# /ship
+
+The one-defect fast path. `/release-train` is for stacked multi-PR rollouts and `/proceed-with-the-recommendation` walks an arbitrary recommendation list; `/ship` is the common case: fix one defect, open one PR, hand it back for review.
+
+Pure routing over existing skills. It adds no new orchestration logic and it does NOT bypass branch protection, force-push, auto-merge, or deploy.
+
+## Usage
+
+```
+/ship <one-line description of the defect>
+```
+
+If the description is ambiguous or names more than one concern, `/ship` halts and asks you to narrow it — one defect per run.
+
+## Behavior
+
+In order, for the single defect:
+
+1. **Ground truth** — `reconcile` (or its inline fallback): confirm the working tree is clean and on a feature branch cut from an up-to-date `origin/<base>`. If on a protected branch or a stale base, halt and ask.
+2. **Reproduce (RED)** — `tdd-workflow`: write a failing test that reproduces the defect; watch it fail. Pre-test implementation code is deleted, not kept.
+3. **Fix (GREEN)** — write the minimal change that makes the test pass; watch it pass. One concern only.
+4. **Verify** — `verification-loop`: run the project's verify ladder (build, types, tests). Build-green is evidence of mechanism, not of the fix — confirm the defect itself no longer reproduces.
+5. **Commit** — one commit, one concern, staged by explicit filename (never `git add -A`). Use a Windows-safe commit message: a single-line `-m` (repeat `-m` for paragraphs) or `git commit -F <tempfile>` — no multi-line here-docs/here-strings.
+6. **Open PR** — `commit-commands:commit-push-pr` (or `gh pr create`): push the branch and open a single-concern PR that cites the plan or issue. **Stop here.** The merge is yours.
+7. **Deploy receipt (advisory)** — after you merge, `deploy-receipt` verifies the deployed SHA matches the merge SHA. Advisory only; `/ship` does not deploy.
+
+## Hard stops (halt and ask, never improvise)
+
+- Ambiguous or multi-concern defect description.
+- Working tree not clean, or branch is protected / cut from a stale base.
+- Any verification step fails with a non-obvious fix.
+- The fix would touch more than 15 non-generated files (that is no longer one concern — split it, or use `/release-train`).
+- Push would target a protected branch.
+
+## Anti-patterns this command refuses
+
+- **Auto-merge.** Never merges the PR it opens, even when CI is green.
+- **Deploy.** Never runs a deploy; `deploy-receipt` only verifies after you merge.
+- **Bypass.** No `--admin`, `--force`, `--no-verify`.
+- **Bundled concerns.** Will not fold an unrelated fix into the same commit; logs it as a deferred follow-up instead.
+
+## Composition
+
+Routes through, in order: `reconcile` → `tdd-workflow` → `verification-loop` → `commit-commands:commit-push-pr` → `deploy-receipt`. Each step falls back to its inline behavior when the preferred skill is not installed.
+
+## Example
+
+```
+/ship registration form accepts a negative deposit amount
+```
+
+Reconciles git state, writes a failing test asserting deposits must be positive, implements the guard, runs the verify ladder, commits one concern with a single-line message, opens the PR, and stops for your review.

--- a/docs/plans/2026-06-17-ship-command.md
+++ b/docs/plans/2026-06-17-ship-command.md
@@ -1,0 +1,61 @@
+# Plan: `/ship` command — single-defect audit→fix→PR pipeline (PowerShell-safe)
+
+- Date: 2026-06-17
+- Branch: `feat/ship-command` (off `origin/main` 136b7f1)
+- Closes: R6 from the 2026-06-17 report-coverage map (no unified `/ship` command exists)
+
+## Goal
+
+A single-concern slash command that walks ONE defect from audit to a review-ready PR, reusing existing skills, with Windows/PowerShell-safe commit guidance. Pure routing — no new orchestration logic, no new skill, no new code.
+
+## Why
+
+The coverage map confirmed the audit→TDD→test→commit→PR→merge→deploy pipeline is already composable from `release-train` + `proceed-with-the-recommendation` + the superpowers stages, but there is no single entry point for the common case: fix one defect, open one PR. `release-train` is multi-PR; `proceed-with-the-recommendation` walks an arbitrary recommendation list. `/ship` is the single-defect fast path.
+
+## Scope (one concern)
+
+In:
+- New `commands/ship.md` — a routing command (prose), command-only, sequencing existing skills for one defect on one branch.
+- Regenerate plugin manifests + `plugins/` mirror via `npm run build` (generated output, committed).
+
+Out (explicitly deferred, not dropped):
+- No multi-PR orchestration — that is `release-train`.
+- No new skill, no new hook, no `.mts` code — keeps skill-count / skill-tiers / skill-law-tag / tool-count invariants untouched.
+- No deploy automation, no auto-merge — `/ship` stops at "PR open, CI green, awaiting your merge". Deploy verification stays advisory via `deploy-receipt`.
+- PowerShell-native fallbacks for `deploy-receipt`'s Bash-only scripts (the other half of R6) → separate follow-up PR.
+
+## Design (routing only)
+
+`/ship <one-line defect description>` walks:
+1. `reconcile` — establish git ground truth; refuse if not on a clean feature branch off `origin/main`.
+2. `tdd-workflow` — RED failing test reproducing the defect → GREEN minimal fix (pre-test code deleted).
+3. `verification-loop` — run the project verify ladder; build/types/tests green before commit.
+4. One commit, one concern, PowerShell-safe message (single-line `-m`, or `-F <tempfile>`) per the global Windows Shell Discipline rule.
+5. `commit-commands:commit-push-pr` — push branch + open PR. STOP. Never auto-merge.
+6. `deploy-receipt` — after you merge, verify the deployed SHA (advisory).
+
+Hard stops (halt and ask): protected-branch push, ambiguous defect description, any verification failure.
+
+## Files
+
+- Source (hand-authored, committed): `commands/ship.md` (1 file).
+- Generated (committed via `npm run build`, never hand-edited): `plugins/continuous-improvement/commands/ship.md` mirror; `.claude-plugin/marketplace.json` + `plugins/continuous-improvement/.claude-plugin/plugin.json` if command lists are embedded; `llms.txt` / docs counts if a command total is cited.
+
+## TDD / verification
+
+1. Before writing the command: grep for any asserted command count (tests, `llms.txt`, README, `scripts/`); bump it if one exists (RED if a count test fails first).
+2. Write `commands/ship.md`.
+3. `npm run build` (regenerates mirror + manifests).
+4. `npm run verify:all` green — especially `everything-mirror`, `scripts-citation-drift`, `docs-substrings`, `routing-targets` (every skill `/ship` cites must exist), `doc-runtime-claims`.
+5. `git diff --exit-code -- bin lib test plugins` clean after build (build-pipeline invariant).
+6. Stage by explicit filename (no `git add -A`). One commit, cite this plan. Open PR; do not merge.
+
+## Risks
+
+- Count-drift invariants (`scripts-citation-drift` / `docs-substrings`) if a command total is cited anywhere — caught by `verify:all`.
+- `routing-targets`: every skill `/ship` references must resolve — caught by the invariant.
+- `.mts`/`.mjs` trap: none here (command-only), but rebuild-before-stage still applies to the generated mirror.
+
+## Done when
+
+`verify:all` green + PR open + this plan cited in the commit. Merge and any deploy remain the operator's call.

--- a/plugins/continuous-improvement/commands/ship.md
+++ b/plugins/continuous-improvement/commands/ship.md
@@ -1,0 +1,57 @@
+---
+name: ship
+description: "Single-defect fast path — walk one bug from ground-truth audit through a TDD fix, full verification, a single-concern commit, and an open PR, then stop. Never auto-merges, never deploys. For multi-PR rollouts use /release-train instead."
+---
+
+# /ship
+
+The one-defect fast path. `/release-train` is for stacked multi-PR rollouts and `/proceed-with-the-recommendation` walks an arbitrary recommendation list; `/ship` is the common case: fix one defect, open one PR, hand it back for review.
+
+Pure routing over existing skills. It adds no new orchestration logic and it does NOT bypass branch protection, force-push, auto-merge, or deploy.
+
+## Usage
+
+```
+/ship <one-line description of the defect>
+```
+
+If the description is ambiguous or names more than one concern, `/ship` halts and asks you to narrow it — one defect per run.
+
+## Behavior
+
+In order, for the single defect:
+
+1. **Ground truth** — `reconcile` (or its inline fallback): confirm the working tree is clean and on a feature branch cut from an up-to-date `origin/<base>`. If on a protected branch or a stale base, halt and ask.
+2. **Reproduce (RED)** — `tdd-workflow`: write a failing test that reproduces the defect; watch it fail. Pre-test implementation code is deleted, not kept.
+3. **Fix (GREEN)** — write the minimal change that makes the test pass; watch it pass. One concern only.
+4. **Verify** — `verification-loop`: run the project's verify ladder (build, types, tests). Build-green is evidence of mechanism, not of the fix — confirm the defect itself no longer reproduces.
+5. **Commit** — one commit, one concern, staged by explicit filename (never `git add -A`). Use a Windows-safe commit message: a single-line `-m` (repeat `-m` for paragraphs) or `git commit -F <tempfile>` — no multi-line here-docs/here-strings.
+6. **Open PR** — `commit-commands:commit-push-pr` (or `gh pr create`): push the branch and open a single-concern PR that cites the plan or issue. **Stop here.** The merge is yours.
+7. **Deploy receipt (advisory)** — after you merge, `deploy-receipt` verifies the deployed SHA matches the merge SHA. Advisory only; `/ship` does not deploy.
+
+## Hard stops (halt and ask, never improvise)
+
+- Ambiguous or multi-concern defect description.
+- Working tree not clean, or branch is protected / cut from a stale base.
+- Any verification step fails with a non-obvious fix.
+- The fix would touch more than 15 non-generated files (that is no longer one concern — split it, or use `/release-train`).
+- Push would target a protected branch.
+
+## Anti-patterns this command refuses
+
+- **Auto-merge.** Never merges the PR it opens, even when CI is green.
+- **Deploy.** Never runs a deploy; `deploy-receipt` only verifies after you merge.
+- **Bypass.** No `--admin`, `--force`, `--no-verify`.
+- **Bundled concerns.** Will not fold an unrelated fix into the same commit; logs it as a deferred follow-up instead.
+
+## Composition
+
+Routes through, in order: `reconcile` → `tdd-workflow` → `verification-loop` → `commit-commands:commit-push-pr` → `deploy-receipt`. Each step falls back to its inline behavior when the preferred skill is not installed.
+
+## Example
+
+```
+/ship registration form accepts a negative deposit amount
+```
+
+Reconciles git state, writes a failing test asserting deposits must be positive, implements the guard, runs the verify ladder, commits one concern with a single-line message, opens the PR, and stops for your review.


### PR DESCRIPTION
## Summary

Adds `/ship`, a single-defect fast-path command that walks one bug from a ground-truth audit through a TDD fix, full verification, a single-concern commit, and an open PR — then stops. It never auto-merges and never deploys.

Closes **R6** from the 2026-06-17 report-coverage map: the audit→fix→PR pipeline was already composable from existing skills but had no single entry point for the common case "fix one defect, open one PR" (`/release-train` is multi-PR; `/proceed-with-the-recommendation` walks an arbitrary recommendation list).

## What it does

Pure routing over existing skills, in order:

1. `reconcile` — git ground truth; halt on a protected branch or a stale base
2. `tdd-workflow` — RED failing test reproducing the defect → GREEN minimal fix
3. `verification-loop` — run the project verify ladder (build, types, tests)
4. one single-concern commit, Windows-safe message (single-line `-m` or `-F <tempfile>`)
5. `commit-commands:commit-push-pr` — push + open PR, then **STOP**
6. `deploy-receipt` — advisory post-merge SHA check (no deploy)

## Scope

- In: `commands/ship.md` (command-only) + its generated plugin mirror + the plan doc.
- Out (deferred, not dropped): multi-PR orchestration, any new skill/hook/`.mts` code, deploy automation, auto-merge, and PowerShell-native fallbacks for `deploy-receipt`'s Bash scripts (separate follow-up PR).

## Files

- `commands/ship.md` — hand-authored source
- `plugins/continuous-improvement/commands/ship.md` — generated mirror (`npm run build`)
- `docs/plans/2026-06-17-ship-command.md` — plan

## Verification

- `npm run verify:all` — green (13/13: routing-targets 37/37, tool-count expert=19 / beginner=4, everything-mirror, doc-runtime-claims, scripts-citation-drift, typecheck, …).
- `install.test` — 29/29 pass. `ALL_COMMAND_FILES` is unchanged: `/ship` distributes via the plugin bundle (directory-copy), not the curated standalone-installer set, so the "6 command files in beginner mode" gate stays green.
- `observe.test` in isolation — 12/12 pass.
- The full-suite run surfaced only subprocess-spawn timing failures (`observe.sh` / `observe.mjs` / `route-prompt` / `hook` at 5000ms+ ETIMEDOUT) while the host was saturated; all pass when run in isolation. This is the documented environmental flake class (see CLAUDE.md), not a regression — a markdown-only command cannot affect process-spawn timing.

## Test plan

- [ ] CI green on the PR
- [ ] Manual: `/ship <defect>` on a clean feature branch routes through the stages and stops at PR-open without merging

No new dependencies. No `.mts` source changes (no `.mjs` regeneration beyond the command mirror).
