### PR TITLE
docs(readme): progressive-disclosure rewrite — value prop + quick start above the fold, depth collapsed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- README landing-page structure rationale: docs/plans/2026-05-14-readme-landing-rewrite.md -->
+<!-- README landing-page structure rationale: docs/plans/2026-06-28-readme-progressive-disclosure.md (supersedes docs/plans/2026-05-14-readme-landing-rewrite.md) -->
 
 <p align="center">
   <img src="assets/combined.gif" alt="Before vs After — The 7 Laws of AI Agent Discipline" width="700" />
@@ -15,16 +15,29 @@
 </p>
 
 <p align="center">
-  <a href="https://www.npmjs.com/package/continuous-improvement"><img src="https://img.shields.io/npm/v/continuous-improvement" alt="npm"></a>
+  <a href="https://www.npmjs.com/package/continuous-improvement"><img src="https://img.shields.io/npm/v/continuous-improvement" alt="npm version"></a>
+  <a href="https://www.npmjs.com/package/continuous-improvement"><img src="https://img.shields.io/npm/dm/continuous-improvement" alt="npm downloads"></a>
   <a href="https://docs.anthropic.com/en/docs/claude-code"><img src="https://img.shields.io/badge/Claude%20Code-skill-blueviolet" alt="Claude Code"></a>
   <a href="https://github.com/marketplace/actions/ai-agent-discipline-linter"><img src="https://img.shields.io/badge/GitHub%20Action-marketplace-blue" alt="GitHub Action"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green" alt="license"></a>
-  <a href="test/"><img src="https://img.shields.io/badge/tests-passing-brightgreen" alt="tests"></a>
 </p>
 
 <p align="center">
   <b>New here?</b> → <a href="QUICKSTART.md">QUICKSTART.md</a> (2 minutes) · <a href="https://continuous-improvement.dev">continuous-improvement.dev</a>
 </p>
+
+## Quick start
+
+Inside Claude Code — two commands, no Node, no bash:
+
+```bash
+/plugin marketplace add naimkatiman/continuous-improvement
+/plugin install continuous-improvement@continuous-improvement
+```
+
+**If you don't know which to pick, use Beginner.** That is the install above — enough for ~90% of users. Want the MCP server, observation hooks, and instinct packs too? See [Expert install](#install) below.
+
+Verify it is live: run `/discipline` in Claude Code and you should see the 7 Laws card. (Commands load on session start — if it is not recognized, restart Claude Code once.)
 
 > **What this is *not*:** a prompt template, a `CLAUDE.md`, or a vibes-based reminder. It is a runtime hook (`hooks/gateguard.mjs`) plus a bundled skill set that makes the agent ground every change in real facts — it physically blocks `Edit` / `Write` / destructive `Bash` until the investigation is done, so edits land on understanding instead of guesses.
 
@@ -38,11 +51,9 @@ Claude Code is powerful but leaves intelligence on the table: it edits before re
 2. **During work** — bundled skills enforce planning, one-thing-at-a-time execution, TDD ([`tdd-workflow`](skills/tdd-workflow.md)), and a six-phase verification ladder ([`verification-loop`](skills/verification-loop.md)) before "done".
 3. **After work** — `/seven-laws` reflection plus the Mulahazah instinct engine capture lessons, and the opt-in [`recall-briefing`](hooks/recall-briefing.mjs) hook resurfaces the most relevant past fix on the next related prompt, so the same mistake does not repeat next session.
 
-Beginner install is two slash commands inside Claude Code (no Node, no bash). Expert install adds MCP tools, observation hooks, instinct packs, and a GitHub Action transcript linter for CI.
-
 ---
 
-## Before and after
+## See it in action
 
 Without Continuous Improvement, "fix the login redirect bug" looks like this:
 
@@ -53,146 +64,6 @@ With Continuous Improvement, the same prompt is forced through the gate:
 > `gateguard` blocks the first `Edit` until Claude presents a fact list. Claude reads `useAuth.ts`, finds the existing `redirectAfterLogin` helper, traces *why* the redirect loops (a stale `from` query param), and edits one line in one file. `verification-loop` runs the tests. The reply names the file, the line, the cause.
 
 Same agent. Same model. Different intelligence.
