### PR TITLE
feat(readiness): add /production-readiness-review parallel multi-agent review command

### DIFF
--- a/commands/production-readiness-review.md
+++ b/commands/production-readiness-review.md
@@ -1,0 +1,53 @@
+---
+name: production-readiness-review
+description: "Parallel multi-agent readiness gate — fan blind reviewers across performance, security, UI/UX, and test coverage, each grounding findings in real code/logs/live data, then reconcile into one deduplicated, severity-ranked punch-list. Reports only; never fixes, merges, or deploys."
+---
+
+# /production-readiness-review
+
+The review-side sibling of `/ship`. Fans a set of blind, specialized reviewers across distinct dimensions, then reconciles their findings into a single prioritized punch-list. It reports — it does not fix. Fixing a finding is a separate `/ship` run.
+
+Pure routing over existing skills and agents. Adds no new code.
+
+## Usage
+
+```
+/production-readiness-review [scope]
+```
+
+`scope` defaults to the current branch diff against `origin/main`. Pass a path or PR number to narrow it.
+
+## Behavior
+
+1. **Scope** — establish ground truth: the diff under review and which changes are recent (`git diff`; `reconcile` fallback for branch/base state). Recent changes get extra scrutiny because they are the likeliest source of self-inflicted defects.
+2. **Fan out** — `superpowers:dispatching-parallel-agents` launches four reviewers, each blind to the others. Every reviewer is instructed to ground each finding in real code, logs, or live queries, and never to assume or fabricate state:
+   - **Performance & bundle-size** — hot paths, N+1 queries, unbounded work, regressions.
+   - **Security & data-access** (`security-auditor`) — authn/authz, input handling, injection, secret exposure, unsafe data access.
+   - **UI/UX correctness** — verified live with Playwright when the MCP is available, else static review of the changed surface.
+   - **Test coverage & flaky/stale mocks** (`test-engineer`) — uncovered branches, stale mocks, timing-flaky tests.
+3. **Reconcile** — a final pass dedupes findings across reviewers, ranks each CRITICAL / HIGH / MEDIUM / LOW by severity and confidence, and explicitly flags any defect introduced by the changes under review.
+4. **Present** — emit the consolidated punch-list, severity-ranked, with file references. **Stop.**
+
+## Hard stops (report, never act)
+
+- Does not fix, edit, commit, merge, or deploy anything — output is a punch-list only.
+- A reviewer that cannot ground a finding marks it `unverified` rather than asserting it.
+- If a dimension's tooling is unavailable (e.g. no Playwright MCP), it says so rather than silently skipping coverage.
+
+## Anti-patterns this command refuses
+
+- **Fabricated state.** No finding may rest on an assumed SHA, row, or log line — ground it or mark it `unverified`.
+- **Silent skip.** A dimension that cannot run is reported as not-run, never dropped from the summary.
+- **Drive-by fix.** Findings become `/ship` tasks; this command does not touch code.
+
+## Composition
+
+Routes through: `reconcile` (scope/ground truth) → `superpowers:dispatching-parallel-agents` (fan-out) → the `security-auditor` and `test-engineer` agents (two of the four dimensions) → a reconciliation pass that ranks and dedupes. Each step falls back to its inline behavior when the preferred skill or agent is not installed.
+
+## Example
+
+```
+/production-readiness-review #246
+```
+
+Scopes PR #246's diff, fans four blind reviewers across performance, security, UI/UX, and test coverage, then returns one deduplicated severity-ranked punch-list — flagging anything the PR's own changes introduced — and stops for you to prioritize.

