### PR TITLE
feat(verify): guard the README slash-command list with a check-command-count invariant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ Project-local rules for AI coding agents. Global rules live in `~/.claude/CLAUDE
 
 ## Verification Discipline
 
-- After any code change, run `npm run verify:all` (13 content invariants + typecheck: skill-mirror, skill-tiers, skill-law-tag, skill-count, skill-count-prose, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims, test-imports-only, scripts-citation-drift, third-party-shape, tool-count, typecheck). Anything below that is incomplete.
+- After any code change, run `npm run verify:all` (14 content invariants + typecheck: skill-mirror, skill-tiers, skill-law-tag, skill-count, skill-count-prose, command-count, docs-substrings, everything-mirror, routing-targets, doc-runtime-claims, test-imports-only, scripts-citation-drift, third-party-shape, tool-count, typecheck). Anything below that is incomplete.
 - For doc-only or template-only changes, `npm run typecheck` is the floor.
 - Run all commands from repo root. Verify CWD with `pwd` if a previous step may have changed it.
 - Never claim "verified" or "done" without the passing output. Silence is not a pass.

--- a/bin/check-command-count.mjs
+++ b/bin/check-command-count.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Command Count Check
+ *
+ * The README "## Slash commands" section is hand-maintained: a fenced list of
+ * `/command  description` lines plus "All N commands" / "All N ship" count
+ * claims. The skill count is guarded (check-skill-count, check-skill-count-prose)
+ * but the command count was not — it silently drifted to "18" while 28 commands
+ * shipped (reconciled by hand in PR #263). This lint locks the README list and
+ * its count claims to the actual shipped command set so the drift cannot recur.
+ *
+ * Source of truth: `commands/*.md` (flat source, excluding README.md) — the set
+ * a contributor edits when adding a command. `npm run build` mirrors it into the
+ * bundle and `verify:everything-mirror` already guarantees parity.
+ *
+ * The check asserts, against the README "## Slash commands" section:
+ *   1. set parity — the fenced `/command` lines equal the commands/*.md set
+ *      (reports `missing` = shipped-but-unlisted, `extra` = listed-but-unshipped)
+ *   2. count claims — every "All N commands" / "All N ship" number equals the
+ *      actual command count
+ *
+ * Fail-closed: a missing section, an empty list, or a missing count claim each
+ * produce a violation rather than a silent pass.
+ *
+ * Usage:
+ *   node bin/check-command-count.mjs              # Check the current repo
+ *   node bin/check-command-count.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — README lists every shipped command and every count claim matches
+ *   1 — at least one command missing/extra, or a count claim is stale/missing
+ */
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+const COMMANDS_DIR = "commands";
+const README = "README.md";
+export function listCommandFiles(repoRoot) {
+    return readdirSync(join(repoRoot, COMMANDS_DIR))
+        .filter((f) => f.endsWith(".md") && f !== "README.md")
+        .map((f) => f.slice(0, -3))
+        .sort();
+}
+export function parseReadmeSlashCommands(content) {
+    // Locate the "## Slash commands" section: from its heading to the next H2 (or EOF).
+    const heading = /^##\s+Slash commands\s*$/im.exec(content);
+    if (!heading)
+        return { hasSection: false, listed: [], counts: [] };
+    const rest = content.slice(heading.index + heading[0].length);
+    const nextH2 = /^##\s+/m.exec(rest);
+    const section = nextH2 ? rest.slice(0, nextH2.index) : rest;
+    // Listed commands: lines that begin with "/<name>" at column 0 (the fenced list).
+    const listed = [...section.matchAll(/^\/([a-z][a-z0-9-]*)/gm)].map((m) => m[1]);
+    // Count claims: "All N commands" / "All N ship".
+    const counts = [...section.matchAll(/All (\d+) (?:commands|ship)/g)].map((m) => Number(m[1]));
+    return { hasSection: true, listed, counts };
+}
+export function findViolations(actualNames, parsed) {
+    if (!parsed.hasSection) {
+        return ["README has no '## Slash commands' section — cannot verify the command list."];
+    }
+    const violations = [];
+    if (parsed.listed.length === 0) {
+        violations.push("the '## Slash commands' section lists no commands (expected the fenced /command block).");
+    }
+    const actual = new Set(actualNames);
+    const listed = new Set(parsed.listed);
+    for (const name of actualNames) {
+        if (!listed.has(name))
+            violations.push(`missing: /${name} ships in commands/ but is not listed in the README.`);
+    }
+    for (const name of parsed.listed) {
+        if (!actual.has(name))
+            violations.push(`extra: /${name} is listed in the README but has no commands/${name}.md.`);
+    }
+    if (parsed.counts.length === 0) {
+        violations.push("no 'All N commands' count claim found in the section.");
+    }
+    for (const n of parsed.counts) {
+        if (n !== actualNames.length) {
+            violations.push(`count claim states ${n} but commands/ ships ${actualNames.length}.`);
+        }
+    }
+    return violations;
+}
+function main() {
+    const repoRoot = argv[2] ?? cwd();
+    const actual = listCommandFiles(repoRoot);
+    let content;
+    try {
+        content = readFileSync(join(repoRoot, README), "utf8");
+    }
+    catch {
+        console.error(`FAIL command-count: cannot read ${README} at ${repoRoot}.`);
+        exit(1);
+    }
+    const parsed = parseReadmeSlashCommands(content);
+    const violations = findViolations(actual, parsed);
+    if (violations.length === 0) {
+        console.log(`OK command-count: README lists all ${actual.length} command(s) and every count claim matches commands/.`);
+        exit(0);
+    }
+    console.error(`FAIL command-count: ${violations.length} issue(s) between the README "Slash commands" section and commands/.`);
+    console.error("");
+    for (const v of violations)
+        console.error(`  ${v}`);
+    console.error("");
+    console.error("Fix: update the README '## Slash commands' fenced list and its 'All N commands' / 'All N ship' counts to match commands/*.md.");
+    exit(1);
+}
+const invokedDirectly = argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-command-count.mjs")) {
+    main();
+}