-
----
-
-## Who this is for
-
-Use this if you:
-
-- ship from real repositories with real consequences
-- have been bitten by an agent that edits before understanding
-- want tests, builds, or healthchecks to pass before "done"
-- want lessons from yesterday to survive into today
-
-Skip it if you:
-
-- only do one-off prompts (no edits, no commits)
-- do not use Claude Code
-- dislike *any* friction before agent edits
-- want a prompt template, not a runtime gate
-
-(The runtime gate is `hooks/gateguard.mjs`; full mechanics in [How enforcement works](#how-enforcement-works) below.)
-
----
-
-## The problem this solves
-
-You have used Claude Code (or any agentic coding tool) long enough to recognize the failure pattern. Matt Pocock's [Skills For Real Engineers](https://github.com/mattpocock/skills) names four root failure modes that account for nearly every "the agent didn't help" complaint; the 7 Laws of AI Agent Discipline catch those four at the tool-call boundary plus a fifth that only shows up across sessions.
-
-| # | Failure mode | What you see | Which Law fires | What enforces it |
-|---|---|---|---|---|
-| 1 | **Misalignment** | The agent doesn't do what you want — invents requirements, reinvents helpers that already exist, or builds the wrong thing before anyone challenged the idea | Law 1 (Research) | [`roast`](skills/roast.md), [`grill-me`](skills/grill-me.md), [`grill-with-docs`](skills/grill-with-docs.md), [`gateguard`](skills/gateguard.md), [`workspace-surface-audit`](skills/workspace-surface-audit.md) |
-| 2 | **No shared language** | The agent uses 20 words where 1 would do; jargon decoded fresh every session; variable names drift from domain terms | Law 2 (Plan), Law 7 (Learn) | [`grill-with-docs`](skills/grill-with-docs.md) (writes & maintains `CONTEXT.md`), [`token-budget-advisor`](skills/token-budget-advisor.md), [`strategic-compact`](skills/strategic-compact.md) |
-| 3 | **No feedback loop** | The code doesn't work — agent claims "done" without running build, tests, or healthcheck | Law 4 (Verify) | [`tdd-workflow`](skills/tdd-workflow.md), [`verification-loop`](skills/verification-loop.md), [`deploy-receipt`](skills/deploy-receipt.md) |
-| 4 | **Design rot** | Ball-of-mud accelerates — agent bundles three concerns into one PR, stacks untested changes, ignores prior architectural decisions | Law 2 (Plan), Law 3 (One Thing) | [`superpowers:writing-plans`](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md), [`safety-guard`](skills/safety-guard.md), [`worktree-safety`](skills/worktree-safety.md), [`wild-risa-balance`](skills/wild-risa-balance.md) |
-| 5 | **Forgotten lessons** | Next session starts from zero — prior corrections, decisions, instincts are lost; the same mistake repeats next week | Law 5 (Reflect), Law 7 (Learn) | [`handoff`](skills/handoff.md), Mulahazah instinct engine |
-
-Three of those alignment + reflection skills (`grill-me`, `grill-with-docs`, `handoff`) are MIT-licensed ports from mattpocock/skills; the rest are continuous-improvement-native. Every failure mode has at least one runtime hook or model-side skill that catches it before it lands in the diff.
-
----
-
-## Install
-
-**If you don't know which to pick, use Beginner.** It is enough for ~90% of users and adds no Node or bash dependency.
-
-### Beginner — inside Claude Code, two commands (plus one optional companion)
-
-You get the 7 Laws skill, the hooks that enforce it, and the slash commands. Nothing else to install.
-
-```bash
-# Inside Claude Code (no shell needed)
-/plugin marketplace add naimkatiman/continuous-improvement
-/plugin install continuous-improvement@continuous-improvement
-```
-
-The doubled name is correct: it reads as `<plugin>@<marketplace>`.
-
-**Optional companion (recommended).** The `/superpowers` dispatcher routes per-task to specialist skills (`writing-plans`, `test-driven-development`, `using-git-worktrees`, `dispatching-parallel-agents`, `finishing-a-development-branch`, etc.) shipped by Obra's `superpowers` plugin, which is vendored into this same marketplace as a pinned-SHA snapshot. Install it with one extra line:
-
-```bash
-/plugin install superpowers@continuous-improvement
-```
-
-Without the companion the dispatcher still works — every routing target has a concrete inline fallback — but specialist quality is fallback-quality, not dedicated-skill-quality.
-
-Verify: run `/discipline` in Claude Code — you should see the 7 Laws card.
-If the command is not recognized, restart your Claude Code session first; the marketplace did pick the plugin up but commands load on session start.
-
-**Second-stage verify (proves the runtime gate is firing — i.e. `hooks/gateguard.mjs` is invoked — not just docs claiming it).** Ask Claude to write a throwaway file with no research first:
-
-```
-Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
-```
-
-You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook (`hooks/gateguard.mjs`) with a fact-list reason. That block is the proof the hook is wired and enforcing. If Claude writes the file with no pause, the hook did not load — see Troubleshooting below. (To also verify observation hooks, run `/dashboard` and confirm a non-zero `Total` under `Observations`.)
-
-### How enforcement works
-
-The 7 Laws are enforced at **two layers**:
-
-- **Runtime layer (hooks).** `gateguard` ships as a PreToolUse hook (`hooks/gateguard.mjs`) that physically blocks Edit / Write / MultiEdit / destructive Bash on the first mutation per file until the agent presents the facts named in [skills/gateguard.md § Gate Types](skills/gateguard.md). Destructive Bash (`rm -rf`, `git push --force`, `--force-with-lease`, `DROP DATABASE`, Windows `Remove-Item -Recurse`, etc.) is gated on every call, not just first. Read-only and exploratory tools (Read, Grep, Glob, routine Bash like `git status`) bypass the gate. Per-session state at `~/.claude/instincts/<project-hash>/gateguard-session.json` caps cumulative clearances at 50 distinct files to bound stuck-loop damage. A second runtime hook, `goal-drift-stop` (`hooks/goal-drift-stop.mjs`), fires on `Stop`: it scores each turn against the stated `## Goal` and, on a substantive wrap-up that has drifted off-goal, warns by default (or re-prompts under `CLAUDE_GOAL_DRIFT_GATE=block`) — so a drifted session can't quietly declare "done". Fail-open.
-- **Model layer (skills).** Once the runtime gate clears for a file, the rest of the discipline (`tdd-workflow`, `verification-loop`, `proceed-with-the-recommendation`, etc.) runs model-side — the agent reads each skill and applies it. `observe.sh` / `observe.mjs` records every tool call into the Mulahazah feed for instinct extraction; that surface is observational, not enforcement.
-
-V1 honest limitations: the runtime gate is honor-system once the agent flips `_gateguard_facts_presented: true` (the hook can't verify the investigation actually happened); the state file is deletable and parallel hook invocations can race. Documented in `src/hooks/gateguard.mts` and `src/lib/gateguard-state.mts` headers.
-
-### Expert — adds MCP server, observation hooks, and instinct packs
-
-Pick this if you want the MCP tools (19 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, and starter packs.
-
-Preconditions: Node 18 / 20 / 22, plus bash on Windows (Git Bash or WSL — `hooks/observe.sh` is a bash script and silently no-ops without it). **`jq` is no longer required**: as of v3.6.0, `observe.sh` prefers the Node observer (`bin/observe.mjs`) which writes the rich event schema natively without external dependencies. The bash thin-schema path is kept as a two-phase shim, so legacy installs that have not re-run `npx continuous-improvement install` since v3.5.x will still degrade silently without `jq` (`winget install jqlang.jq` on Windows, `brew install jq` on macOS, `apt install jq` on Debian/Ubuntu) — re-running the installer is the cleaner fix and removes the dependency entirely. See [CHANGELOG.md](CHANGELOG.md) `[3.6.0]` for the migration details.
-
-```bash
-npx continuous-improvement install --mode expert
-npx continuous-improvement install --pack react   # optional: react | python | go | meta
-# --pack seeds 5–10 starter instincts so suggestions appear in week 1 instead of week 4.
-```
-
-Verify: run `/dashboard` in Claude Code — you should see instinct health and observation count.
-Update later with `/plugin marketplace update continuous-improvement` or by re-running the npx command. When you run the npx installer, it makes one throttled, fail-open read of the public npm registry and prints a one-line notice if a newer version is published (no telemetry — nothing about you is sent). Silence it with `CLAUDE_CI_UPDATE_CHECK=off`.
-
-### Troubleshooting install
-
-Three failures account for nearly every install support thread. Try them in order:
-
-| Symptom | Real cause | Fix |
-|---|---|---|
-| `/discipline` says "command not recognized" right after `/plugin install` | Slash commands load on session start; the marketplace did pick the plugin up | Quit and reopen Claude Code, then run `/discipline` again |
-| Expert mode hooks never fire on Windows | `observe.sh` is bash; PowerShell silently no-ops on it | Install Git Bash (or WSL) and re-run `npx continuous-improvement install --mode expert` |
-| `/plugin marketplace add ...` returned nothing visible | Marketplace add was silent; the plugin is not yet selected | Run `/plugin install continuous-improvement@continuous-improvement` to select and activate it |
-
-If none of those apply, paste the output of `npx continuous-improvement install` into a GitHub issue — that surface logs every step.
-
-### Operator modes
-
-The framework has documented operator-level modes that change hook behavior without rebuilding the plugin. These are first-class — set them once in your shell rc and they persist across sessions.
-
-| Env var | Effect | How to set |
-|---|---|---|
-| `CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` | `three-section-close.mjs` short-circuits before any enforcement or telemetry. Use when end-of-turn reflection should run as internal thinking rather than visible "What has been done / What is next / Recommendation" sections. Public default unchanged — the rule still fires for everyone else. | bash/zsh: `export CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_THREE_SECTION_CLOSE_DISABLED','1','User')` (persistent). |
-| `CLAUDE_GOAL_DRIFT_GATE` | `goal-drift-stop.mjs` (a `Stop` hook) scores each turn's activity against the `## Goal` in `task_plan.md` and acts on drift. `warn` (default) prints a one-line stderr notice and never blocks; `block` re-prompts a substantive wrap-up that has drifted off-goal so the goal gates the close; `off` disables it. Reads the same observation feed as Mulahazah; fails open on any error. | bash/zsh: `export CLAUDE_GOAL_DRIFT_GATE=block` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_GOAL_DRIFT_GATE='block'` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_GOAL_DRIFT_GATE','block','User')` (persistent). |
-| `CLAUDE_RECALL_BRIEFING=1` | `hooks/recall-briefing.mjs` (a UserPromptSubmit hook) makes episodic memory proactive: on the first substantive prompt of a session it searches this project's past observations (BM25) and injects a one-time `<system-reminder>` with the most relevant prior activity, so the agent reuses a past fix instead of re-deriving it. Opt-in and default off; it is an amplifier, never a gate — it cannot block a prompt and fails open. The `ci_recall` MCP tool stays available for explicit, deeper searches. | bash/zsh: `export CLAUDE_RECALL_BRIEFING=1` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_RECALL_BRIEFING=1` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_RECALL_BRIEFING','1','User')` (persistent). |
-| `CLAUDE_WORKFLOW_DISTILL_NUDGE=on` | `hooks/workflow-distill.mjs` (a `Stop` hook) closes the orchestration-to-memory loop: when a native Workflow run's output then passed a verify in the same session, it prints a one-line stderr nudge to run the `ci_distill_from_workflow` MCP tool, so an expensive multi-agent run leaves a durable Mulahazah draft instinct instead of evaporating. `on` enables it; default (unset or any other value) is off. Opt-in amplifier, never a gate — it cannot block the Stop, dedupes per run, and fails open. | bash/zsh: `export CLAUDE_WORKFLOW_DISTILL_NUDGE=on` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_WORKFLOW_DISTILL_NUDGE='on'` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_WORKFLOW_DISTILL_NUDGE','on','User')` (persistent). |
-
-### Works with other agents
-
-Claude Code gets the full install (hooks, MCP server, instinct learning). Every other agent platform can still run the 7 Laws as a rules file — one flag writes the skill text into the file that platform reads, at your project root:
-
-```bash
-npx continuous-improvement install --target gemini,codex
-```
-
-| Target | File written |
-|---|---|
-| `gemini` | `GEMINI.md` (Gemini CLI context file) |
-| `codex` | `AGENTS.md` (agents.md standard — also read by opencode, Jules, Cursor ≥0.50) |
-| `cursor` | `.cursor/rules/continuous-improvement.mdc` (`alwaysApply: true`) |
-| `windsurf` | `.windsurf/rules/continuous-improvement.md` |
-| `zed` | `.rules` |
-| `aider` | `CONVENTIONS.md` + a minimal `.aider.conf.yml` if none exists |
-| `copilot` | `.github/copilot-instructions.md` |
-
-Shared files (`GEMINI.md`, `AGENTS.md`, `.rules`, `CONVENTIONS.md`, `copilot-instructions.md`) are merged through a managed marker block — your existing content is preserved and reinstalls are idempotent. Targets can be combined freely (`--target claude,gemini,codex` runs the full Claude Code install plus the rules files).
 
 ---
 
@@ -220,7 +91,165 @@ Full spec, reflection-block format, and anti-examples: [SKILL.md](SKILL.md). Ful
 
 ---
 
+## Install
+
+**Beginner (recommended)** is the two-command [Quick start](#quick-start) above — the 7 Laws skill, the hooks that enforce it, and the slash commands. Nothing else to install.
+
+<details>
+<summary><b>Optional companion — the <code>/superpowers</code> dispatcher (recommended)</b></summary>
+
+The `/superpowers` dispatcher routes per-task to specialist skills (`writing-plans`, `test-driven-development`, `using-git-worktrees`, `dispatching-parallel-agents`, `finishing-a-development-branch`, etc.) shipped by Obra's `superpowers` plugin, which is vendored into this same marketplace as a pinned-SHA snapshot. Install it with one extra line:
+
+```bash
+/plugin install superpowers@continuous-improvement
+```
+
+Without the companion the dispatcher still works — every routing target has a concrete inline fallback — but specialist quality is fallback-quality, not dedicated-skill-quality.
+
+**Second-stage verify (proves the runtime gate is firing — i.e. `hooks/gateguard.mjs` is invoked — not just docs claiming it).** Ask Claude to write a throwaway file with no research first:
+
+```
+Edit a new file scratch.txt and put the word "hello" in it. Don't research anything first.
+```
+
+You should see Claude **blocked** by the bundled `gateguard` PreToolUse hook (`hooks/gateguard.mjs`) with a fact-list reason. That block is the proof the hook is wired and enforcing. If Claude writes the file with no pause, the hook did not load — see Troubleshooting below. (To also verify observation hooks, run `/dashboard` and confirm a non-zero `Total` under `Observations`.)
+
+</details>
+
+<details>
+<summary><b>How enforcement works (two layers: runtime hooks + model-side skills)</b></summary>
+
+The 7 Laws are enforced at **two layers**:
+
+- **Runtime layer (hooks).** `gateguard` ships as a PreToolUse hook (`hooks/gateguard.mjs`) that physically blocks Edit / Write / MultiEdit / destructive Bash on the first mutation per file until the agent presents the facts named in [skills/gateguard.md § Gate Types](skills/gateguard.md). Destructive Bash (`rm -rf`, `git push --force`, `--force-with-lease`, `DROP DATABASE`, Windows `Remove-Item -Recurse`, etc.) is gated on every call, not just first. Read-only and exploratory tools (Read, Grep, Glob, routine Bash like `git status`) bypass the gate. Per-session state at `~/.claude/instincts/<project-hash>/gateguard-session.json` caps cumulative clearances at 50 distinct files to bound stuck-loop damage. A second runtime hook, `goal-drift-stop` (`hooks/goal-drift-stop.mjs`), fires on `Stop`: it scores each turn against the stated `## Goal` and, on a substantive wrap-up that has drifted off-goal, warns by default (or re-prompts under `CLAUDE_GOAL_DRIFT_GATE=block`) — so a drifted session can't quietly declare "done". Fail-open.
+- **Model layer (skills).** Once the runtime gate clears for a file, the rest of the discipline (`tdd-workflow`, `verification-loop`, `proceed-with-the-recommendation`, etc.) runs model-side — the agent reads each skill and applies it. `observe.sh` / `observe.mjs` records every tool call into the Mulahazah feed for instinct extraction; that surface is observational, not enforcement.
+
+V1 honest limitations: the runtime gate is honor-system once the agent flips `_gateguard_facts_presented: true` (the hook can't verify the investigation actually happened); the state file is deletable and parallel hook invocations can race. Documented in `src/hooks/gateguard.mts` and `src/lib/gateguard-state.mts` headers.
+
+</details>
+
+<details>
+<summary><b>Expert install — MCP server, observation hooks, and instinct packs</b></summary>
+
+Pick this if you want the MCP tools (19 of them, including `ci_plan_init` / `ci_plan_status` for `task_plan.md`-style planning), the session hooks that feed Mulahazah, and starter packs.
+
+Preconditions: Node 18 / 20 / 22, plus bash on Windows (Git Bash or WSL — `hooks/observe.sh` is a bash script and silently no-ops without it). **`jq` is no longer required**: as of v3.6.0, `observe.sh` prefers the Node observer (`bin/observe.mjs`) which writes the rich event schema natively without external dependencies. The bash thin-schema path is kept as a two-phase shim, so legacy installs that have not re-run `npx continuous-improvement install` since v3.5.x will still degrade silently without `jq` (`winget install jqlang.jq` on Windows, `brew install jq` on macOS, `apt install jq` on Debian/Ubuntu) — re-running the installer is the cleaner fix and removes the dependency entirely. See [CHANGELOG.md](CHANGELOG.md) `[3.6.0]` for the migration details.
+
+```bash
+npx continuous-improvement install --mode expert
+npx continuous-improvement install --pack react   # optional: react | python | go | meta
+# --pack seeds 5–10 starter instincts so suggestions appear in week 1 instead of week 4.
+```
+
+Verify: run `/dashboard` in Claude Code — you should see instinct health and observation count.
+Update later with `/plugin marketplace update continuous-improvement` or by re-running the npx command. When you run the npx installer, it makes one throttled, fail-open read of the public npm registry and prints a one-line notice if a newer version is published (no telemetry — nothing about you is sent). Silence it with `CLAUDE_CI_UPDATE_CHECK=off`.
+
+</details>
+
+<details>
+<summary><b>Troubleshooting install</b></summary>
+
+Three failures account for nearly every install support thread. Try them in order:
+
+| Symptom | Real cause | Fix |
+|---|---|---|
+| `/discipline` says "command not recognized" right after `/plugin install` | Slash commands load on session start; the marketplace did pick the plugin up | Quit and reopen Claude Code, then run `/discipline` again |
+| Expert mode hooks never fire on Windows | `observe.sh` is bash; PowerShell silently no-ops on it | Install Git Bash (or WSL) and re-run `npx continuous-improvement install --mode expert` |
+| `/plugin marketplace add ...` returned nothing visible | Marketplace add was silent; the plugin is not yet selected | Run `/plugin install continuous-improvement@continuous-improvement` to select and activate it |
+
+If none of those apply, paste the output of `npx continuous-improvement install` into a GitHub issue — that surface logs every step.
+
+</details>
+
+<details>
+<summary><b>Operator modes (env vars that change hook behavior)</b></summary>
+
+The framework has documented operator-level modes that change hook behavior without rebuilding the plugin. These are first-class — set them once in your shell rc and they persist across sessions.
+
+| Env var | Effect | How to set |
+|---|---|---|
+| `CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` | `three-section-close.mjs` short-circuits before any enforcement or telemetry. Use when end-of-turn reflection should run as internal thinking rather than visible "What has been done / What is next / Recommendation" sections. Public default unchanged — the rule still fires for everyone else. | bash/zsh: `export CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_THREE_SECTION_CLOSE_DISABLED=1` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_THREE_SECTION_CLOSE_DISABLED','1','User')` (persistent). |
+| `CLAUDE_GOAL_DRIFT_GATE` | `goal-drift-stop.mjs` (a `Stop` hook) scores each turn's activity against the `## Goal` in `task_plan.md` and acts on drift. `warn` (default) prints a one-line stderr notice and never blocks; `block` re-prompts a substantive wrap-up that has drifted off-goal so the goal gates the close; `off` disables it. Reads the same observation feed as Mulahazah; fails open on any error. | bash/zsh: `export CLAUDE_GOAL_DRIFT_GATE=block` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_GOAL_DRIFT_GATE='block'` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_GOAL_DRIFT_GATE','block','User')` (persistent). |
+| `CLAUDE_RECALL_BRIEFING=1` | `hooks/recall-briefing.mjs` (a UserPromptSubmit hook) makes episodic memory proactive: on the first substantive prompt of a session it searches this project's past observations (BM25) and injects a one-time `<system-reminder>` with the most relevant prior activity, so the agent reuses a past fix instead of re-deriving it. Opt-in and default off; it is an amplifier, never a gate — it cannot block a prompt and fails open. The `ci_recall` MCP tool stays available for explicit, deeper searches. | bash/zsh: `export CLAUDE_RECALL_BRIEFING=1` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_RECALL_BRIEFING=1` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_RECALL_BRIEFING','1','User')` (persistent). |
+| `CLAUDE_WORKFLOW_DISTILL_NUDGE=on` | `hooks/workflow-distill.mjs` (a `Stop` hook) closes the orchestration-to-memory loop: when a native Workflow run's output then passed a verify in the same session, it prints a one-line stderr nudge to run the `ci_distill_from_workflow` MCP tool, so an expensive multi-agent run leaves a durable Mulahazah draft instinct instead of evaporating. `on` enables it; default (unset or any other value) is off. Opt-in amplifier, never a gate — it cannot block the Stop, dedupes per run, and fails open. | bash/zsh: `export CLAUDE_WORKFLOW_DISTILL_NUDGE=on` in `~/.bashrc` / `~/.zshrc`. PowerShell: `$env:CLAUDE_WORKFLOW_DISTILL_NUDGE='on'` (session) or `[Environment]::SetEnvironmentVariable('CLAUDE_WORKFLOW_DISTILL_NUDGE','on','User')` (persistent). |
+
+</details>
+
+<details>
+<summary><b>Works with other agents (Gemini, Codex, Cursor, Windsurf, Zed, Aider, Copilot)</b></summary>
+
+Claude Code gets the full install (hooks, MCP server, instinct learning). Every other agent platform can still run the 7 Laws as a rules file — one flag writes the skill text into the file that platform reads, at your project root:
+
+```bash
+npx continuous-improvement install --target gemini,codex
+```
+
+| Target | File written |
+|---|---|
+| `gemini` | `GEMINI.md` (Gemini CLI context file) |
+| `codex` | `AGENTS.md` (agents.md standard — also read by opencode, Jules, Cursor ≥0.50) |
+| `cursor` | `.cursor/rules/continuous-improvement.mdc` (`alwaysApply: true`) |
+| `windsurf` | `.windsurf/rules/continuous-improvement.md` |
+| `zed` | `.rules` |
+| `aider` | `CONVENTIONS.md` + a minimal `.aider.conf.yml` if none exists |
+| `copilot` | `.github/copilot-instructions.md` |
+
+Shared files (`GEMINI.md`, `AGENTS.md`, `.rules`, `CONVENTIONS.md`, `copilot-instructions.md`) are merged through a managed marker block — your existing content is preserved and reinstalls are idempotent. Targets can be combined freely (`--target claude,gemini,codex` runs the full Claude Code install plus the rules files).
+
+</details>
+
+---
+
+## Who this is for
+
+<details>
+<summary><b>Use it if you ship from real repos — skip it if you only do one-off prompts</b></summary>
+
+Use this if you:
+
+- ship from real repositories with real consequences
+- have been bitten by an agent that edits before understanding
+- want tests, builds, or healthchecks to pass before "done"
+- want lessons from yesterday to survive into today
+
+Skip it if you:
+
+- only do one-off prompts (no edits, no commits)
+- do not use Claude Code
+- dislike *any* friction before agent edits
+- want a prompt template, not a runtime gate
+
+(The runtime gate is `hooks/gateguard.mjs`; full mechanics in [How enforcement works](#install) above.)
+
+</details>
+
+---
+
+## The problem this solves
+
+<details>
+<summary><b>Five failure modes every agentic-coding user hits — and which Law catches each</b></summary>
+
+You have used Claude Code (or any agentic coding tool) long enough to recognize the failure pattern. Matt Pocock's [Skills For Real Engineers](https://github.com/mattpocock/skills) names four root failure modes that account for nearly every "the agent didn't help" complaint; the 7 Laws of AI Agent Discipline catch those four at the tool-call boundary plus a fifth that only shows up across sessions.
+
+| # | Failure mode | What you see | Which Law fires | What enforces it |
+|---|---|---|---|---|
+| 1 | **Misalignment** | The agent doesn't do what you want — invents requirements, reinvents helpers that already exist, or builds the wrong thing before anyone challenged the idea | Law 1 (Research) | [`roast`](skills/roast.md), [`grill-me`](skills/grill-me.md), [`grill-with-docs`](skills/grill-with-docs.md), [`gateguard`](skills/gateguard.md), [`workspace-surface-audit`](skills/workspace-surface-audit.md) |
+| 2 | **No shared language** | The agent uses 20 words where 1 would do; jargon decoded fresh every session; variable names drift from domain terms | Law 2 (Plan), Law 7 (Learn) | [`grill-with-docs`](skills/grill-with-docs.md) (writes & maintains `CONTEXT.md`), [`token-budget-advisor`](skills/token-budget-advisor.md), [`strategic-compact`](skills/strategic-compact.md) |
+| 3 | **No feedback loop** | The code doesn't work — agent claims "done" without running build, tests, or healthcheck | Law 4 (Verify) | [`tdd-workflow`](skills/tdd-workflow.md), [`verification-loop`](skills/verification-loop.md), [`deploy-receipt`](skills/deploy-receipt.md) |
+| 4 | **Design rot** | Ball-of-mud accelerates — agent bundles three concerns into one PR, stacks untested changes, ignores prior architectural decisions | Law 2 (Plan), Law 3 (One Thing) | [`superpowers:writing-plans`](https://github.com/obra/superpowers/blob/main/skills/writing-plans/SKILL.md), [`safety-guard`](skills/safety-guard.md), [`worktree-safety`](skills/worktree-safety.md), [`wild-risa-balance`](skills/wild-risa-balance.md) |
+| 5 | **Forgotten lessons** | Next session starts from zero — prior corrections, decisions, instincts are lost; the same mistake repeats next week | Law 5 (Reflect), Law 7 (Learn) | [`handoff`](skills/handoff.md), Mulahazah instinct engine |
+
+Three of those alignment + reflection skills (`grill-me`, `grill-with-docs`, `handoff`) are MIT-licensed ports from mattpocock/skills; the rest are continuous-improvement-native. Every failure mode has at least one runtime hook or model-side skill that catches it before it lands in the diff.
+
+</details>
+
+---
+
 ## Mulahazah: auto-leveling learning
+
+<details>
+<summary><b>How instincts form, level up, and decay — you configure nothing</b></summary>
 
 Hooks capture every tool call. After ~20 observations Claude analyzes patterns and creates **instincts** with confidence scores: silent below 0.5, suggested at 0.5–0.69, auto-applied at 0.7+. Corrections drop confidence by 0.1; unused instincts decay. Project-scoped; promoted to global after seen across 2+ projects. You configure nothing.
 
@@ -228,9 +257,14 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
   <img src="assets/diagram-mulahazah-learning.jpg" alt="Mulahazah pipeline" width="820" />
 </p>
 
+</details>
+
 ---
 
-## Slash Commands
+## Slash commands
+
+<details>
+<summary><b>All 18 commands (Beginner gets every one)</b></summary>
 
 `/seven-laws` is the canonical reflect-and-learn command. `/continuous-improvement` is kept as an alias for backward compatibility — both run the same workflow.
 
@@ -257,6 +291,8 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
 
 All 18 ship in the marketplace bundle. The Beginner install gets all of them — with one caveat: `/learn-eval` and `/harvest` only produce useful output once Mulahazah has accumulated observation history (~20 observations), so running them on day 1 returns an empty result, not a broken command. `/swarm` and `/release-train` are orchestration commands aimed at larger multi-agent or multi-PR work. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
 
+</details>
+
 ---
 
 ## Skills
@@ -280,7 +316,20 @@ Catches writes without prior research (Law 1), too many edits without verificati
 
 ---
 
-## Uninstall
+## More
+
+- [QUICKSTART.md](QUICKSTART.md) — 2-minute setup
+- [SKILL.md](SKILL.md) — full 7 Laws spec
+- [docs/skills.md](docs/skills.md) — full 27-skill catalog
+- [examples/](examples/) — bug fix, feature build, refactor walkthroughs
+- [templates/insights-claude-md.md](templates/insights-claude-md.md) — paste-in CLAUDE.md blocks for verification discipline, environment notes, think-before-acting, and git/deploy workflow (sourced from the 28-day usage report)
+- [CONTRIBUTING.md](CONTRIBUTING.md) — architecture, repo internals, adding a new skill
+- [SECURITY.md](SECURITY.md)
+
+<details>
+<summary><b>Uninstall · the brand stack · in the wild</b></summary>
+
+### Uninstall
 
 ```bash
 npx continuous-improvement install --uninstall
@@ -288,9 +337,7 @@ npx continuous-improvement install --uninstall
 
 Removes skill, hooks, commands, MCP server. Learned instincts in `~/.claude/instincts/` are preserved — delete manually for a clean slate.
 
----
-
-## The Brand Stack
+### The brand stack
 
 One product, three names. Use the one that fits the audience:
 
@@ -302,28 +349,12 @@ One product, three names. Use the one that fits the audience:
 
 Every skill description leads with `Enforces Law N (...)` so the discipline tag shows up the moment the skill is loaded; the lint `verify:skill-law-tag` blocks any skill that drops the tag.
 
----
-
-## In the wild
+### In the wild
 
 Workflows from this repo, applied to real open-source contributions:
 
-### pm-skills (product-on-purpose, Apache 2.0)
+**pm-skills (product-on-purpose, Apache 2.0)** — [F-07 discover-market-sizing](https://github.com/product-on-purpose/pm-skills/pull/141), a new domain skill in the Discover phase covering TAM/SAM/SOM market sizing for the [pm-skills](https://github.com/product-on-purpose/pm-skills) library. Authored end-to-end with `/superpowers` and `/proceed-with-the-recommendation`: surface audit before any code, brainstorm gate with WILD/RISA framing, branch isolation off the upstream fork, single-skill PR scope per the upstream maintainer's curated-contributions model, count cascade across 23 docs files, and 9 local validators green before push.
 
-[F-07 discover-market-sizing](https://github.com/product-on-purpose/pm-skills/pull/141) - new domain skill in the Discover phase covering TAM/SAM/SOM market sizing for the [pm-skills](https://github.com/product-on-purpose/pm-skills) library.
-
-Authored end-to-end with `/superpowers` and `/proceed-with-the-recommendation`: surface audit before any code, brainstorm gate with WILD/RISA framing, branch isolation off the upstream fork, single-skill PR scope per the upstream maintainer's curated-contributions model, count cascade across 23 docs files, and 9 local validators green before push (`lint-skills-frontmatter`, `validate-agents-md`, `validate-commands`, `check-count-consistency`, `check-nav-completeness`, `check-generated-content-untouched`, `check-generated-freshness`, `validate-meeting-skills-family`, `validate-plugin-install`).
-
----
-
-## More
-
-- [QUICKSTART.md](QUICKSTART.md) — 2-minute setup
-- [SKILL.md](SKILL.md) — full 7 Laws spec
-- [docs/skills.md](docs/skills.md) — full 27-skill catalog
-- [examples/](examples/) — bug fix, feature build, refactor walkthroughs
-- [templates/insights-claude-md.md](templates/insights-claude-md.md) — paste-in CLAUDE.md blocks for verification discipline, environment notes, think-before-acting, and git/deploy workflow (sourced from the 28-day usage report)
-- [CONTRIBUTING.md](CONTRIBUTING.md) — architecture, repo internals, adding a new skill
-- [SECURITY.md](SECURITY.md)
+</details>
 
 MIT.

--- a/docs/plans/2026-06-28-readme-progressive-disclosure.md
+++ b/docs/plans/2026-06-28-readme-progressive-disclosure.md
@@ -1,0 +1,59 @@
+# README progressive-disclosure rewrite + discoverability tuning
+
+Date: 2026-06-28
+Slug: readme-progressive-disclosure
+Supersedes the landing rationale in `docs/plans/2026-05-14-readme-landing-rewrite.md` (structure kept, depth collapsed).
+
+## Task (one sentence)
+
+Make the README easy to scan by keeping the value prop + quick start above the fold and pushing reference depth behind collapsible `<details>` blocks, and lift repo discoverability with research-backed, low-risk metadata fixes.
+
+## Why
+
+A `/deep-research` sweep (6 agents, cited) confirmed:
+
+- The README is the single highest-leverage discovery asset: it is the only repo content Google reliably indexes, it is the rendered npmjs.com landing page, and it is the conversion surface after topic/marketplace discovery ([GitHub Docs — About READMEs](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)).
+- Canonical structure: logo + one-line value prop + ~4 functional badges + copy-paste quick start in the first viewport, then features/usage/config/contributing; keep the scannable surface tight and link out for depth.
+- Progressive disclosure: keep the first screen expanded; collapse secondary material (config matrix, troubleshooting, FAQ, long command/skill lists). Collapsed text is still indexed by GitHub code search, so depth is preserved with no SEO loss ([GitHub Docs — collapsed sections](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-collapsed-sections)).
+- npm retired its quality/popularity/maintenance scores in Dec 2024; search is now objective word-match relevance + downloads + dependents + recency. The description's first sentence is the surfaced snippet ([GitHub Changelog](https://github.blog/changelog/2024-12-02-announcing-npms-new-simplified-search-experience-ga/)).
+- GitHub topics are already 19/20 (not the gap). The About description is the top controllable ranking field and currently carries a grammar bug ("Agents that gets sharper").
+
+## Collapsible render rules (locked, from research)
+
+1. Blank line immediately after every `</summary>` (highest-frequency render bug).
+2. Descriptive `<summary>` labels ("Expert install — MCP server + hooks", not "Click here").
+3. One flat layer only; never nest `<details>` inside `<details>`.
+4. `<details open>` only for must-see-but-long content.
+
+## Invariants the rewrite MUST preserve (CI gates)
+
+Verbatim tokens that must remain somewhere in `README.md` (collapsed content counts — checks read raw file text):
+
+- `If you don't know which to pick, use Beginner.` (docs-substrings)
+- `planning-with-files`, `task_plan.md`, `ci_plan_init` (docs-substrings)
+- `27 skills`, `1 core + 1 featured + 6 tier-1 + 16 tier-2 + 3 always-bundled`, `28th skill` (skill-count-prose)
+- Any line containing "physically block" / "PreToolUse hook" / "runtime gate" needs a `hooks/<name>.mjs` reference within ±5 lines (doc-runtime-claims).
+
+`README.md` is NOT part of the `plugins/` mirror and does not feed `verify:generated`, so this change is isolated.
+
+## Plan
+
+1. Branch `docs/readme-progressive-disclosure` off clean `main`. (done)
+2. This plan doc. (done)
+3. Rewrite `README.md`:
+   - Above the fold: hero GIF, H1, value prop, ~5 functional badges (swap the static "tests passing" vanity badge for a real npm-downloads badge), New-here pointer, copy-paste quick start + the Beginner decision rule.
+   - Keep expanded: What this does (3 layers), See it in action (before/after), The 7 Laws table + loop diagram, Skills one-liner, GitHub Action, More/links.
+   - Collapse behind `<details>`: Who this is for, The problem this solves (5-mode table), How enforcement works, Expert install, Troubleshooting, Operator modes, Works with other agents, Mulahazah, Slash commands, Uninstall, Brand stack, In the wild.
+4. `npm run verify:all` green (content invariants + typecheck).
+5. Commit (cite this plan), push, open PR.
+6. Direct (not git): fix the GitHub About description via `gh repo edit` to a keyword-led, grammatical, readable string.
+
+## Deferred to a follow-up (logged, not dropped)
+
+- npm `keywords` + first-sentence `description` tuning in `package.json` — feeds generated manifests, so it carries a `verify:generated` blast radius; ship as its own single-concern PR.
+- Social preview image (1280×640 PNG <1MB) — must be uploaded in repo Settings UI; no API.
+- Submit to community awesome-lists / Claude Code marketplaces for backlinks + star velocity.
+
+## Verification
+
+`npm run verify:all` must print OK for skill-count-prose, docs-substrings, doc-runtime-claims, and typecheck (plus the other 10 invariants unaffected). No "should work" — paste the passing output.


### PR DESCRIPTION
## What & why

Make the README easy to scan and lift repo discoverability, grounded in a `/deep-research` sweep (6 cited agents) on 2026 README + GitHub/npm discovery best practice.

The README is the highest-leverage discovery asset — the only repo content Google reliably indexes, the rendered npmjs.com landing page, and the conversion surface after topic/marketplace discovery. The old README was strong but ~330 lines fully expanded, so the value prop and quick start sat below a wall of reference depth.

## Changes

- **Above the fold now:** hero GIF, H1, value prop, 5 functional badges, copy-paste quick start with the Beginner decision rule. Swapped the static "tests passing" vanity badge for a real npm-downloads badge (downloads are now an actual npm search-sort signal since npm retired its quality/popularity scores in Dec 2024).
- **Stays expanded** (must-see): What this does, See it in action (before/after), the 7 Laws + loop diagram, Skills, GitHub Action, More/links.
- **Collapsed behind one flat layer of `<details>`** (reference depth): enforcement internals, optional companion, Expert install, troubleshooting, operator modes, other-agent targets, the 5-failure-mode table, Mulahazah, the 18 slash commands, uninstall/brand-stack/in-the-wild.
- Collapsible render rules followed: blank line after every `</summary>`, descriptive `<summary>` labels, no nested `<details>`. Collapsed text is still indexed by GitHub code search, so depth is preserved with no SEO loss.

## Invariants

All 14 `verify:all` gates green, including the README-coupled ones: `skill-count-prose` (27 skills / breakdown / 28th), `docs-substrings` (Beginner decision rule, `planning-with-files`, `task_plan.md`, `ci_plan_init`), and `doc-runtime-claims` (every "physically block / PreToolUse hook / runtime gate" line keeps its `hooks/<name>.mjs` anchor within ±5 lines). README is not part of the `plugins/` mirror, so `verify:generated` is unaffected.

## Plan / research

`docs/plans/2026-06-28-readme-progressive-disclosure.md` (cites the sources).

## Follow-ups (deferred, logged in the plan doc)

- npm `keywords` + first-sentence `description` tuning in `package.json` (carries a `verify:generated` blast radius, so its own PR).
- 1280x640 social-preview image (Settings UI only, no API).
- Submit to community awesome-lists / Claude Code marketplaces for backlinks + star velocity.

## Separately (not in this PR)

The GitHub About description grammar bug ("Agents that gets sharper") is being fixed directly via repo settings, not a git change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