--- a/docs/plans/2026-06-17-production-readiness-review-command.md
+++ b/docs/plans/2026-06-17-production-readiness-review-command.md
@@ -1,0 +1,60 @@
+# Plan: `/production-readiness-review` command — parallel multi-agent readiness gate
+
+- Date: 2026-06-17
+- Branch: `feat/production-readiness-review` (off `origin/main` 136b7f1)
+- Closes: R13 from the 2026-06-17 report-coverage map (no named orchestrator binds the parallel-review pieces into a readiness gate)
+
+## Goal
+
+One command that fans parallel specialized agents across distinct review dimensions — each grounding every finding against real code, logs, or live queries — then reconciles them into a single deduplicated, severity-ranked punch-list. Reports only; it does not fix.
+
+## Why
+
+The coverage map confirmed the pieces already exist (`superpowers:dispatching-parallel-agents`, plus the `code-reviewer` / `security-auditor` / `test-engineer` agents that already rate findings by severity and confidence), but nothing binds them into a named readiness gate. `/production-readiness-review` is that entry point — the sibling of `/ship` for the review side.
+
+## Scope (one concern)
+
+In:
+- New `commands/production-readiness-review.md` — routing command (prose), command-only.
+- Regenerate the `plugins/` mirror via `npm run build` (generated output).
+
+Out (deferred, not dropped):
+- No new skill, hook, or `.mts` code.
+- No auto-fix — the command reports a punch-list and stops; fixing is a separate `/ship` run per finding.
+- No merge, no deploy.
+- Not added to the `proceed-with-the-recommendation` routing table (so `routing-targets` is untouched).
+
+## Design (routing only)
+
+`/production-readiness-review` walks:
+1. **Scope** — establish ground truth: the diff under review and which changes are recent (`git diff`, `reconcile` fallback).
+2. **Fan out** — `superpowers:dispatching-parallel-agents` launches four blind reviewers, each told to ground every finding in real code/logs/live data and never assume state:
+   - performance & bundle-size
+   - security & data-access (`security-auditor`)
+   - UI/UX correctness (Playwright when available, else static review)
+   - test coverage & flaky/stale mocks (`test-engineer`)
+3. **Reconcile** — dedupe across reviewers, severity-rank (CRITICAL/HIGH/MEDIUM/LOW), and explicitly flag any defect introduced by recent changes.
+4. **Present** — emit the consolidated punch-list. **Stop.** Do not fix.
+
+## Files
+
+- Source (hand-authored): `commands/production-readiness-review.md` (1 file).
+- Generated (via `npm run build`): `plugins/continuous-improvement/commands/production-readiness-review.md` mirror.
+
+## TDD / verification
+
+1. `ALL_COMMAND_FILES` is a hardcoded installer set — unchanged (this command distributes via the plugin bundle), so `install.test` stays green.
+2. Write the command.
+3. `npm run build` (regenerate mirror).
+4. `npm run verify:all` green — especially `everything-mirror`, `doc-runtime-claims` (avoid "runtime hook/gate/physically blocks" phrasing — this is a routing command), `scripts-citation-drift` (cite only existing skills/agents), `routing-targets` (unchanged).
+5. `git diff --exit-code -- .claude-plugin bin hooks test lib plugins` clean after build.
+6. Stage by explicit filename. One commit citing this plan. Open PR; do not merge.
+
+## Risks
+
+- `doc-runtime-claims` false-trip if the prose claims a runtime gate — keep it framed as orchestration/advice.
+- Cited agents (`code-reviewer`, `security-auditor`, `test-engineer`) and `superpowers:dispatching-parallel-agents` must exist — all confirmed present.
+
+## Done when
+
+`verify:all` green + PR open + this plan cited in the commit. Prioritizing and acting on the punch-list is the operator's call.

