### PR TITLE
chore(release): v3.16.0 — ship /roast to npm + npx

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this skill are documented here.
 
 ---
 
+## [3.16.0] — 2026-06-27
+
+### Added
+
+- **`/roast` — a 5-persona adversarial idea council that pressure-tests a plan before any code is written** — routes a proposed idea or plan through five distinct critic personas (each attacking a different failure axis) and reconciles their objections into a go / revise / kill verdict. Catches misalignment at Law 1 (Research) before it lands in the diff. Brings the bundle to 26 skills. (#255, #256)
+- **npm-install users get nudged when a newer version is published** — the installer compares the running version against the registry `latest` and surfaces an upgrade hint instead of silently running stale. (#252)
+- **Hook nudge to distill a verified Workflow run into a reusable instinct** — a completed multi-agent Workflow's verified trajectory no longer evaporates with the session; the agent is prompted to capture it as a draft instinct. (#251)
+- **`lint-transcript` GitHub Action IO + fleet docs** — the transcript linter ships defined Action inputs/outputs for CI wiring, with fleet-usage documentation. (#250)
+- **Skill use-case decision guide** — a when-to-reach-for-each-skill map so the right skill is picked without scanning all of them. (#254)
+
+### Changed
+
+- **`skill-count` prose is now gated against the actual bundle** — the verify suite fails if any doc claims a skill count that disagrees with the shipped skill set; synced all prose to 26 after `/roast`. (#256)
+
 ## [3.15.0] — 2026-06-21
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles three grounding skills (gateguard, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.15.0",
+      "version": "3.16.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 26 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.15.0",
+  "version": "3.16.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
## Why

`/roast` (#255, #256) and three other user-facing changes landed after the `3.15.0` cut (2026-06-21), so npm `latest` and `npx continuous-improvement` were serving a bundle without them. The README already references `/roast`; this release closes the gap for npm + npx.

## What ships in 3.16.0

- **`/roast`** — 5-persona adversarial idea council (#255, #256). Bundle now 26 skills.
- npm-install upgrade nudge when a newer version is published (#252)
- Hook nudge to distill a verified Workflow run into an instinct (#251)
- `lint-transcript` GitHub Action IO + fleet docs (#250)
- Skill use-case decision guide (#254)
- skill-count prose gated against the bundle (#256)

## Changes in this PR

- `package.json` 3.15.0 → 3.16.0 (source of truth)
- `CHANGELOG.md` 3.16.0 section
- Regenerated manifests (`marketplace.json`, `plugin.json`, `beginner.json`, `expert.json`) via `npm run build`

## Verification

- `npm run verify:all` — all 13 invariants + typecheck green
- Real drift = 7 files (2 hand-edited + 5 generated); staged by explicit filename

## Release mechanics

After squash-merge to `main`, push tag `v3.16.0` to trigger `release.yml` (OIDC publish, configured at the 3.15.0 cut). npx picks up `latest` automatically.