### PR TITLE
chore(release): cut v3.18.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 27 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.15.0",
+  "version": "3.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.15.0",
+      "version": "3.18.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "Claude Code that gets sharper every session: the persistent-memory and runtime-discipline layer built on the 7 Laws of AI Agent Discipline. It grounds every edit in real facts before it lands and, through the Mulahazah engine, turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Shipped as 27 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles three grounding skills (gateguard, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 27 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.17.0",
+      "version": "3.18.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 27 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.17.0",
+  "version": "3.18.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
Release bump for 3.18.0. Ships the gateguard v2 hardening (#270): destructive-bash message-arg carve-out, opt-in CI_GATEGUARD_TARGET_LOCK, and the unquoted @{u} detector. Version bump + regenerated manifests only.