--- a/plugins/continuous-improvement/commands/production-readiness-review.md
+++ b/plugins/continuous-improvement/commands/production-readiness-review.md
@@ -1,0 +1,53 @@
+---
+name: production-readiness-review
+description: "Parallel multi-agent readiness gate — fan blind reviewers across performance, security, UI/UX, and test coverage, each grounding findings in real code/logs/live data, then reconcile into one deduplicated, severity-ranked punch-list. Reports only; never fixes, merges, or deploys."
+---
+
+# /production-readiness-review
+
+The review-side sibling of `/ship`. Fans a set of blind, specialized reviewers across distinct dimensions, then reconciles their findings into a single prioritized punch-list. It reports — it does not fix. Fixing a finding is a separate `/ship` run.
+
+Pure routing over existing skills and agents. Adds no new code.
+
+## Usage
+
+```
+/production-readiness-review [scope]
+```
+
+`scope` defaults to the current branch diff against `origin/main`. Pass a path or PR number to narrow it.
+
+## Behavior
+
+1. **Scope** — establish ground truth: the diff under review and which changes are recent (`git diff`; `reconcile` fallback for branch/base state). Recent changes get extra scrutiny because they are the likeliest source of self-inflicted defects.
+2. **Fan out** — `superpowers:dispatching-parallel-agents` launches four reviewers, each blind to the others. Every reviewer is instructed to ground each finding in real code, logs, or live queries, and never to assume or fabricate state:
+   - **Performance & bundle-size** — hot paths, N+1 queries, unbounded work, regressions.
+   - **Security & data-access** (`security-auditor`) — authn/authz, input handling, injection, secret exposure, unsafe data access.
+   - **UI/UX correctness** — verified live with Playwright when the MCP is available, else static review of the changed surface.
+   - **Test coverage & flaky/stale mocks** (`test-engineer`) — uncovered branches, stale mocks, timing-flaky tests.
+3. **Reconcile** — a final pass dedupes findings across reviewers, ranks each CRITICAL / HIGH / MEDIUM / LOW by severity and confidence, and explicitly flags any defect introduced by the changes under review.
+4. **Present** — emit the consolidated punch-list, severity-ranked, with file references. **Stop.**
+
+## Hard stops (report, never act)
+
+- Does not fix, edit, commit, merge, or deploy anything — output is a punch-list only.
+- A reviewer that cannot ground a finding marks it `unverified` rather than asserting it.
+- If a dimension's tooling is unavailable (e.g. no Playwright MCP), it says so rather than silently skipping coverage.
+
+## Anti-patterns this command refuses
+
+- **Fabricated state.** No finding may rest on an assumed SHA, row, or log line — ground it or mark it `unverified`.
+- **Silent skip.** A dimension that cannot run is reported as not-run, never dropped from the summary.
+- **Drive-by fix.** Findings become `/ship` tasks; this command does not touch code.
+
+## Composition
+
+Routes through: `reconcile` (scope/ground truth) → `superpowers:dispatching-parallel-agents` (fan-out) → the `security-auditor` and `test-engineer` agents (two of the four dimensions) → a reconciliation pass that ranks and dedupes. Each step falls back to its inline behavior when the preferred skill or agent is not installed.
+
+## Example
+
+```
+/production-readiness-review #246
+```
+
+Scopes PR #246's diff, fans four blind reviewers across performance, security, UI/UX, and test coverage, then returns one deduplicated severity-ranked punch-list — flagging anything the PR's own changes introduced — and stops for you to prioritize.


### PR DESCRIPTION
## Summary

Adds `/production-readiness-review`, the review-side sibling of `/ship`: it fans blind specialized reviewers across performance, security, UI/UX, and test coverage — each grounding findings in real code, logs, or live data — then reconciles them into one deduplicated, severity-ranked punch-list. Report-only; it never fixes, merges, or deploys.

Closes **R13** from the 2026-06-17 report-coverage map: the parallel-review pieces already existed (`superpowers:dispatching-parallel-agents` + the severity-rating `security-auditor` / `test-engineer` agents) but nothing bound them into a named readiness gate.

## What it does

1. **Scope** — ground truth on the diff under review; recent changes get extra scrutiny (likeliest source of self-inflicted defects).
2. **Fan out** — `dispatching-parallel-agents` launches four blind reviewers (perf/bundle; security/data-access via `security-auditor`; UI/UX via Playwright when available, else static; test coverage/flaky-mocks via `test-engineer`), each forbidden from assuming or fabricating state.
3. **Reconcile** — dedupe across reviewers, rank CRITICAL/HIGH/MEDIUM/LOW by severity + confidence, flag defects introduced by the changes under review.
4. **Present** — emit the punch-list and stop. Fixing a finding is a separate `/ship` run.

## Scope

- In: `commands/production-readiness-review.md` (command-only) + generated mirror + plan doc.
- Out (deferred): no new skill/hook/`.mts` code; no auto-fix (report-only); no merge/deploy; not added to the `proceed-with-the-recommendation` routing table (so `routing-targets` is untouched).

## Files

- `commands/production-readiness-review.md` — hand-authored source
- `plugins/continuous-improvement/commands/production-readiness-review.md` — generated mirror (`npm run build`)
- `docs/plans/2026-06-17-production-readiness-review-command.md` — plan

## Verification

- `npm run verify:all` — green (12/12 invariants + typecheck: everything-mirror 59/59, routing-targets 37/37, tool-count expert=19 / beginner=4, doc-runtime-claims clean — the command avoids runtime-gate phrasing).
- `install.test` — 29/29 pass. `ALL_COMMAND_FILES` unchanged; the command distributes via the plugin bundle, not the curated standalone-installer set.
- No `.mts` source changes; no `.mjs` regeneration beyond the command mirror.

## Test plan

- [ ] CI green on the PR
- [ ] Manual: `/production-readiness-review #<pr>` fans the four reviewers and returns one deduplicated, severity-ranked punch-list without editing code

Part of the 2026-06-17 report-coverage build train; PR #246 (`/ship`) is the fix-side sibling. No new dependencies.
