### PR TITLE
chore(release): cut v3.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this skill are documented here.
 
 ---
 
+## [3.15.0] — 2026-06-21
+
+### Added
+
+- **`/ship` cuts one defect from audit to an open PR** — a single-concern fast path that routes `reconcile` → `tdd-workflow` → `verification-loop` → `commit-push-pr` → `deploy-receipt` for one fix, then stops at PR-open. Never auto-merges or deploys. Command-only; `/release-train` remains the multi-PR path. Plan: `docs/plans/2026-06-17-ship-command.md`. (#246)
+- **`/production-readiness-review` fans a blind multi-agent review into one punch-list** — parallel reviewers across performance, security, UI/UX, and test coverage, each grounding findings in real code/logs/live data, reconciled into a deduplicated, severity-ranked list. Report-only; never fixes, merges, or deploys. Plan: `docs/plans/2026-06-17-production-readiness-review-command.md`. (#247)
+- **`hook-pack` enforces push-to-main and commit-size at the tool boundary** — a warn-default PreToolUse hook (Bash-matched so the non-Bash hot path stays cheap; gateguard stays first) that flags a direct `git push` to a protected branch (`main`/`master`/`release/*`) and a `git commit` staging more than 15 files. Mode `CLAUDE_CI_HOOKPACK_GATE=warn|block|off`; warn never blocks, so zero disruption until you opt into `block`. Pure logic in `lib/hook-pack-gate`. Plan: `docs/plans/2026-06-17-enforcing-hook-pack.md`. (#248)
+- **`/plan-pack` turns a plan doc into a commentable review packet for colleague review** — converts a `docs/plans/` doc into a structured packet a colleague can comment on before implementation. (#244)
+- **How-to-best-use guide** mapping the agentic-engineering workflow to the plugin's skills, commands, and hooks (`docs/using-this-plugin.md`). (#245)
+
 ## [3.14.0] — 2026-06-14
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.13.0",
+  "version": "3.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.13.0",
+      "version": "3.15.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles three grounding skills (gateguard, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.14.0",
+      "version": "3.15.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 25 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.14.0",
+  "version": "3.15.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## Summary

Release bump 3.14.0 → 3.15.0. Version bump + regenerated manifests + CHANGELOG only; no code changes (`npm version --no-git-tag-version` + `npm run build`).

Bundles everything unreleased on `main` since 3.14.0 (#244–#248):

- `/plan-pack` — plan doc → commentable review packet (#244)
- how-to-best-use guide `docs/using-this-plugin.md` (#245)
- `/ship` — single-defect audit→fix→PR command (#246)
- `/production-readiness-review` — parallel multi-agent readiness gate (#247)
- `hook-pack` — warn-default push-to-main + commit-size PreToolUse gates (#248)

## What ships on merge

Marketplace consumers (`/plugin update continuous-improvement`) get 3.15.0. The code is already on `main`; the **version bump is what refreshes the cached plugin files** (cached files aren't re-copied on resync unless the version changes), so this is what makes the new commands + hook actually load for installed users.

## npm publish — held pending account config

npm is published at **3.12.3** (3.13.0 and 3.14.0 were never published). The npm release is tag-triggered (`v*` → `release.yml`), but the v3.13.0 run **published provenance then E404'd on `PUT`** while running Node 22.22 / npm 11.16 — both above the OIDC floor, so it is not an npm-version problem. Per `docs/RELEASING.md`'s troubleshooting table, signed-provenance-then-E404 on a current npm means the **OIDC trusted publisher isn't configured/matching on npmjs.com**.

That is a one-time account setting only the npm owner can make: npmjs.com → `continuous-improvement` → Settings → Trusted Publisher → GitHub Actions publisher, owner `naimkatiman`, repo `continuous-improvement`, workflow `release.yml`, environment blank.

Until that's confirmed, tagging `v3.15.0` would E404 again and leave a dangling tag. **So the tag is intentionally held.** Merge this for the marketplace release; then configure the trusted publisher (or use the manual `npm publish` + OTP fallback in `docs/RELEASING.md`) and the `v3.15.0` tag can be pushed.

## Verification

- `npm run build` regenerated the 5 manifests + `package.json`/`package-lock.json` to 3.15.0.
- `verify:all` GREEN; `verify:generated` clean.
- No new dependencies.
