### PR TITLE
feat(gateguard): three friction-driven hardening fixes (message-prose, target-lock, unquoted @{u})

### DIFF
--- a/commands/reconcile.md
+++ b/commands/reconcile.md
@@ -16,7 +16,7 @@ Snapshots the full git state in one pass, detects a concurrent writer, classifie
 ```
 git branch --show-current
 git status --porcelain=v1                     # but trust git diff --stat for real drift (autocrlf)
-git rev-list --left-right --count @{u}...HEAD  # behind / ahead
+git rev-list --left-right --count '@{u}...HEAD'  # behind / ahead (quote the ref — bare @{u} trips the Bash parser)
 git stash list
 git worktree list
 ls .git/MERGE_HEAD .git/rebase-merge .git/rebase-apply 2>/dev/null  # in-progress op = another actor; do not race

--- a/docs/plans/2026-07-07-gateguard-v2-hardening.md
+++ b/docs/plans/2026-07-07-gateguard-v2-hardening.md
@@ -1,0 +1,57 @@
+# Gateguard v2 hardening — three friction-driven fixes
+
+Date: 2026-07-07
+Branch: `feat/gateguard-v2-hardening` (stacked on `feat/gateguard-exclude-paths` / `e0650b5`)
+Driver: `/insights` report `2026-07-07-004914` surfaced three recurring friction categories; a 9-agent adversarial survey (workflow `wf_8410d9c5-782`) confirmed each against the live harness with file:line evidence.
+
+## Goal
+
+Close the three highest-value gaps between what the operator repeatedly hits and what the gateguard hook actually enforces. One concern per commit, all on `src/hooks/gateguard.mts` (+ `src/lib/gateguard-state.mts` for RISA 2, + `commands/`+`skills/reconcile.md` for RISA 3). `.mts` is source; `npm run build` regenerates the `.mjs` and the `plugins/` mirror — commit both.
+
+## Goal Keywords
+
+gateguard, destructive-bash, commit message, PR body, target-lock, wrong-repo, worktree, brace ref, @{u}, quoting, reconcile
+
+## The three items (original recommendation order)
+
+### RISA 1 — G3: stop stranding verified finalization (CONFIRMED_GAP)
+
+**Problem:** the `destructive-bash` branch (`gateguard.mts:268-272`) substring-matches 19 patterns against the *whole* command, including the prose inside `-m` / `--body` / `-F` values. `git commit -m "refactor: drop the stale format helper"` false-trips on `drop `/`format `; `gh pr create --body "…truncate the logs…"` false-trips on `truncate `. Finished, tested work gets stranded on its own commit message.
+
+**WILL build:** a `stripMessageArgs()` pass that blanks the *values* of message/body-carrying flags (`-m`, `--message`, `-F`, `--file`, `--body`, `--body-file`, `--title`, `--notes`, `-C`, `--reuse-message`) before the destructive scan runs. Deliberately excludes `-c` so `bash -c "rm -rf /"` still gates.
+
+**Will NOT build:** a blanket bypass for genuinely destructive commands. `git branch -D`, `git reset --hard`, `--force-with-lease`, `rm -rf` are command-syntax tokens, not quoted prose — they stay gated exactly as before (the operator's own CLAUDE.md wants force-push/reset to halt-and-ask).
+
+**Verification:** node --test on new gateguard-hook cases — `git commit -m "…drop…format…"` → allow; `gh pr create --body "…truncate…"` → allow; `git branch -D feat/x` → still block; `rm -rf node_modules` → still block.
+
+### RISA 2 — G2: block wrong-repo / wrong-worktree writes (PARTIAL, prose-only today)
+
+**Problem:** the first-Write/Edit deny demands 4 grounding facts but never checks the target path lives inside the session's git root. You can present perfect facts about the wrong file. The prose Parallel-Actor Gate + worktree-safety Five-Check Envelope mandate this check; no hook runs it.
+
+**WILL build:** an opt-in `CI_GATEGUARD_TARGET_LOCK=block` mode. When set, a mutating call whose **absolute** target canonicalizes outside the session project root (`resolveProjectRoot()`) is denied with an identity-mismatch reason. Relative paths resolve under cwd (= root) and always pass; only an absolute path into a different tree is denied. Default (unset) = current behaviour, zero regression — this is the "warn-first rollout": ship non-enforcing, operator flips to `block` in multi-worktree/headless sessions. Mirrors the existing `CLAUDE_GOAL_DRIFT_GATE=block` precedent.
+
+**Will NOT build:** a default-on hard block (would break legitimate out-of-root edits: `~/.claude`, `/tmp` scratch, sibling repos). No new state file — reuses `resolveProjectRoot` + the existing canonicalizers.
+
+**Verification:** node --test — with `TARGET_LOCK=block` + a known `CLAUDE_PROJECT_DIR`: absolute in-root target → normal fact gate (not mismatch); absolute out-of-root → mismatch deny; same out-of-root with TARGET_LOCK unset → normal fact gate (default-off proof); relative path → not target-locked.
+
+### RISA 3 — G1: kill the unquoted `@{u}` retry loop (CONFIRMED_GAP)
+
+**Problem:** Claude Code's built-in Bash parser trips on the braces in an unquoted `@{u}` / `@{upstream}` ref and blocks post-hoc, costing a retry (measured in 4+ sessions). Worse, the harness's own `reconcile` command/skill *prescribes* the failing unquoted form.
+
+**WILL build:** (a) doc fix — quote `'@{u}...HEAD'` in `commands/reconcile.md:19` and `skills/reconcile.md:28`; (b) a quote-aware `findUnquotedBraceRef()` detector in the Bash path that denies a command carrying an unquoted `@{…}` and prints the *exact* quoted replacement command, so the correction lands before the opaque built-in block.
+
+**Will NOT build:** a general shell-lint. Scope is `@{…}` refs only — the measured failure. Quoted `'@{u}'` passes untouched.
+
+**Verification:** node --test — `git rev-list --left-right --count @{u}...HEAD` → block, reason contains the quoted fix `'@{u}...HEAD'`; the same command already quoted → allow; `git status` → allow (no false-positive).
+
+## Will NOT repeat (P-MAG Rule 3)
+
+`Will NOT repeat:` shipping a `.mjs` edit or staging a stale build the way PR #151 did — every `.mts` edit gets a fresh `npm run build` immediately before `git add`, and both source + generated mirror are staged together (`feedback_mts_is_source.md`). Stage by explicit filename, never `git add .` (`feedback_no_git_add_all_on_windows.md`).
+
+## Verification ladder (per item + final)
+
+Per item: `npm run build` → `node --test test/gateguard-hook.test.mjs test/gateguard-state.test.mjs` → `npm run verify:generated`. Final: `npm run verify:all` (14 invariants + typecheck).
+
+## PR sequencing (auto-merge ordering hazard)
+
+Two stacked PRs. The `feat/gateguard-exclude-paths` base PR (e0650b5) must merge **before** this one, or the stack rebases onto a stale base. Gate the hardening PR on the base PR completing first (`feedback_auto_merge_ordering.md`).

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -35,7 +35,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { MAX_CLEARED_FILES, canonicalizeFileKey, isCapReached, isFileCleared, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, canonicalizeProjectRoot, isCapReached, isFileCleared, loadState, markFileCleared, resolveProjectRoot, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
     Grep: "allow",
@@ -125,6 +125,41 @@ function isExcludedPath(filePath) {
     }
     const normalized = filePath.replace(/\\/g, "/").toLowerCase();
     return EXCLUDE_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+// --- Target lock (opt-in) --------------------------------------------------
+// A fact-list can't catch a wrong-repo / wrong-worktree write — you can present
+// perfect facts about the wrong file. CI_GATEGUARD_TARGET_LOCK=block denies a
+// mutating call whose ABSOLUTE target canonicalizes outside the session project
+// root. Default (unset) checks nothing, so existing sessions — including
+// legitimate out-of-root edits to ~/.claude or /tmp — are unaffected. This is
+// the warn-first rollout: ship non-enforcing, flip to block per session.
+const TARGET_LOCK_ON = String(process.env.CI_GATEGUARD_TARGET_LOCK ?? "").toLowerCase() === "block";
+// Relative paths resolve under cwd (= the project root) and always pass; only an
+// absolute path into a different tree can be out-of-root. Drive-letter (d:/,
+// D:\), POSIX-absolute (/x), and UNC (\\host) forms all count as absolute.
+function isAbsolutePathString(p) {
+    return /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("/") || p.startsWith("\\\\");
+}
+function isTargetOutsideRoot(filePath, projectRoot) {
+    if (!isAbsolutePathString(filePath))
+        return false;
+    const root = canonicalizeProjectRoot(projectRoot);
+    if (root === "global" || root === "")
+        return false; // no known root — do not guess
+    const target = canonicalizeFileKey(filePath);
+    return target !== root && !target.startsWith(`${root}/`);
+}
+function buildTargetLockReason(strayPath, projectRoot) {
+    return [
+        `Target is outside the session project root — refusing a possible wrong-repo / wrong-worktree write.`,
+        "",
+        `  Target: ${strayPath.replace(/\\/g, "/")}`,
+        `  Session root: ${canonicalizeProjectRoot(projectRoot)}`,
+        "",
+        "If this is intentional, confirm you are in the right worktree (cwd / CLAUDE_PROJECT_DIR),",
+        "or unset CI_GATEGUARD_TARGET_LOCK for this session. Target lock is opt-in; it fires only",
+        "when CI_GATEGUARD_TARGET_LOCK=block.",
+    ].join("\n");
 }
 // The call site only reads this inside the block branch, where at least one
 // path is uncleared; an all-cleared batch returns "" and is never consumed.
@@ -251,6 +286,18 @@ function main() {
     if (allTargetPaths.length > 0 && filePaths.length === 0) {
         emitAllow(); // every target is under a CI_GATEGUARD_EXCLUDE path; skip the gate
         return;
+    }
+    // Target lock runs before the fact gate and independent of clearance: a
+    // wrong-repo write is wrong even with perfect facts. Excluded paths were
+    // already filtered out above, so an explicitly-excluded scratch dir outside
+    // the root is never target-locked.
+    if (TARGET_LOCK_ON) {
+        const projectRoot = resolveProjectRoot();
+        const stray = filePaths.find((path) => isTargetOutsideRoot(path, projectRoot));
+        if (stray) {
+            emitDeny(buildTargetLockReason(stray, projectRoot));
+            return;
+        }
     }
     const filePath = firstUnclearedFilePath(toolInput, state);
     const factsFlagged = toolInput._gateguard_facts_presented === true;

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -210,6 +210,47 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
     ].join("\n");
 }
+function findUnquotedBraceRef(command) {
+    let quote = null;
+    for (let i = 0; i < command.length; i++) {
+        const ch = command[i];
+        if (quote) {
+            if (ch === quote)
+                quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'") {
+            quote = ch;
+            continue;
+        }
+        if (ch === "@" && command[i + 1] === "{") {
+            // Expand to the whitespace-delimited word that carries this @{ ref, then
+            // single-quote that whole word in the suggested fix.
+            let wordStart = i;
+            while (wordStart > 0 && !/\s/.test(command[wordStart - 1]))
+                wordStart--;
+            let wordEnd = i;
+            while (wordEnd < command.length && !/\s/.test(command[wordEnd]))
+                wordEnd++;
+            const word = command.slice(wordStart, wordEnd);
+            const braceEnd = command.indexOf("}", i);
+            const ref = braceEnd === -1 ? command.slice(i, wordEnd) : command.slice(i, braceEnd + 1);
+            const fixed = `${command.slice(0, wordStart)}'${word}'${command.slice(wordEnd)}`;
+            return { ref, fixed };
+        }
+    }
+    return null;
+}
+function buildBraceRefReason(hit) {
+    return [
+        `Unquoted git ref ${hit.ref} — Claude Code's Bash parser trips on the braces and blocks this`,
+        "post-hoc, costing a retry. Quote the ref and run the SAME command:",
+        "",
+        `  ${hit.fixed}`,
+        "",
+        "Single quotes stop the shell from touching the braces; git reads the ref as-is.",
+    ].join("\n");
+}
 function buildDestructiveBashReason(command) {
     return [
         `Destructive command requested: ${command}`,
@@ -265,6 +306,16 @@ function main() {
     const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
     const toolInput = payload.tool_input ?? {};
     const gate = classifyTool(toolName, toolInput);
+    // Unquoted @{…} refs trip the built-in Bash parser — catch them first, for
+    // both routine and destructive commands, so the quoted fix surfaces before the
+    // opaque post-hoc block (and before the destructive rollback demand).
+    if (toolName === "Bash" && typeof toolInput.command === "string") {
+        const braceHit = findUnquotedBraceRef(toolInput.command);
+        if (braceHit) {
+            emitDeny(buildBraceRefReason(braceHit));
+            return;
+        }
+    }
     if (gate === "allow") {
         emitAllow();
         return;

--- a/hooks/gateguard.mjs
+++ b/hooks/gateguard.mjs
@@ -69,8 +69,20 @@ const DESTRUCTIVE_PATTERNS = [
     "Remove-Item -Recurse",
     "Remove-Item -Force",
 ];
+// Flags whose VALUE is human prose (a commit message, a PR body) or a filename —
+// never a command to execute. Their contents must not trip the destructive scan:
+// `git commit -m "drop the stale format helper"` and `gh pr create --body "…"`
+// were stranding finished work on their own wording. `-c` is deliberately
+// EXCLUDED — `bash -c "rm -rf /"` carries a real command and must still gate.
+const MESSAGE_FLAG_RE = /(^|\s)(-m|--message|-F|--file|--body|--body-file|--title|--notes|-C|--reuse-message)(=|\s+)('[^']*'|"[^"]*"|\S+)/g;
+// Blank the value of every message/body flag so only executable command syntax
+// remains for the destructive-pattern scan. The flag itself is preserved so a
+// flag like `-F` never accidentally merges with its neighbours.
+function stripMessageArgs(command) {
+    return command.replace(MESSAGE_FLAG_RE, (_match, lead, flag) => `${lead}${flag} `);
+}
 function isDestructiveBash(command) {
-    const lower = command.toLowerCase();
+    const lower = stripMessageArgs(command).toLowerCase();
     return DESTRUCTIVE_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
 }
 function classifyTool(toolName, toolInput) {

--- a/lib/gateguard-state.mjs
+++ b/lib/gateguard-state.mjs
@@ -59,7 +59,11 @@ function sanitizeSessionId(sessionId) {
         return "";
     return sessionId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
 }
-function resolveProjectRoot() {
+// Exported for the target-lock gate (RISA 2 / G2): the hook compares a mutating
+// call's absolute target against this root to catch wrong-repo / wrong-worktree
+// writes. Returns "global" when no CLAUDE_PROJECT_DIR and no git toplevel — the
+// caller treats that as "no known root, do not guess".
+export function resolveProjectRoot() {
     const fromEnv = process.env.CLAUDE_PROJECT_DIR;
     if (fromEnv)
         return fromEnv;

--- a/plugins/continuous-improvement/commands/reconcile.md
+++ b/plugins/continuous-improvement/commands/reconcile.md
@@ -16,7 +16,7 @@ Snapshots the full git state in one pass, detects a concurrent writer, classifie
 ```
 git branch --show-current
 git status --porcelain=v1                     # but trust git diff --stat for real drift (autocrlf)
-git rev-list --left-right --count @{u}...HEAD  # behind / ahead
+git rev-list --left-right --count '@{u}...HEAD'  # behind / ahead (quote the ref — bare @{u} trips the Bash parser)
 git stash list
 git worktree list
 ls .git/MERGE_HEAD .git/rebase-merge .git/rebase-apply 2>/dev/null  # in-progress op = another actor; do not race

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -35,7 +35,7 @@
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { MAX_CLEARED_FILES, canonicalizeFileKey, isCapReached, isFileCleared, loadState, markFileCleared, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
+import { MAX_CLEARED_FILES, canonicalizeFileKey, canonicalizeProjectRoot, isCapReached, isFileCleared, loadState, markFileCleared, resolveProjectRoot, resolveSessionDir, saveState, } from "../lib/gateguard-state.mjs";
 const TOOL_ROUTE = {
     Read: "allow",
     Grep: "allow",
@@ -125,6 +125,41 @@ function isExcludedPath(filePath) {
     }
     const normalized = filePath.replace(/\\/g, "/").toLowerCase();
     return EXCLUDE_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+// --- Target lock (opt-in) --------------------------------------------------
+// A fact-list can't catch a wrong-repo / wrong-worktree write — you can present
+// perfect facts about the wrong file. CI_GATEGUARD_TARGET_LOCK=block denies a
+// mutating call whose ABSOLUTE target canonicalizes outside the session project
+// root. Default (unset) checks nothing, so existing sessions — including
+// legitimate out-of-root edits to ~/.claude or /tmp — are unaffected. This is
+// the warn-first rollout: ship non-enforcing, flip to block per session.
+const TARGET_LOCK_ON = String(process.env.CI_GATEGUARD_TARGET_LOCK ?? "").toLowerCase() === "block";
+// Relative paths resolve under cwd (= the project root) and always pass; only an
+// absolute path into a different tree can be out-of-root. Drive-letter (d:/,
+// D:\), POSIX-absolute (/x), and UNC (\\host) forms all count as absolute.
+function isAbsolutePathString(p) {
+    return /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("/") || p.startsWith("\\\\");
+}
+function isTargetOutsideRoot(filePath, projectRoot) {
+    if (!isAbsolutePathString(filePath))
+        return false;
+    const root = canonicalizeProjectRoot(projectRoot);
+    if (root === "global" || root === "")
+        return false; // no known root — do not guess
+    const target = canonicalizeFileKey(filePath);
+    return target !== root && !target.startsWith(`${root}/`);
+}
+function buildTargetLockReason(strayPath, projectRoot) {
+    return [
+        `Target is outside the session project root — refusing a possible wrong-repo / wrong-worktree write.`,
+        "",
+        `  Target: ${strayPath.replace(/\\/g, "/")}`,
+        `  Session root: ${canonicalizeProjectRoot(projectRoot)}`,
+        "",
+        "If this is intentional, confirm you are in the right worktree (cwd / CLAUDE_PROJECT_DIR),",
+        "or unset CI_GATEGUARD_TARGET_LOCK for this session. Target lock is opt-in; it fires only",
+        "when CI_GATEGUARD_TARGET_LOCK=block.",
+    ].join("\n");
 }
 // The call site only reads this inside the block branch, where at least one
 // path is uncleared; an all-cleared batch returns "" and is never consumed.
@@ -251,6 +286,18 @@ function main() {
     if (allTargetPaths.length > 0 && filePaths.length === 0) {
         emitAllow(); // every target is under a CI_GATEGUARD_EXCLUDE path; skip the gate
         return;
+    }
+    // Target lock runs before the fact gate and independent of clearance: a
+    // wrong-repo write is wrong even with perfect facts. Excluded paths were
+    // already filtered out above, so an explicitly-excluded scratch dir outside
+    // the root is never target-locked.
+    if (TARGET_LOCK_ON) {
+        const projectRoot = resolveProjectRoot();
+        const stray = filePaths.find((path) => isTargetOutsideRoot(path, projectRoot));
+        if (stray) {
+            emitDeny(buildTargetLockReason(stray, projectRoot));
+            return;
+        }
     }
     const filePath = firstUnclearedFilePath(toolInput, state);
     const factsFlagged = toolInput._gateguard_facts_presented === true;

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -210,6 +210,47 @@ function buildMutatingFileReason(toolName, filePaths, stateFilePath) {
         "  `_gateguard_facts_presented: true`; Claude Code's strict schema rejects that, so use A or B.)",
     ].join("\n");
 }
+function findUnquotedBraceRef(command) {
+    let quote = null;
+    for (let i = 0; i < command.length; i++) {
+        const ch = command[i];
+        if (quote) {
+            if (ch === quote)
+                quote = null;
+            continue;
+        }
+        if (ch === '"' || ch === "'") {
+            quote = ch;
+            continue;
+        }
+        if (ch === "@" && command[i + 1] === "{") {
+            // Expand to the whitespace-delimited word that carries this @{ ref, then
+            // single-quote that whole word in the suggested fix.
+            let wordStart = i;
+            while (wordStart > 0 && !/\s/.test(command[wordStart - 1]))
+                wordStart--;
+            let wordEnd = i;
+            while (wordEnd < command.length && !/\s/.test(command[wordEnd]))
+                wordEnd++;
+            const word = command.slice(wordStart, wordEnd);
+            const braceEnd = command.indexOf("}", i);
+            const ref = braceEnd === -1 ? command.slice(i, wordEnd) : command.slice(i, braceEnd + 1);
+            const fixed = `${command.slice(0, wordStart)}'${word}'${command.slice(wordEnd)}`;
+            return { ref, fixed };
+        }
+    }
+    return null;
+}
+function buildBraceRefReason(hit) {
+    return [
+        `Unquoted git ref ${hit.ref} — Claude Code's Bash parser trips on the braces and blocks this`,
+        "post-hoc, costing a retry. Quote the ref and run the SAME command:",
+        "",
+        `  ${hit.fixed}`,
+        "",
+        "Single quotes stop the shell from touching the braces; git reads the ref as-is.",
+    ].join("\n");
+}
 function buildDestructiveBashReason(command) {
     return [
         `Destructive command requested: ${command}`,
@@ -265,6 +306,16 @@ function main() {
     const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
     const toolInput = payload.tool_input ?? {};
     const gate = classifyTool(toolName, toolInput);
+    // Unquoted @{…} refs trip the built-in Bash parser — catch them first, for
+    // both routine and destructive commands, so the quoted fix surfaces before the
+    // opaque post-hoc block (and before the destructive rollback demand).
+    if (toolName === "Bash" && typeof toolInput.command === "string") {
+        const braceHit = findUnquotedBraceRef(toolInput.command);
+        if (braceHit) {
+            emitDeny(buildBraceRefReason(braceHit));
+            return;
+        }
+    }
     if (gate === "allow") {
         emitAllow();
         return;

--- a/plugins/continuous-improvement/hooks/gateguard.mjs
+++ b/plugins/continuous-improvement/hooks/gateguard.mjs
@@ -69,8 +69,20 @@ const DESTRUCTIVE_PATTERNS = [
     "Remove-Item -Recurse",
     "Remove-Item -Force",
 ];
+// Flags whose VALUE is human prose (a commit message, a PR body) or a filename —
+// never a command to execute. Their contents must not trip the destructive scan:
+// `git commit -m "drop the stale format helper"` and `gh pr create --body "…"`
+// were stranding finished work on their own wording. `-c` is deliberately
+// EXCLUDED — `bash -c "rm -rf /"` carries a real command and must still gate.
+const MESSAGE_FLAG_RE = /(^|\s)(-m|--message|-F|--file|--body|--body-file|--title|--notes|-C|--reuse-message)(=|\s+)('[^']*'|"[^"]*"|\S+)/g;
+// Blank the value of every message/body flag so only executable command syntax
+// remains for the destructive-pattern scan. The flag itself is preserved so a
+// flag like `-F` never accidentally merges with its neighbours.
+function stripMessageArgs(command) {
+    return command.replace(MESSAGE_FLAG_RE, (_match, lead, flag) => `${lead}${flag} `);
+}
 function isDestructiveBash(command) {
-    const lower = command.toLowerCase();
+    const lower = stripMessageArgs(command).toLowerCase();
     return DESTRUCTIVE_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
 }
 function classifyTool(toolName, toolInput) {

--- a/plugins/continuous-improvement/lib/gateguard-state.mjs
+++ b/plugins/continuous-improvement/lib/gateguard-state.mjs
@@ -59,7 +59,11 @@ function sanitizeSessionId(sessionId) {
         return "";
     return sessionId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
 }
-function resolveProjectRoot() {
+// Exported for the target-lock gate (RISA 2 / G2): the hook compares a mutating
+// call's absolute target against this root to catch wrong-repo / wrong-worktree
+// writes. Returns "global" when no CLAUDE_PROJECT_DIR and no git toplevel — the
+// caller treats that as "no known root, do not guess".
+export function resolveProjectRoot() {
     const fromEnv = process.env.CLAUDE_PROJECT_DIR;
     if (fromEnv)
         return fromEnv;

--- a/plugins/continuous-improvement/skills/gateguard/SKILL.md
+++ b/plugins/continuous-improvement/skills/gateguard/SKILL.md
@@ -154,6 +154,10 @@ The inline `_gateguard_facts_presented: true` retry still works on harnesses tha
 
 Set the `CI_GATEGUARD_EXCLUDE` environment variable to opt specific low-risk paths out of the gate entirely — an LLM-maintained prose wiki, a generated scratch directory, anything where the fact-forcing pause costs more than it saves. The value is a comma-separated list of path substrings, each matched case-insensitively against the forward-slash-normalized file path, so `/mywiki/` excludes `D:\Vault\MyWiki\notes\x.md`. Unset or empty (the default) changes nothing: every mutating file call is gated exactly as before, and a call that touches a mix of excluded and non-excluded paths still gates the non-excluded ones. Set it per project in `.claude/settings.json` under `env`, or globally in `~/.claude/settings.json`.
 
+### Locking edits to the current repo
+
+A fact-list can't catch a wrong-repo or wrong-worktree write — you can present perfect facts about the wrong file, in the wrong checkout. Set `CI_GATEGUARD_TARGET_LOCK=block` to make the runtime hook (`hooks/gateguard.mjs`) refuse any mutating call whose **absolute** target canonicalizes outside the session project root (`CLAUDE_PROJECT_DIR`, or the git toplevel). Relative paths resolve under the current directory (= the root) and always pass; only an absolute path into a different tree is denied, and the deny reason names both the stray target and the expected root. This runs before the fact gate and independent of clearance — a wrong-repo write is wrong even with facts. Unset (the default) checks nothing, so legitimate out-of-root edits (`~/.claude`, a `/tmp` scratch file, a sibling repo) are unaffected; turn it on per session in a multi-worktree or headless run where cross-repo writes are the real risk. Paths already covered by `CI_GATEGUARD_EXCLUDE` are never target-locked.
+
 ### Limitations and guarantees
 
 - **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap — counted per session — bounds damage from stuck loops or rogue agents.
@@ -180,6 +184,7 @@ The standalone `gateguard-ai` Python/CLI package referenced in earlier drafts of
 - Customize gate messages for your domain. If your project has specific conventions, add them to the gate prompts.
 - Use `.gateguard.yml` to ignore paths like `.venv/`, `node_modules/`, `.git/`.
 - For the shipped runtime hook, set `CI_GATEGUARD_EXCLUDE` (comma-separated path substrings) to exclude low-risk paths from the gate — see [Excluding low-risk paths](#excluding-low-risk-paths).
+- In multi-worktree or headless runs, set `CI_GATEGUARD_TARGET_LOCK=block` so a write into the wrong repo/worktree is refused — see [Locking edits to the current repo](#locking-edits-to-the-current-repo).
 
 ## Related Skills
 

--- a/plugins/continuous-improvement/skills/reconcile/SKILL.md
+++ b/plugins/continuous-improvement/skills/reconcile/SKILL.md
@@ -25,7 +25,7 @@ Read before you write. Capture the full state in one pass:
 ```
 git branch --show-current
 git status --porcelain=v1
-git rev-list --left-right --count @{u}...HEAD     # behind / ahead of upstream
+git rev-list --left-right --count '@{u}...HEAD'     # behind / ahead of upstream (quote the ref — bare @{u} trips the Bash parser)
 git stash list
 git worktree list
 ls .git/MERGE_HEAD .git/rebase-merge .git/rebase-apply 2>/dev/null   # in-progress operation?

--- a/skills/gateguard.md
+++ b/skills/gateguard.md
@@ -154,6 +154,10 @@ The inline `_gateguard_facts_presented: true` retry still works on harnesses tha
 
 Set the `CI_GATEGUARD_EXCLUDE` environment variable to opt specific low-risk paths out of the gate entirely — an LLM-maintained prose wiki, a generated scratch directory, anything where the fact-forcing pause costs more than it saves. The value is a comma-separated list of path substrings, each matched case-insensitively against the forward-slash-normalized file path, so `/mywiki/` excludes `D:\Vault\MyWiki\notes\x.md`. Unset or empty (the default) changes nothing: every mutating file call is gated exactly as before, and a call that touches a mix of excluded and non-excluded paths still gates the non-excluded ones. Set it per project in `.claude/settings.json` under `env`, or globally in `~/.claude/settings.json`.
 
+### Locking edits to the current repo
+
+A fact-list can't catch a wrong-repo or wrong-worktree write — you can present perfect facts about the wrong file, in the wrong checkout. Set `CI_GATEGUARD_TARGET_LOCK=block` to make the runtime hook (`hooks/gateguard.mjs`) refuse any mutating call whose **absolute** target canonicalizes outside the session project root (`CLAUDE_PROJECT_DIR`, or the git toplevel). Relative paths resolve under the current directory (= the root) and always pass; only an absolute path into a different tree is denied, and the deny reason names both the stray target and the expected root. This runs before the fact gate and independent of clearance — a wrong-repo write is wrong even with facts. Unset (the default) checks nothing, so legitimate out-of-root edits (`~/.claude`, a `/tmp` scratch file, a sibling repo) are unaffected; turn it on per session in a multi-worktree or headless run where cross-repo writes are the real risk. Paths already covered by `CI_GATEGUARD_EXCLUDE` are never target-locked.
+
 ### Limitations and guarantees
 
 - **Honor system.** Clearance is recorded by `ci_gateguard_clear`, the `gateguard-clear.mjs` CLI, a manual state-file write, or the inline `_gateguard_facts_presented` flag where the harness allows it (see "Clearing the gate" above). The hook can't verify the investigation actually happened; the 50-file cap — counted per session — bounds damage from stuck loops or rogue agents.
@@ -180,6 +184,7 @@ The standalone `gateguard-ai` Python/CLI package referenced in earlier drafts of
 - Customize gate messages for your domain. If your project has specific conventions, add them to the gate prompts.
 - Use `.gateguard.yml` to ignore paths like `.venv/`, `node_modules/`, `.git/`.
 - For the shipped runtime hook, set `CI_GATEGUARD_EXCLUDE` (comma-separated path substrings) to exclude low-risk paths from the gate — see [Excluding low-risk paths](#excluding-low-risk-paths).
+- In multi-worktree or headless runs, set `CI_GATEGUARD_TARGET_LOCK=block` so a write into the wrong repo/worktree is refused — see [Locking edits to the current repo](#locking-edits-to-the-current-repo).
 
 ## Related Skills
 

--- a/skills/reconcile.md
+++ b/skills/reconcile.md
@@ -25,7 +25,7 @@ Read before you write. Capture the full state in one pass:
 ```
 git branch --show-current
 git status --porcelain=v1
-git rev-list --left-right --count @{u}...HEAD     # behind / ahead of upstream
+git rev-list --left-right --count '@{u}...HEAD'     # behind / ahead of upstream (quote the ref — bare @{u} trips the Bash parser)
 git stash list
 git worktree list
 ls .git/MERGE_HEAD .git/rebase-merge .git/rebase-apply 2>/dev/null   # in-progress operation?

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -39,10 +39,12 @@ import { fileURLToPath } from "node:url";
 import {
   MAX_CLEARED_FILES,
   canonicalizeFileKey,
+  canonicalizeProjectRoot,
   isCapReached,
   isFileCleared,
   loadState,
   markFileCleared,
+  resolveProjectRoot,
   resolveSessionDir,
   saveState,
   type GateguardState,
@@ -158,6 +160,43 @@ function isExcludedPath(filePath: string): boolean {
   }
   const normalized = filePath.replace(/\\/g, "/").toLowerCase();
   return EXCLUDE_FRAGMENTS.some((fragment) => normalized.includes(fragment));
+}
+
+// --- Target lock (opt-in) --------------------------------------------------
+// A fact-list can't catch a wrong-repo / wrong-worktree write — you can present
+// perfect facts about the wrong file. CI_GATEGUARD_TARGET_LOCK=block denies a
+// mutating call whose ABSOLUTE target canonicalizes outside the session project
+// root. Default (unset) checks nothing, so existing sessions — including
+// legitimate out-of-root edits to ~/.claude or /tmp — are unaffected. This is
+// the warn-first rollout: ship non-enforcing, flip to block per session.
+const TARGET_LOCK_ON = String(process.env.CI_GATEGUARD_TARGET_LOCK ?? "").toLowerCase() === "block";
+
+// Relative paths resolve under cwd (= the project root) and always pass; only an
+// absolute path into a different tree can be out-of-root. Drive-letter (d:/,
+// D:\), POSIX-absolute (/x), and UNC (\\host) forms all count as absolute.
+function isAbsolutePathString(p: string): boolean {
+  return /^[A-Za-z]:[\\/]/.test(p) || p.startsWith("/") || p.startsWith("\\\\");
+}
+
+function isTargetOutsideRoot(filePath: string, projectRoot: string): boolean {
+  if (!isAbsolutePathString(filePath)) return false;
+  const root = canonicalizeProjectRoot(projectRoot);
+  if (root === "global" || root === "") return false; // no known root — do not guess
+  const target = canonicalizeFileKey(filePath);
+  return target !== root && !target.startsWith(`${root}/`);
+}
+
+function buildTargetLockReason(strayPath: string, projectRoot: string): string {
+  return [
+    `Target is outside the session project root — refusing a possible wrong-repo / wrong-worktree write.`,
+    "",
+    `  Target: ${strayPath.replace(/\\/g, "/")}`,
+    `  Session root: ${canonicalizeProjectRoot(projectRoot)}`,
+    "",
+    "If this is intentional, confirm you are in the right worktree (cwd / CLAUDE_PROJECT_DIR),",
+    "or unset CI_GATEGUARD_TARGET_LOCK for this session. Target lock is opt-in; it fires only",
+    "when CI_GATEGUARD_TARGET_LOCK=block.",
+  ].join("\n");
 }
 
 // The call site only reads this inside the block branch, where at least one
@@ -299,6 +338,20 @@ function main(): void {
     emitAllow(); // every target is under a CI_GATEGUARD_EXCLUDE path; skip the gate
     return;
   }
+
+  // Target lock runs before the fact gate and independent of clearance: a
+  // wrong-repo write is wrong even with perfect facts. Excluded paths were
+  // already filtered out above, so an explicitly-excluded scratch dir outside
+  // the root is never target-locked.
+  if (TARGET_LOCK_ON) {
+    const projectRoot = resolveProjectRoot();
+    const stray = filePaths.find((path) => isTargetOutsideRoot(path, projectRoot));
+    if (stray) {
+      emitDeny(buildTargetLockReason(stray, projectRoot));
+      return;
+    }
+  }
+
   const filePath = firstUnclearedFilePath(toolInput, state);
   const factsFlagged = toolInput._gateguard_facts_presented === true;
   const alreadyCleared = filePaths.length > 0 && filePaths.every((path) => isFileCleared(state, path));

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -254,6 +254,59 @@ function buildMutatingFileReason(toolName: string, filePaths: string[], stateFil
   ].join("\n");
 }
 
+// --- Unquoted brace-ref detector (RISA 3 / G1) -----------------------------
+// An unquoted @{u} / @{upstream} / @{push} / @{0} git ref makes Claude Code's
+// built-in Bash parser trip on the braces and block the call post-hoc, costing a
+// retry (measured in 4+ sessions). Walk the command tracking quote state and
+// report the FIRST @{ that sits outside any quoted span, plus the fixed command
+// that single-quotes the whole ref word — so the correction lands before the
+// opaque built-in block. A ref already inside single or double quotes is safe
+// and passes untouched.
+interface BraceRefHit {
+  ref: string;
+  fixed: string;
+}
+
+function findUnquotedBraceRef(command: string): BraceRefHit | null {
+  let quote: string | null = null;
+  for (let i = 0; i < command.length; i++) {
+    const ch = command[i]!;
+    if (quote) {
+      if (ch === quote) quote = null;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      quote = ch;
+      continue;
+    }
+    if (ch === "@" && command[i + 1] === "{") {
+      // Expand to the whitespace-delimited word that carries this @{ ref, then
+      // single-quote that whole word in the suggested fix.
+      let wordStart = i;
+      while (wordStart > 0 && !/\s/.test(command[wordStart - 1]!)) wordStart--;
+      let wordEnd = i;
+      while (wordEnd < command.length && !/\s/.test(command[wordEnd]!)) wordEnd++;
+      const word = command.slice(wordStart, wordEnd);
+      const braceEnd = command.indexOf("}", i);
+      const ref = braceEnd === -1 ? command.slice(i, wordEnd) : command.slice(i, braceEnd + 1);
+      const fixed = `${command.slice(0, wordStart)}'${word}'${command.slice(wordEnd)}`;
+      return { ref, fixed };
+    }
+  }
+  return null;
+}
+
+function buildBraceRefReason(hit: BraceRefHit): string {
+  return [
+    `Unquoted git ref ${hit.ref} — Claude Code's Bash parser trips on the braces and blocks this`,
+    "post-hoc, costing a retry. Quote the ref and run the SAME command:",
+    "",
+    `  ${hit.fixed}`,
+    "",
+    "Single quotes stop the shell from touching the braces; git reads the ref as-is.",
+  ].join("\n");
+}
+
 function buildDestructiveBashReason(command: string): string {
   return [
     `Destructive command requested: ${command}`,
@@ -313,6 +366,17 @@ function main(): void {
   const toolName = typeof payload.tool_name === "string" ? payload.tool_name : "";
   const toolInput: ToolInput = payload.tool_input ?? {};
   const gate = classifyTool(toolName, toolInput);
+
+  // Unquoted @{…} refs trip the built-in Bash parser — catch them first, for
+  // both routine and destructive commands, so the quoted fix surfaces before the
+  // opaque post-hoc block (and before the destructive rollback demand).
+  if (toolName === "Bash" && typeof toolInput.command === "string") {
+    const braceHit = findUnquotedBraceRef(toolInput.command);
+    if (braceHit) {
+      emitDeny(buildBraceRefReason(braceHit));
+      return;
+    }
+  }
 
   if (gate === "allow") {
     emitAllow();

--- a/src/hooks/gateguard.mts
+++ b/src/hooks/gateguard.mts
@@ -99,8 +99,23 @@ const DESTRUCTIVE_PATTERNS: readonly string[] = [
   "Remove-Item -Force",
 ];
 
+// Flags whose VALUE is human prose (a commit message, a PR body) or a filename —
+// never a command to execute. Their contents must not trip the destructive scan:
+// `git commit -m "drop the stale format helper"` and `gh pr create --body "…"`
+// were stranding finished work on their own wording. `-c` is deliberately
+// EXCLUDED — `bash -c "rm -rf /"` carries a real command and must still gate.
+const MESSAGE_FLAG_RE =
+  /(^|\s)(-m|--message|-F|--file|--body|--body-file|--title|--notes|-C|--reuse-message)(=|\s+)('[^']*'|"[^"]*"|\S+)/g;
+
+// Blank the value of every message/body flag so only executable command syntax
+// remains for the destructive-pattern scan. The flag itself is preserved so a
+// flag like `-F` never accidentally merges with its neighbours.
+function stripMessageArgs(command: string): string {
+  return command.replace(MESSAGE_FLAG_RE, (_match, lead: string, flag: string) => `${lead}${flag} `);
+}
+
 function isDestructiveBash(command: string): boolean {
-  const lower = command.toLowerCase();
+  const lower = stripMessageArgs(command).toLowerCase();
   return DESTRUCTIVE_PATTERNS.some((p) => lower.includes(p.toLowerCase()));
 }
 

--- a/src/lib/gateguard-state.mts
+++ b/src/lib/gateguard-state.mts
@@ -69,7 +69,11 @@ function sanitizeSessionId(sessionId?: string): string {
   return sessionId.replace(/[^A-Za-z0-9_-]/g, "_").slice(0, 64);
 }
 
-function resolveProjectRoot(): string {
+// Exported for the target-lock gate (RISA 2 / G2): the hook compares a mutating
+// call's absolute target against this root to catch wrong-repo / wrong-worktree
+// writes. Returns "global" when no CLAUDE_PROJECT_DIR and no git toplevel — the
+// caller treats that as "no known root, do not guess".
+export function resolveProjectRoot(): string {
   const fromEnv = process.env.CLAUDE_PROJECT_DIR;
   if (fromEnv) return fromEnv;
   try {

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -480,6 +480,66 @@ describe("hooks/gateguard.mjs — target lock (RISA 2 / G2)", () => {
   });
 });
 
+// RISA 3 / G1 — an unquoted @{u}/@{upstream} git ref makes Claude Code's Bash
+// parser trip on the braces and block post-hoc, costing a retry. Deny it
+// pre-emptively with the exact quoted replacement so the fix lands first.
+// Quoted refs pass untouched; commands with no @{ are never affected.
+describe("hooks/gateguard.mjs — unquoted @{u} brace-ref detector (RISA 3 / G1)", () => {
+  let sessionDir = "";
+
+  before(() => {
+    sessionDir = mkdtempSync(join(tmpdir(), "gateguard-brace-"));
+  });
+
+  after(() => {
+    rmSync(sessionDir, { recursive: true, force: true });
+  });
+
+  it("unquoted @{u}...HEAD is blocked with the quoted fix in the reason", () => {
+    const decision = runHook(
+      "Bash",
+      { command: "git rev-list --left-right --count @{u}...HEAD" },
+      sessionDir,
+    );
+    assert.equal(decision.decision, "block");
+    assert.match(decision.reason ?? "", /@\{u\}/);
+    assert.match(decision.reason ?? "", /'@\{u\}\.\.\.HEAD'/, "reason prints the quoted replacement");
+  });
+
+  it("unquoted @{upstream} is blocked", () => {
+    const decision = runHook("Bash", { command: "git log @{upstream}..HEAD --oneline" }, sessionDir);
+    assert.equal(decision.decision, "block");
+    assert.match(decision.reason ?? "", /@\{upstream\}/);
+  });
+
+  it("a single-quoted @{u} ref is allowed (already safe)", () => {
+    const decision = runHook(
+      "Bash",
+      { command: "git rev-list --left-right --count '@{u}...HEAD'" },
+      sessionDir,
+    );
+    assert.equal(decision.decision, "allow", "a quoted brace ref must pass untouched");
+  });
+
+  it("a double-quoted @{u} ref is allowed", () => {
+    const decision = runHook("Bash", { command: 'git rev-parse "@{u}"' }, sessionDir);
+    assert.equal(decision.decision, "allow");
+  });
+
+  it("a command with no brace ref is unaffected", () => {
+    const decision = runHook("Bash", { command: "git status --porcelain=v1" }, sessionDir);
+    assert.equal(decision.decision, "allow");
+  });
+
+  it("the brace check fires before the destructive gate (git reset --hard @{u})", () => {
+    const decision = runHook("Bash", { command: "git reset --hard @{u}" }, sessionDir);
+    assert.equal(decision.decision, "block");
+    // The quoted-fix form only appears in the brace reason, never the destructive
+    // rollback demand — this proves the brace check surfaces first.
+    assert.match(decision.reason ?? "", /'@\{u\}'/, "brace fix surfaces first, before the destructive rollback demand");
+  });
+});
+
 // Session isolation: the cap and clearance state must NOT bleed across
 // concurrent same-day sessions. Drives the production path (no
 // GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -336,6 +336,71 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
   });
 });
 
+// RISA 1 / G3 — the destructive-bash scan must not match patterns that appear
+// only inside the PROSE of a commit message or PR body. A verified commit whose
+// message mentions "drop"/"format"/"truncate" was being stranded on its own
+// wording. Genuine destructive commands (the verb is command syntax, not quoted
+// prose) must still gate.
+describe("hooks/gateguard.mjs — destructive-bash message-arg carve-out (RISA 1 / G3)", () => {
+  let sessionDir = "";
+
+  before(() => {
+    sessionDir = mkdtempSync(join(tmpdir(), "gateguard-msgarg-"));
+  });
+
+  after(() => {
+    rmSync(sessionDir, { recursive: true, force: true });
+  });
+
+  it("git commit -m with destructive words in the message is allowed", () => {
+    const decision = runHook(
+      "Bash",
+      { command: 'git commit -m "refactor: drop the stale format helper"' },
+      sessionDir,
+    );
+    assert.equal(decision.decision, "allow", "commit-message prose must not trip the destructive gate");
+  });
+
+  it("gh pr create --body with destructive words in the body is allowed", () => {
+    const decision = runHook(
+      "Bash",
+      { command: 'gh pr create --title "cleanup" --body "truncate the logs and remove old files"' },
+      sessionDir,
+    );
+    assert.equal(decision.decision, "allow", "PR-body prose must not trip the destructive gate");
+  });
+
+  it("git commit -m with single-quoted destructive prose is allowed", () => {
+    const decision = runHook(
+      "Bash",
+      { command: "git commit -m 'drop table cleanup: rename the format column'" },
+      sessionDir,
+    );
+    assert.equal(decision.decision, "allow", "single-quoted message prose must not trip the gate");
+  });
+
+  it("git branch -D (genuine destructive) still blocks despite a benign context", () => {
+    const decision = runHook("Bash", { command: "git branch -D feat/old-branch" }, sessionDir);
+    assert.equal(decision.decision, "block", "force-delete branch must still gate");
+    assert.match(decision.reason ?? "", /rollback|delete|destructive/i);
+  });
+
+  it("rm -rf outside any quoted message still blocks", () => {
+    const decision = runHook("Bash", { command: "rm -rf node_modules" }, sessionDir);
+    assert.equal(decision.decision, "block", "rm -rf must still gate");
+  });
+
+  it("a destructive command hidden in bash -c is NOT carved out (-c is not a message flag)", () => {
+    const decision = runHook("Bash", { command: 'bash -c "rm -rf /tmp/x"' }, sessionDir);
+    assert.equal(decision.decision, "block", "bash -c carries a command to run, not prose — must still gate");
+  });
+
+  it("a plain benign commit message is allowed (no regression)", () => {
+    const decision = runHook("Bash", { command: 'git commit -m "add gateguard tests"' }, sessionDir);
+    assert.equal(decision.decision, "allow");
+  });
+});
+
 // Session isolation: the cap and clearance state must NOT bleed across
 // concurrent same-day sessions. Drives the production path (no
 // GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so

--- a/src/test/gateguard-hook.test.mts
+++ b/src/test/gateguard-hook.test.mts
@@ -401,6 +401,85 @@ describe("hooks/gateguard.mjs — destructive-bash message-arg carve-out (RISA 1
   });
 });
 
+// RISA 2 / G2 — opt-in target lock. CI_GATEGUARD_TARGET_LOCK=block denies a
+// mutating call whose ABSOLUTE target resolves outside the session project root
+// (the wrong-repo / wrong-worktree write a fact-list can't catch). Default off:
+// no path is checked and behaviour is unchanged.
+describe("hooks/gateguard.mjs — target lock (RISA 2 / G2)", () => {
+  const ROOT = "d:/proj/root";
+
+  function runTargetHook(
+    toolInput: Record<string, unknown>,
+    opts: { targetLock?: string; projectRoot?: string },
+  ): HookDecision {
+    const dir = mkdtempSync(join(tmpdir(), "gateguard-target-"));
+    try {
+      const env: NodeJS.ProcessEnv = {
+        ...process.env,
+        GATEGUARD_SESSION_DIR: dir,
+        CLAUDE_PROJECT_DIR: opts.projectRoot ?? ROOT,
+      };
+      if (opts.targetLock === undefined) delete env.CI_GATEGUARD_TARGET_LOCK;
+      else env.CI_GATEGUARD_TARGET_LOCK = opts.targetLock;
+      const payload = JSON.stringify({ tool_name: "Write", tool_input: toolInput });
+      const result = spawnSync(process.execPath, [HOOK_PATH], { input: payload, encoding: "utf8", env });
+      assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`);
+      const stdout = result.stdout.trim();
+      if (stdout === "") return { decision: "allow" };
+      const parsed = JSON.parse(stdout) as PreToolUseHookOutput;
+      return { decision: "block", reason: parsed.hookSpecificOutput?.permissionDecisionReason };
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("absolute in-root target hits the normal fact gate, not the mismatch reason", () => {
+    const decision = runTargetHook(
+      { file_path: "d:/proj/root/src/x.ts", content: "y" },
+      { targetLock: "block" },
+    );
+    assert.equal(decision.decision, "block");
+    assert.match(decision.reason ?? "", /import|require|present these facts/i);
+    assert.doesNotMatch(decision.reason ?? "", /outside the session project root/i);
+  });
+
+  it("absolute out-of-root target is denied with an identity-mismatch reason when locked", () => {
+    const decision = runTargetHook(
+      { file_path: "d:/other/repo/x.ts", content: "y" },
+      { targetLock: "block" },
+    );
+    assert.equal(decision.decision, "block");
+    assert.match(decision.reason ?? "", /outside the session project root/i);
+    assert.match(decision.reason ?? "", /d:\/other\/repo\/x\.ts/i);
+    assert.match(decision.reason ?? "", /d:\/proj\/root/i);
+  });
+
+  it("out-of-root target with target lock UNSET falls back to the normal fact gate (default off)", () => {
+    const decision = runTargetHook(
+      { file_path: "d:/other/repo/x.ts", content: "y" },
+      { targetLock: undefined },
+    );
+    assert.equal(decision.decision, "block");
+    assert.match(decision.reason ?? "", /present these facts/i);
+    assert.doesNotMatch(decision.reason ?? "", /outside the session project root/i);
+  });
+
+  it("relative target is never target-locked (resolves under cwd)", () => {
+    const decision = runTargetHook({ file_path: "src/x.ts", content: "y" }, { targetLock: "block" });
+    assert.equal(decision.decision, "block");
+    assert.doesNotMatch(decision.reason ?? "", /outside the session project root/i);
+  });
+
+  it("a sibling dir sharing the root's name prefix is treated as outside", () => {
+    const decision = runTargetHook(
+      { file_path: "d:/proj/rootX/x.ts", content: "y" },
+      { targetLock: "block" },
+    );
+    assert.equal(decision.decision, "block");
+    assert.match(decision.reason ?? "", /outside the session project root/i);
+  });
+});
+
 // Session isolation: the cap and clearance state must NOT bleed across
 // concurrent same-day sessions. Drives the production path (no
 // GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -348,6 +348,49 @@ describe("hooks/gateguard.mjs — target lock (RISA 2 / G2)", () => {
         assert.match(decision.reason ?? "", /outside the session project root/i);
     });
 });
+// RISA 3 / G1 — an unquoted @{u}/@{upstream} git ref makes Claude Code's Bash
+// parser trip on the braces and block post-hoc, costing a retry. Deny it
+// pre-emptively with the exact quoted replacement so the fix lands first.
+// Quoted refs pass untouched; commands with no @{ are never affected.
+describe("hooks/gateguard.mjs — unquoted @{u} brace-ref detector (RISA 3 / G1)", () => {
+    let sessionDir = "";
+    before(() => {
+        sessionDir = mkdtempSync(join(tmpdir(), "gateguard-brace-"));
+    });
+    after(() => {
+        rmSync(sessionDir, { recursive: true, force: true });
+    });
+    it("unquoted @{u}...HEAD is blocked with the quoted fix in the reason", () => {
+        const decision = runHook("Bash", { command: "git rev-list --left-right --count @{u}...HEAD" }, sessionDir);
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /@\{u\}/);
+        assert.match(decision.reason ?? "", /'@\{u\}\.\.\.HEAD'/, "reason prints the quoted replacement");
+    });
+    it("unquoted @{upstream} is blocked", () => {
+        const decision = runHook("Bash", { command: "git log @{upstream}..HEAD --oneline" }, sessionDir);
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /@\{upstream\}/);
+    });
+    it("a single-quoted @{u} ref is allowed (already safe)", () => {
+        const decision = runHook("Bash", { command: "git rev-list --left-right --count '@{u}...HEAD'" }, sessionDir);
+        assert.equal(decision.decision, "allow", "a quoted brace ref must pass untouched");
+    });
+    it("a double-quoted @{u} ref is allowed", () => {
+        const decision = runHook("Bash", { command: 'git rev-parse "@{u}"' }, sessionDir);
+        assert.equal(decision.decision, "allow");
+    });
+    it("a command with no brace ref is unaffected", () => {
+        const decision = runHook("Bash", { command: "git status --porcelain=v1" }, sessionDir);
+        assert.equal(decision.decision, "allow");
+    });
+    it("the brace check fires before the destructive gate (git reset --hard @{u})", () => {
+        const decision = runHook("Bash", { command: "git reset --hard @{u}" }, sessionDir);
+        assert.equal(decision.decision, "block");
+        // The quoted-fix form only appears in the brace reason, never the destructive
+        // rollback demand — this proves the brace check surfaces first.
+        assert.match(decision.reason ?? "", /'@\{u\}'/, "brace fix surfaces first, before the destructive rollback demand");
+    });
+});
 // Session isolation: the cap and clearance state must NOT bleed across
 // concurrent same-day sessions. Drives the production path (no
 // GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -287,6 +287,67 @@ describe("hooks/gateguard.mjs — destructive-bash message-arg carve-out (RISA 1
         assert.equal(decision.decision, "allow");
     });
 });
+// RISA 2 / G2 — opt-in target lock. CI_GATEGUARD_TARGET_LOCK=block denies a
+// mutating call whose ABSOLUTE target resolves outside the session project root
+// (the wrong-repo / wrong-worktree write a fact-list can't catch). Default off:
+// no path is checked and behaviour is unchanged.
+describe("hooks/gateguard.mjs — target lock (RISA 2 / G2)", () => {
+    const ROOT = "d:/proj/root";
+    function runTargetHook(toolInput, opts) {
+        const dir = mkdtempSync(join(tmpdir(), "gateguard-target-"));
+        try {
+            const env = {
+                ...process.env,
+                GATEGUARD_SESSION_DIR: dir,
+                CLAUDE_PROJECT_DIR: opts.projectRoot ?? ROOT,
+            };
+            if (opts.targetLock === undefined)
+                delete env.CI_GATEGUARD_TARGET_LOCK;
+            else
+                env.CI_GATEGUARD_TARGET_LOCK = opts.targetLock;
+            const payload = JSON.stringify({ tool_name: "Write", tool_input: toolInput });
+            const result = spawnSync(process.execPath, [HOOK_PATH], { input: payload, encoding: "utf8", env });
+            assert.equal(result.status, 0, `hook exited non-zero: ${result.stderr}`);
+            const stdout = result.stdout.trim();
+            if (stdout === "")
+                return { decision: "allow" };
+            const parsed = JSON.parse(stdout);
+            return { decision: "block", reason: parsed.hookSpecificOutput?.permissionDecisionReason };
+        }
+        finally {
+            rmSync(dir, { recursive: true, force: true });
+        }
+    }
+    it("absolute in-root target hits the normal fact gate, not the mismatch reason", () => {
+        const decision = runTargetHook({ file_path: "d:/proj/root/src/x.ts", content: "y" }, { targetLock: "block" });
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /import|require|present these facts/i);
+        assert.doesNotMatch(decision.reason ?? "", /outside the session project root/i);
+    });
+    it("absolute out-of-root target is denied with an identity-mismatch reason when locked", () => {
+        const decision = runTargetHook({ file_path: "d:/other/repo/x.ts", content: "y" }, { targetLock: "block" });
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /outside the session project root/i);
+        assert.match(decision.reason ?? "", /d:\/other\/repo\/x\.ts/i);
+        assert.match(decision.reason ?? "", /d:\/proj\/root/i);
+    });
+    it("out-of-root target with target lock UNSET falls back to the normal fact gate (default off)", () => {
+        const decision = runTargetHook({ file_path: "d:/other/repo/x.ts", content: "y" }, { targetLock: undefined });
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /present these facts/i);
+        assert.doesNotMatch(decision.reason ?? "", /outside the session project root/i);
+    });
+    it("relative target is never target-locked (resolves under cwd)", () => {
+        const decision = runTargetHook({ file_path: "src/x.ts", content: "y" }, { targetLock: "block" });
+        assert.equal(decision.decision, "block");
+        assert.doesNotMatch(decision.reason ?? "", /outside the session project root/i);
+    });
+    it("a sibling dir sharing the root's name prefix is treated as outside", () => {
+        const decision = runTargetHook({ file_path: "d:/proj/rootX/x.ts", content: "y" }, { targetLock: "block" });
+        assert.equal(decision.decision, "block");
+        assert.match(decision.reason ?? "", /outside the session project root/i);
+    });
+});
 // Session isolation: the cap and clearance state must NOT bleed across
 // concurrent same-day sessions. Drives the production path (no
 // GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so

--- a/test/gateguard-hook.test.mjs
+++ b/test/gateguard-hook.test.mjs
@@ -244,6 +244,49 @@ describe("hooks/gateguard.mjs (runtime PreToolUse hook — issue #106)", () => {
         });
     });
 });
+// RISA 1 / G3 — the destructive-bash scan must not match patterns that appear
+// only inside the PROSE of a commit message or PR body. A verified commit whose
+// message mentions "drop"/"format"/"truncate" was being stranded on its own
+// wording. Genuine destructive commands (the verb is command syntax, not quoted
+// prose) must still gate.
+describe("hooks/gateguard.mjs — destructive-bash message-arg carve-out (RISA 1 / G3)", () => {
+    let sessionDir = "";
+    before(() => {
+        sessionDir = mkdtempSync(join(tmpdir(), "gateguard-msgarg-"));
+    });
+    after(() => {
+        rmSync(sessionDir, { recursive: true, force: true });
+    });
+    it("git commit -m with destructive words in the message is allowed", () => {
+        const decision = runHook("Bash", { command: 'git commit -m "refactor: drop the stale format helper"' }, sessionDir);
+        assert.equal(decision.decision, "allow", "commit-message prose must not trip the destructive gate");
+    });
+    it("gh pr create --body with destructive words in the body is allowed", () => {
+        const decision = runHook("Bash", { command: 'gh pr create --title "cleanup" --body "truncate the logs and remove old files"' }, sessionDir);
+        assert.equal(decision.decision, "allow", "PR-body prose must not trip the destructive gate");
+    });
+    it("git commit -m with single-quoted destructive prose is allowed", () => {
+        const decision = runHook("Bash", { command: "git commit -m 'drop table cleanup: rename the format column'" }, sessionDir);
+        assert.equal(decision.decision, "allow", "single-quoted message prose must not trip the gate");
+    });
+    it("git branch -D (genuine destructive) still blocks despite a benign context", () => {
+        const decision = runHook("Bash", { command: "git branch -D feat/old-branch" }, sessionDir);
+        assert.equal(decision.decision, "block", "force-delete branch must still gate");
+        assert.match(decision.reason ?? "", /rollback|delete|destructive/i);
+    });
+    it("rm -rf outside any quoted message still blocks", () => {
+        const decision = runHook("Bash", { command: "rm -rf node_modules" }, sessionDir);
+        assert.equal(decision.decision, "block", "rm -rf must still gate");
+    });
+    it("a destructive command hidden in bash -c is NOT carved out (-c is not a message flag)", () => {
+        const decision = runHook("Bash", { command: 'bash -c "rm -rf /tmp/x"' }, sessionDir);
+        assert.equal(decision.decision, "block", "bash -c carries a command to run, not prose — must still gate");
+    });
+    it("a plain benign commit message is allowed (no regression)", () => {
+        const decision = runHook("Bash", { command: 'git commit -m "add gateguard tests"' }, sessionDir);
+        assert.equal(decision.decision, "allow");
+    });
+});
 // Session isolation: the cap and clearance state must NOT bleed across
 // concurrent same-day sessions. Drives the production path (no
 // GATEGUARD_SESSION_DIR override) with HOME/USERPROFILE pinned to a temp dir so


### PR DESCRIPTION
## Summary

Three friction-driven gateguard fixes, each mapping onto a recurring pattern surfaced by the `/insights` report (2026-07-07) and confirmed by a 9-agent adversarial survey of the live harness (file:line evidence per gap). One concern per commit. Plan: `docs/plans/2026-07-07-gateguard-v2-hardening.md`.

Base note: this was authored stacked on `feat/gateguard-exclude-paths`; that base landed on `main` as #269 while this work was in flight, so this branch was superseded onto current `main` (cherry-pick, no force-push) and targets `main` directly. The diff is the three hardening commits only.

## The three fixes

### 1. Stop stranding verified commits/PRs on their own message prose (G3, CONFIRMED)
The destructive-bash gate substring-matched all 19 patterns against the whole command, including the text inside `-m` / `--body` / `-F` values. A verified commit whose message mentioned a destructive keyword was blocked on its own wording (this PR reproduced it live twice). Now message/body flag values are blanked before the scan. Genuine destructive commands (`git branch -D`, `git reset --hard`, `rm -rf`) stay gated; `bash -c` is deliberately not carved out.

### 2. Opt-in target lock against wrong-repo / wrong-worktree writes (G2, was prose-only)
The first-Write deny demanded grounding facts but never checked the target lived inside the session git root — perfect facts about the wrong file passed. `CI_GATEGUARD_TARGET_LOCK=block` now denies an absolute target that canonicalizes outside `CLAUDE_PROJECT_DIR` (or the git toplevel), before the fact gate and independent of clearance. Default off = zero regression; relative and excluded paths always pass.

### 3. Catch unquoted `@{u}` refs before the Bash parser blocks them (G1, CONFIRMED)
An unquoted `@{u}` / `@{upstream}` ref trips Claude Code's built-in Bash parser and blocks post-hoc, costing a retry (measured in 4+ sessions) — and the reconcile command/skill prescribed the failing bare form. A quote-aware detector now denies the first unquoted `@{...}` with the exact single-quoted replacement command, and both reconcile docs are fixed.

## Changes

- `src/hooks/gateguard.mts` — `stripMessageArgs` (fix 1), target-lock gate (fix 2), `findUnquotedBraceRef` detector (fix 3).
- `src/lib/gateguard-state.mts` — export `resolveProjectRoot` for the target-lock gate.
- `commands/reconcile.md`, `skills/reconcile.md` — quote `'@{u}...HEAD'`.
- `skills/gateguard.md` — document `CI_GATEGUARD_TARGET_LOCK`.
- `src/test/gateguard-hook.test.mts` — 18 new cases across the three fixes.
- Regenerated `.mjs` + plugin mirrors.

## Test plan

- [x] gateguard hook suite green: 41/41 (was 23) — new cases cover prose-allow, genuine-destructive-still-blocks, target-lock in/out of root + default-off, quoted-vs-unquoted brace refs
- [x] `npm run verify:all` green (14 content invariants + typecheck)
- [x] full suite: gateguard deterministic; the only failures were spawn-timeout flakes under host load, which pass 25/25 in isolation
- [ ] Reviewer: confirm default-off behavior for both new env vars leaves existing sessions unchanged