--- a/docs/plans/2026-06-28-command-count-invariant.md
+++ b/docs/plans/2026-06-28-command-count-invariant.md
@@ -1,0 +1,50 @@
+# Plan: `check-command-count` verify invariant
+
+Date: 2026-06-28
+Branch: `feat/check-command-count-invariant`
+
+## Problem
+
+The README "Slash commands" section is hand-maintained: a fenced list of `/command  description` lines plus "All N commands" / "All N ship" count claims. The skill count is guarded (`check-skill-count`, `check-skill-count-prose`) but the **command count is not**. It silently drifted to "18" while 28 commands shipped; PR #263 reconciled it by hand. Without an invariant it will drift again on the next command added.
+
+## Goal
+
+Add `verify:command-count` to `verify:all` so the README can never under- or over-state the shipped slash-command set again.
+
+## Source of truth
+
+`commands/*.md` (flat source, excluding `README.md`) — the set a contributor edits when adding a command, mirrored into the bundle by `npm run build` and already parity-checked by `verify:everything-mirror`.
+
+## What the check asserts
+
+Against the README "## Slash commands" section:
+
+1. **Set parity** — the `/command` lines in the fenced block equal the `commands/*.md` set. Reports `missing` (shipped but not listed) and `extra` (listed but not shipped).
+2. **Count claims** — every `All N commands` / `All N ship` number in the section equals the actual command count.
+
+Fail-closed on malformed input: no `## Slash commands` section, no listed commands, or no count claim each produce a violation rather than a silent pass (per the 2026-06-03 boundary-test lesson).
+
+## Shape (mirrors `check-skill-count.mts`)
+
+- `listCommandFiles(repoRoot): string[]` — sorted command names from `commands/`.
+- `parseReadmeSlashCommands(content): { hasSection, listed, counts }` — pure, unit-testable without the filesystem.
+- `findViolations(actualNames, parsed): string[]` — empty array = pass.
+- `main()` — `OK command-count: ...` / `FAIL command-count: ...`, exit 0/1. Windows-safe `endsWith(".mjs")` main-guard.
+
+## Files
+
+- `src/bin/check-command-count.mts` (source) → `bin/check-command-count.mjs` (generated, +x)
+- `src/test/check-command-count.test.mts` (source) → `test/check-command-count.test.mjs` (generated)
+- `package.json` — `verify:command-count` script + insert into `verify:all` chain
+- `CLAUDE.md` — invariant list 13 → 14 content invariants
+
+## Verification
+
+- TDD: edge-case tests RED first, then implement to GREEN.
+- `npm run build` + `git diff --exit-code` clean (generated pair committed).
+- `npm run verify:all` green with the new check in the chain.
+- `npm test` full suite green.
+
+## Out of scope
+
+`docs/ai-improvement/README.md` repo-map counts (carry other stale snapshots on a separate axis — version, entrypoint/test counts). Not coupled to this invariant.

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "verify:skill-law-tag": "node bin/check-skill-law-tag.mjs",
     "verify:skill-count": "node bin/check-skill-count.mjs",
     "verify:skill-count-prose": "node bin/check-skill-count-prose.mjs",
