### PR TITLE
docs(readme): list all 28 slash commands + fix stale repo-map counts

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
 ## Slash commands
 
 <details>
-<summary><b>All 18 commands (Beginner gets every one)</b></summary>
+<summary><b>All 28 commands (Beginner gets every one)</b></summary>
 
 `/seven-laws` is the canonical reflect-and-learn command. `/continuous-improvement` is kept as an alias for backward compatibility — both run the same workflow.
 
@@ -278,22 +278,32 @@ Hooks capture every tool call. After ~20 observations Claude analyzes patterns a
 /proceed-with-the-recommendation  Walk any agent's recommendation list top-to-bottom
 /superpowers                      Law activator — route the task to the right specialist
 /workspace-surface-audit          Audit repo + MCP + env, recommend high-value skills
-/planning-with-files              Create task_plan.md, findings.md, progress.md
+/roast                            5-persona adversarial council — GO / RESHAPE / KILL on an idea
 /grill-me                         Interview-mode alignment (one question at a time)
 /grill-with-docs                  Grill-me with persistent outcomes — updates CONTEXT.md + ADRs inline
+/intent-driven-development        Scope an ambiguous change into verifiable acceptance criteria
+/planning-with-files              Create task_plan.md, findings.md, progress.md
+/goal-check                       Score recent activity against the task_plan.md goal (drift detector)
+/reconcile                        Establish git ground truth before any mutation; verify a push landed
+/audit                            Audit recent commits for real defects, confirm each before fixing
+/ship                             Single-defect fast path — reconcile, TDD fix, verify, one PR
+/production-readiness-review      Parallel readiness gate — severity-ranked punch-list (reports only)
 /handoff                          End-of-session compaction into mktemp brief for the next agent
+/recall                           BM25 search over past observations — "have I hit this before?"
 /discipline                       Quick reference card of the 7 Laws
+/model-forward                    Restate the model-forward stance — go with the model, not against it
 /verify-install                   One-shot post-install check — commands, gateguard, observe
 /dashboard                        Visual instinct health dashboard
 /companion-preference             Inspect companion-preference hook telemetry
 /ralph                            Autonomous PRD story-by-story loop
 /learn-eval                       Capture session patterns into new skills (needs observation history)
 /harvest                          Extract reusable patterns from session friction (needs observation history)
+/distill                          Distill repeated successful sequences into draft instincts (needs observation history)
 /release-train                    Coordinate a multi-PR release sequence
 /swarm                            Fan-out coordination across parallel sub-agents
 ```
 
-All 18 ship in the marketplace bundle. The Beginner install gets all of them — with one caveat: `/learn-eval` and `/harvest` only produce useful output once Mulahazah has accumulated observation history (~20 observations), so running them on day 1 returns an empty result, not a broken command. `/swarm` and `/release-train` are orchestration commands aimed at larger multi-agent or multi-PR work. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
+All 28 ship in the marketplace bundle. The Beginner install gets all of them — with one caveat: `/learn-eval`, `/harvest`, and `/distill` only produce useful output once Mulahazah has accumulated observation history (~20 observations), so running them on day 1 returns an empty result, not a broken command. `/swarm` and `/release-train` are orchestration commands aimed at larger multi-agent or multi-PR work. In Expert (`npx`) mode, the installer mirrors the full set into `~/.claude/commands/` and additionally exposes the planning workflow through the MCP tools `ci_plan_init` (initialize `task_plan.md`, `findings.md`, `progress.md` in the project root) and `ci_plan_status` (summarize their current contents).
 
 </details>
 

--- a/docs/ai-improvement/README.md
+++ b/docs/ai-improvement/README.md
@@ -61,8 +61,8 @@ The package is positioned as an AI-agent reliability layer. Business value comes
 |---|---|---|
 | `package.json` | npm package metadata, CLI bins, verification scripts | Version `3.14.0`; zero runtime dependencies; dev dependency on TypeScript and Node types. |
 | `README.md`, `QUICKSTART.md`, `SKILL.md` | User-facing product narrative and 7 Laws operating spec | README is landing-page style; Quickstart optimizes beginner install; root skill is the core rule set. |
-| `skills/` | Source skills bundled into plugin | 24 companion skill markdown files plus README; root `SKILL.md` is the core skill. Mirrored into plugin bundle by build. |
-| `commands/` | Claude slash-command source files | 24 command files including `/seven-laws`, `/verify-install`, `/dashboard`, `/goal-check`, `/distill`. |
+| `skills/` | Source skills bundled into plugin | 26 companion skill markdown files plus README; root `SKILL.md` is the core skill. Mirrored into plugin bundle by build. |
+| `commands/` | Claude slash-command source files | 28 command files including `/seven-laws`, `/intent-driven-development`, `/dashboard`, `/goal-check`, `/distill`. |
 | `agents/` | Claude subagent personas | Code reviewer, security auditor, test engineer, plus README. |
 | `src/bin/` | TypeScript source for CLIs/generators/MCP server | 25 `.mts` entrypoints including installer, linter, manifest generator, MCP server, plan-pack, checks. |
 | `src/lib/` | Pure/shared runtime logic | Goal scoring, recall indexing, skill distillation, gateguard state, install targets, metadata. |


### PR DESCRIPTION
## What

The README "Slash commands" section claimed "All 18 commands" and listed 18, but the repo and plugin bundle both ship 28. The list was missing 10 commands, including `/intent-driven-development` (shipped in v3.17.0, PR #258). This reconciles the list plus two stale counts in the secondary repo-map doc.

## Why

A user reported `/intent-driven-development` was absent from the README. Investigation found the cause is broader than one skill: the command list silently drifted to 18 while 28 shipped, because no command-count verify check guards it.

## Changes

**README.md**
- "All 18 commands" -> "All 28 commands" (summary header + body sentence)
- Added the 10 missing commands: `audit`, `distill`, `goal-check`, `intent-driven-development`, `model-forward`, `production-readiness-review`, `recall`, `reconcile`, `roast`, `ship`
- Added `/distill` to the observation-history caveat

**docs/ai-improvement/README.md** (Current Repo Map)
- `24` -> `28` command files
- `24` -> `26` companion skill markdown files (26 companions + 1 core `SKILL.md` = 27 bundled)

## Verification

- `npm run build` clean, no generated-tree drift
- `npm run verify:all` green: 14 content invariants + typecheck
- Adversarial verification workflow (5 agents): a completeness sweep across README / QUICKSTART / SKILL / docs / CONTRIBUTING / llms.txt / plugin docs, plus a source-checked accuracy review of all 10 new descriptions. It caught and I fixed: `/ship` first step is `reconcile` not "audit" (the bare "audit" collided with the sibling `/audit`); `/distill` filters repeated *successful* sequences; and the two stale repo-map counts above.

## Scope notes

- `llms.txt`, `skills/README.md`, and the plugin README do not enumerate the full command/skill set (prose or a curated subset that says so), so none needed changes.
- The `docs/ai-improvement` repo map carries other stale snapshot values (version `3.14.0`, entrypoint/test counts) on a different staleness axis. Left untouched here.

## Recommended follow-up

No verify check exists for the command count, which is why this drifted. A `check-command-count.mjs` invariant (README-listed commands == `ls commands/*.md`) wired into `verify:all` would prevent recurrence. Separate single-concern PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