+    "verify:command-count": "node bin/check-command-count.mjs",
     "verify:docs-substrings": "node bin/check-docs-substrings.mjs",
     "verify:everything-mirror": "node bin/check-everything-mirror.mjs",
     "verify:routing-targets": "node bin/check-routing-targets.mjs",
@@ -56,7 +57,7 @@
     "verify:scripts-citation-drift": "node bin/check-scripts-citation-drift.mjs",
     "verify:third-party-shape": "node bin/check-third-party-shape.mjs",
     "verify:tool-count": "node bin/check-tool-count.mjs",
-    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:skill-count-prose && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run verify:test-imports-only && npm run verify:scripts-citation-drift && npm run verify:third-party-shape && npm run verify:tool-count && npm run typecheck"
+    "verify:all": "npm run verify:skill-mirror && npm run verify:skill-tiers && npm run verify:skill-law-tag && npm run verify:skill-count && npm run verify:skill-count-prose && npm run verify:command-count && npm run verify:docs-substrings && npm run verify:everything-mirror && npm run verify:routing-targets && npm run verify:doc-runtime-claims && npm run verify:test-imports-only && npm run verify:scripts-citation-drift && npm run verify:third-party-shape && npm run verify:tool-count && npm run typecheck"
   },
   "files": [
     ".claude-plugin/",

--- a/src/bin/check-command-count.mts
+++ b/src/bin/check-command-count.mts
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+/**
+ * Command Count Check
+ *
+ * The README "## Slash commands" section is hand-maintained: a fenced list of
+ * `/command  description` lines plus "All N commands" / "All N ship" count
+ * claims. The skill count is guarded (check-skill-count, check-skill-count-prose)
+ * but the command count was not — it silently drifted to "18" while 28 commands
+ * shipped (reconciled by hand in PR #263). This lint locks the README list and
+ * its count claims to the actual shipped command set so the drift cannot recur.
+ *
+ * Source of truth: `commands/*.md` (flat source, excluding README.md) — the set
+ * a contributor edits when adding a command. `npm run build` mirrors it into the
+ * bundle and `verify:everything-mirror` already guarantees parity.
+ *
+ * The check asserts, against the README "## Slash commands" section:
+ *   1. set parity — the fenced `/command` lines equal the commands/*.md set
+ *      (reports `missing` = shipped-but-unlisted, `extra` = listed-but-unshipped)
+ *   2. count claims — every "All N commands" / "All N ship" number equals the
+ *      actual command count
+ *
+ * Fail-closed: a missing section, an empty list, or a missing count claim each
+ * produce a violation rather than a silent pass.
+ *
+ * Usage:
+ *   node bin/check-command-count.mjs              # Check the current repo
+ *   node bin/check-command-count.mjs <repo-root>  # Check a specific repo root
+ *
+ * Exit codes:
+ *   0 — README lists every shipped command and every count claim matches
+ *   1 — at least one command missing/extra, or a count claim is stale/missing
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import { argv, cwd, exit } from "node:process";
+
+const COMMANDS_DIR = "commands";
+const README = "README.md";
+
+export function listCommandFiles(repoRoot: string): string[] {
+  return readdirSync(join(repoRoot, COMMANDS_DIR))
+    .filter((f) => f.endsWith(".md") && f !== "README.md")
+    .map((f) => f.slice(0, -3))
+    .sort();
+}
+
+export interface ParsedSlashCommands {
+  hasSection: boolean;
+  listed: string[];
+  counts: number[];
+}
+
+export function parseReadmeSlashCommands(content: string): ParsedSlashCommands {
+  // Locate the "## Slash commands" section: from its heading to the next H2 (or EOF).
+  const heading = /^##\s+Slash commands\s*$/im.exec(content);
+  if (!heading) return { hasSection: false, listed: [], counts: [] };
+  const rest = content.slice(heading.index + heading[0].length);
+  const nextH2 = /^##\s+/m.exec(rest);
+  const section = nextH2 ? rest.slice(0, nextH2.index) : rest;
+
+  // Listed commands: lines that begin with "/<name>" at column 0 (the fenced list).
+  const listed = [...section.matchAll(/^\/([a-z][a-z0-9-]*)/gm)].map((m) => m[1]);
+  // Count claims: "All N commands" / "All N ship".
+  const counts = [...section.matchAll(/All (\d+) (?:commands|ship)/g)].map((m) => Number(m[1]));
+
+  return { hasSection: true, listed, counts };
+}
+
+export function findViolations(actualNames: string[], parsed: ParsedSlashCommands): string[] {
+  if (!parsed.hasSection) {
+    return ["README has no '## Slash commands' section — cannot verify the command list."];
+  }
+  const violations: string[] = [];
+  if (parsed.listed.length === 0) {
+    violations.push("the '## Slash commands' section lists no commands (expected the fenced /command block).");
+  }
+  const actual = new Set(actualNames);
+  const listed = new Set(parsed.listed);
+  for (const name of actualNames) {
+    if (!listed.has(name)) violations.push(`missing: /${name} ships in commands/ but is not listed in the README.`);
+  }
+  for (const name of parsed.listed) {
+    if (!actual.has(name)) violations.push(`extra: /${name} is listed in the README but has no commands/${name}.md.`);
+  }
+  if (parsed.counts.length === 0) {
+    violations.push("no 'All N commands' count claim found in the section.");
+  }
+  for (const n of parsed.counts) {
+    if (n !== actualNames.length) {
+      violations.push(`count claim states ${n} but commands/ ships ${actualNames.length}.`);
+    }
+  }
+  return violations;
+}
+
+function main(): void {
+  const repoRoot = argv[2] ?? cwd();
+  const actual = listCommandFiles(repoRoot);
+
+  let content: string;
+  try {
+    content = readFileSync(join(repoRoot, README), "utf8");
+  } catch {
+    console.error(`FAIL command-count: cannot read ${README} at ${repoRoot}.`);
+    exit(1);
+  }
+
+  const parsed = parseReadmeSlashCommands(content);
+  const violations = findViolations(actual, parsed);
+
+  if (violations.length === 0) {
+    console.log(
+      `OK command-count: README lists all ${actual.length} command(s) and every count claim matches commands/.`,
+    );
+    exit(0);
+  }
+
+  console.error(
+    `FAIL command-count: ${violations.length} issue(s) between the README "Slash commands" section and commands/.`,
+  );
+  console.error("");
+  for (const v of violations) console.error(`  ${v}`);
+  console.error("");
+  console.error(
+    "Fix: update the README '## Slash commands' fenced list and its 'All N commands' / 'All N ship' counts to match commands/*.md.",
+  );
+  exit(1);
+}
+
+const invokedDirectly =
+  argv[1] !== undefined && import.meta.url.endsWith(argv[1].replace(/\\/g, "/"));
+if (invokedDirectly || argv[1]?.endsWith("check-command-count.mjs")) {
+  main();
+}

--- a/src/test/check-command-count.test.mts
+++ b/src/test/check-command-count.test.mts
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  findViolations,
+  listCommandFiles,
+  parseReadmeSlashCommands,
+} from "../bin/check-command-count.mjs";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-command-count.mjs");
+
+/** Build a README "## Slash commands" section listing the given commands with a count claim. */
+function makeReadme(commands: string[], claimedCount: number): string {
+  const block = commands.map((c) => `/${c}` + " ".repeat(Math.max(2, 30 - c.length)) + "does a thing").join("\n");
+  return [
+    "# Title",
+    "",
+    "## Slash commands",
+    "",
+    "<details>",
+    `<summary><b>All ${claimedCount} commands (Beginner gets every one)</b></summary>`,
+    "",
+    "Intro prose here.",
+    "",
+    "```",
+    block,
+    "```",
+    "",
+    `All ${claimedCount} ship in the marketplace bundle.`,
+    "",
+    "</details>",
+    "",
+    "## Next section",
+    "",
+    "Other content.",
+    "",
+  ].join("\n");
+}
+
+function setupRepo(commands: string[], readme: string): string {
+  const root = mkdtempSync(join(tmpdir(), "command-count-test-"));
+  mkdirSync(join(root, "commands"), { recursive: true });
+  for (const c of commands) {
+    writeFileSync(join(root, "commands", `${c}.md`), `---\nname: ${c}\n---\n# /${c}\n`);
+  }
+  writeFileSync(join(root, "README.md"), readme);
+  return root;
+}
+
+describe("check-command-count — unit", () => {
+  it("listCommandFiles counts *.md and excludes README.md", () => {
+    const root = setupRepo(["alpha", "beta", "gamma"], "noop");
+    try {
+      writeFileSync(join(root, "commands", "README.md"), "# README\n");
+      const names = listCommandFiles(root);
+      assert.deepEqual(names, ["alpha", "beta", "gamma"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("parseReadmeSlashCommands extracts listed commands and count claims", () => {
+    const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "beta"], 2));
+    assert.equal(parsed.hasSection, true);
+    assert.deepEqual(parsed.listed.sort(), ["alpha", "beta"]);
+    assert.deepEqual(parsed.counts, [2, 2]);
+  });
+
+  it("parseReadmeSlashCommands fails closed when there is no Slash commands section", () => {
+    const parsed = parseReadmeSlashCommands("# Title\n\n## Other\n\nNo commands here.\n");
+    assert.equal(parsed.hasSection, false);
+  });
+
+  it("findViolations returns empty array when README matches the shipped set and count", () => {
+    const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "beta"], 2));
+    assert.deepEqual(findViolations(["alpha", "beta"], parsed), []);
+  });
+
+  it("findViolations flags a shipped command missing from the README list", () => {
+    const parsed = parseReadmeSlashCommands(makeReadme(["alpha"], 1));
+    const v = findViolations(["alpha", "beta"], parsed);
+    assert.ok(v.some((s) => /missing/.test(s) && /beta/.test(s)), v.join(" | "));
+  });
+
+  it("findViolations flags a listed command that is not shipped", () => {
+    const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "ghost"], 2));
+    const v = findViolations(["alpha"], parsed);
+    assert.ok(v.some((s) => /extra/.test(s) && /ghost/.test(s)), v.join(" | "));
+  });
+
+  it("findViolations flags a count claim that does not match the shipped count", () => {
+    const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "beta"], 5));
+    const v = findViolations(["alpha", "beta"], parsed);
+    assert.ok(v.some((s) => /count/.test(s) && /5/.test(s)), v.join(" | "));
+  });
+
+  it("findViolations fails closed when there is no Slash commands section", () => {
+    const parsed = parseReadmeSlashCommands("# Title\n\nNothing.\n");
+    const v = findViolations(["alpha"], parsed);
+    assert.ok(v.length > 0 && /section/.test(v[0]), v.join(" | "));
+  });
+
+  it("findViolations fails closed when the section lists no commands", () => {
+    const parsed = parseReadmeSlashCommands("# Title\n\n## Slash commands\n\nNo list.\n\n## End\n");
+    const v = findViolations(["alpha"], parsed);
+    assert.ok(v.some((s) => /no .*command/i.test(s)), v.join(" | "));
+  });
+
+  it("findViolations fails closed when the section states no count claim", () => {
+    const readme = "# Title\n\n## Slash commands\n\n```\n/alpha   does a thing\n```\n\n## End\n";
+    const parsed = parseReadmeSlashCommands(readme);
+    const v = findViolations(["alpha"], parsed);
+    assert.ok(v.some((s) => /count claim/i.test(s)), v.join(" | "));
+  });
+});
+
+describe("check-command-count — integration", () => {
+  it("CLI exits 0 when the README lists every shipped command with the right count", () => {
+    const cmds = ["alpha", "beta", "gamma"];
+    const root = setupRepo(cmds, makeReadme(cmds, cmds.length));
+    try {
+      const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      assert.match(out, /OK command-count: README lists all 3 command\(s\)/);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("CLI exits 1 and names the command missing from the README list", () => {
+    const root = setupRepo(["alpha", "beta", "gamma"], makeReadme(["alpha", "beta"], 2));
+    try {
+      let exited = false;
+      try {
+        execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+      } catch (err) {
+        exited = true;
+        const e = err as { status?: number; stderr?: string };
+        assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+        assert.match(e.stderr ?? "", /FAIL command-count/);
+        assert.match(e.stderr ?? "", /gamma/);
+      }
+      assert.ok(exited, "CLI should have exited non-zero when a command is unlisted");
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it("verifies the live repo lists every shipped command", () => {
+    const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+    assert.match(out, /OK command-count:/);
+  });
+});

--- a/test/check-command-count.test.mjs
+++ b/test/check-command-count.test.mjs
@@ -1,0 +1,142 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+import { findViolations, listCommandFiles, parseReadmeSlashCommands, } from "../bin/check-command-count.mjs";
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const REPO_ROOT = join(__dirname, "..");
+const CHECKER = join(REPO_ROOT, "bin", "check-command-count.mjs");
+/** Build a README "## Slash commands" section listing the given commands with a count claim. */
+function makeReadme(commands, claimedCount) {
+    const block = commands.map((c) => `/${c}` + " ".repeat(Math.max(2, 30 - c.length)) + "does a thing").join("\n");
+    return [
+        "# Title",
+        "",
+        "## Slash commands",
+        "",
+        "<details>",
+        `<summary><b>All ${claimedCount} commands (Beginner gets every one)</b></summary>`,
+        "",
+        "Intro prose here.",
+        "",
+        "```",
+        block,
+        "```",
+        "",
+        `All ${claimedCount} ship in the marketplace bundle.`,
+        "",
+        "</details>",
+        "",
+        "## Next section",
+        "",
+        "Other content.",
+        "",
+    ].join("\n");
+}
+function setupRepo(commands, readme) {
+    const root = mkdtempSync(join(tmpdir(), "command-count-test-"));
+    mkdirSync(join(root, "commands"), { recursive: true });
+    for (const c of commands) {
+        writeFileSync(join(root, "commands", `${c}.md`), `---\nname: ${c}\n---\n# /${c}\n`);
+    }
+    writeFileSync(join(root, "README.md"), readme);
+    return root;
+}
+describe("check-command-count — unit", () => {
+    it("listCommandFiles counts *.md and excludes README.md", () => {
+        const root = setupRepo(["alpha", "beta", "gamma"], "noop");
+        try {
+            writeFileSync(join(root, "commands", "README.md"), "# README\n");
+            const names = listCommandFiles(root);
+            assert.deepEqual(names, ["alpha", "beta", "gamma"]);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("parseReadmeSlashCommands extracts listed commands and count claims", () => {
+        const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "beta"], 2));
+        assert.equal(parsed.hasSection, true);
+        assert.deepEqual(parsed.listed.sort(), ["alpha", "beta"]);
+        assert.deepEqual(parsed.counts, [2, 2]);
+    });
+    it("parseReadmeSlashCommands fails closed when there is no Slash commands section", () => {
+        const parsed = parseReadmeSlashCommands("# Title\n\n## Other\n\nNo commands here.\n");
+        assert.equal(parsed.hasSection, false);
+    });
+    it("findViolations returns empty array when README matches the shipped set and count", () => {
+        const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "beta"], 2));
+        assert.deepEqual(findViolations(["alpha", "beta"], parsed), []);
+    });
+    it("findViolations flags a shipped command missing from the README list", () => {
+        const parsed = parseReadmeSlashCommands(makeReadme(["alpha"], 1));
+        const v = findViolations(["alpha", "beta"], parsed);
+        assert.ok(v.some((s) => /missing/.test(s) && /beta/.test(s)), v.join(" | "));
+    });
+    it("findViolations flags a listed command that is not shipped", () => {
+        const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "ghost"], 2));
+        const v = findViolations(["alpha"], parsed);
+        assert.ok(v.some((s) => /extra/.test(s) && /ghost/.test(s)), v.join(" | "));
+    });
+    it("findViolations flags a count claim that does not match the shipped count", () => {
+        const parsed = parseReadmeSlashCommands(makeReadme(["alpha", "beta"], 5));
+        const v = findViolations(["alpha", "beta"], parsed);
+        assert.ok(v.some((s) => /count/.test(s) && /5/.test(s)), v.join(" | "));
+    });
+    it("findViolations fails closed when there is no Slash commands section", () => {
+        const parsed = parseReadmeSlashCommands("# Title\n\nNothing.\n");
+        const v = findViolations(["alpha"], parsed);
+        assert.ok(v.length > 0 && /section/.test(v[0]), v.join(" | "));
+    });
+    it("findViolations fails closed when the section lists no commands", () => {
+        const parsed = parseReadmeSlashCommands("# Title\n\n## Slash commands\n\nNo list.\n\n## End\n");
+        const v = findViolations(["alpha"], parsed);
+        assert.ok(v.some((s) => /no .*command/i.test(s)), v.join(" | "));
+    });
+    it("findViolations fails closed when the section states no count claim", () => {
+        const readme = "# Title\n\n## Slash commands\n\n```\n/alpha   does a thing\n```\n\n## End\n";
+        const parsed = parseReadmeSlashCommands(readme);
+        const v = findViolations(["alpha"], parsed);
+        assert.ok(v.some((s) => /count claim/i.test(s)), v.join(" | "));
+    });
+});
+describe("check-command-count — integration", () => {
+    it("CLI exits 0 when the README lists every shipped command with the right count", () => {
+        const cmds = ["alpha", "beta", "gamma"];
+        const root = setupRepo(cmds, makeReadme(cmds, cmds.length));
+        try {
+            const out = execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            assert.match(out, /OK command-count: README lists all 3 command\(s\)/);
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("CLI exits 1 and names the command missing from the README list", () => {
+        const root = setupRepo(["alpha", "beta", "gamma"], makeReadme(["alpha", "beta"], 2));
+        try {
+            let exited = false;
+            try {
+                execFileSync("node", [CHECKER, root], { encoding: "utf8" });
+            }
+            catch (err) {
+                exited = true;
+                const e = err;
+                assert.equal(e.status, 1, `expected exit 1, got ${e.status}`);
+                assert.match(e.stderr ?? "", /FAIL command-count/);
+                assert.match(e.stderr ?? "", /gamma/);
+            }
+            assert.ok(exited, "CLI should have exited non-zero when a command is unlisted");
+        }
+        finally {
+            rmSync(root, { recursive: true, force: true });
+        }
+    });
+    it("verifies the live repo lists every shipped command", () => {
+        const out = execFileSync("node", [CHECKER, REPO_ROOT], { encoding: "utf8" });
+        assert.match(out, /OK command-count:/);
+    });
+});


### PR DESCRIPTION
## What

Adds a `check-command-count` invariant to `verify:all` so the README "Slash commands" section can never again under- or over-state the shipped command set.

## Why

The skill count is guarded (`check-skill-count`, `check-skill-count-prose`) but the **command count was not**. It silently drifted to "All 18 commands" while 28 shipped; PR #263 reconciled it by hand. Without an invariant the list drifts again on the next command added. This is the durable fix behind that PR.

## What it checks

Source of truth: `commands/*.md` (flat source, excluding README.md), already mirror-verified by `verify:everything-mirror`. Against the README "## Slash commands" section:

1. **Set parity** — the fenced `/command` lines equal the `commands/*.md` set; reports `missing` (shipped but unlisted) and `extra` (listed but unshipped).
2. **Count claims** — every `All N commands` / `All N ship` number equals the actual count.

Fail-closed: a missing section, an empty list, or an absent count claim each produce a violation, not a silent pass (per the 2026-06-03 boundary-test lesson).

## Shape

Mirrors `check-skill-count.mts`: exported pure functions (`listCommandFiles`, `parseReadmeSlashCommands`, `findViolations`) for unit testing, a `main()` with `OK` / `FAIL` + exit 0/1, and a Windows-safe `endsWith(".mjs")` main-guard.

## Files

- `src/bin/check-command-count.mts` -> `bin/check-command-count.mjs` (generated, exec bit set)
- `src/test/check-command-count.test.mts` -> `test/check-command-count.test.mjs`
- `package.json` — `verify:command-count` script + inserted into the `verify:all` chain
- `CLAUDE.md` — invariant list 13 -> 14 content invariants
- `docs/plans/2026-06-28-command-count-invariant.md` — plan

## Verification

- `npm run build` + `npm run verify:generated` clean (no generated drift; bin committed 100755)
- `npm run verify:all` green: now 14 content invariants + typecheck, including the new check passing on the live repo ("README lists all 28 command(s)")
- `npm test` 903/903 green, including 13 new tests (10 unit fail-closed edge cases + 3 integration)

## Out of scope

`docs/ai-improvement/README.md` repo-map counts carry other stale snapshots (version, entrypoint/test counts) on a separate axis; not coupled to this invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
