### PR TITLE
fix(release): accept npm pack JSON from npm latest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,7 @@ Dated entries. Roll older than 60 days into `docs/audits/archive-<quarter>.md`.
 | 2026-07-10 | The Windows installer accepted any executable answering `bash --version`; WSL Bash then failed on the native `C:/...` hook paths written to settings. | Probe the exact capability the installed command needs before writing any target. | Installer path-read probe + incompatible-Bash integration test. |
 | 2026-07-10 | Landing release markers stayed at v3.14.0 after package v3.20.0, and the mobile hero nowrap rule overflowed a 375 px viewport. | Tie landing markers to `package.json` in CI and verify the smallest supported viewport. | `verify:landing-version` + landing mobile regression + 375/768/1440 browser checks. |
 | 2026-07-10 | Windows committed new generated CLIs and copied plugin helpers as `100644`; the Linux build normalized them to `100755` and failed `verify:generated` after all tests passed. | New generated executables need their Git mode recorded explicitly from Windows. | `git update-index --chmod=+x` on new CLI and helper artifacts + Linux generated-diff CI gate. |
+| 2026-07-10 | The v3.20.1 release passed PR CI but stopped before publish because npm latest returned `npm pack --json` as a single object on Linux while the artifact test required a one-element array. | Release tests must normalize supported CLI output shapes used by the trusted-publishing environment. | Object-and-array regression in `distribution-artifacts.test.mts` + release workflow test gate. |
 
 ## Deferred
 

--- a/src/test/distribution-artifacts.test.mts
+++ b/src/test/distribution-artifacts.test.mts
@@ -93,7 +93,33 @@ function runNpm(args: string[]): string {
   return execFileSync("npm", args, options);
 }
 
+function parseNpmPackResults(output: string): NpmPackResult[] {
+  const parsed: unknown = JSON.parse(output);
+  const candidates = Array.isArray(parsed) ? parsed : [parsed];
+  const allResultsAreValid = candidates.every((candidate): candidate is NpmPackResult => {
+    return (
+      typeof candidate === "object" &&
+      candidate !== null &&
+      Array.isArray((candidate as { files?: unknown }).files)
+    );
+  });
+  if (!allResultsAreValid) {
+    throw new TypeError("npm pack JSON must contain only package results with files arrays");
+  }
+  return candidates;
+}
+
 describe("distribution artifacts", () => {
+  it("accepts npm pack JSON as either an array or a single result object", () => {
+    const result: NpmPackResult = { files: [{ path: "package.json" }] };
+    assert.deepEqual(parseNpmPackResults(JSON.stringify([result])), [result]);
+    assert.deepEqual(parseNpmPackResults(JSON.stringify(result)), [result]);
+    assert.throws(
+      () => parseNpmPackResults(JSON.stringify([result, { files: null }])),
+      /must contain only package results/,
+    );
+  });
+
   it("mirrors every root script into the generated plugin bundle byte-for-byte", () => {
     const sourceFiles = listRelativeFiles(SOURCE_SCRIPTS);
     const bundledFiles = listRelativeFiles(BUNDLED_SCRIPTS);
@@ -124,7 +150,7 @@ describe("distribution artifacts", () => {
       "--json",
       "--ignore-scripts",
     ]);
-    const packResults = JSON.parse(packOutput) as NpmPackResult[];
+    const packResults = parseNpmPackResults(packOutput);
     assert.equal(packResults.length, 1, "npm pack must describe exactly one package");
     const packResult = packResults[0];
     assert.ok(packResult, "npm pack result must be present");

--- a/test/distribution-artifacts.test.mjs
+++ b/test/distribution-artifacts.test.mjs
@@ -53,7 +53,26 @@ function runNpm(args) {
     }
     return execFileSync("npm", args, options);
 }
+function parseNpmPackResults(output) {
+    const parsed = JSON.parse(output);
+    const candidates = Array.isArray(parsed) ? parsed : [parsed];
+    const allResultsAreValid = candidates.every((candidate) => {
+        return (typeof candidate === "object" &&
+            candidate !== null &&
+            Array.isArray(candidate.files));
+    });
+    if (!allResultsAreValid) {
+        throw new TypeError("npm pack JSON must contain only package results with files arrays");
+    }
+    return candidates;
+}
 describe("distribution artifacts", () => {
+    it("accepts npm pack JSON as either an array or a single result object", () => {
+        const result = { files: [{ path: "package.json" }] };
+        assert.deepEqual(parseNpmPackResults(JSON.stringify([result])), [result]);
+        assert.deepEqual(parseNpmPackResults(JSON.stringify(result)), [result]);
+        assert.throws(() => parseNpmPackResults(JSON.stringify([result, { files: null }])), /must contain only package results/);
+    });
     it("mirrors every root script into the generated plugin bundle byte-for-byte", () => {
         const sourceFiles = listRelativeFiles(SOURCE_SCRIPTS);
         const bundledFiles = listRelativeFiles(BUNDLED_SCRIPTS);
@@ -72,7 +91,7 @@ describe("distribution artifacts", () => {
             "--json",
             "--ignore-scripts",
         ]);
-        const packResults = JSON.parse(packOutput);
+        const packResults = parseNpmPackResults(packOutput);
         assert.equal(packResults.length, 1, "npm pack must describe exactly one package");
         const packResult = packResults[0];
         assert.ok(packResult, "npm pack result must be present");


### PR DESCRIPTION
Fixes the v3.20.1 trusted-publishing failure in release run https://github.com/naimkatiman/continuous-improvement/actions/runs/29088577259. npm latest can emit a single object for npm pack --json; the artifact test now accepts the object and array forms and rejects malformed entries. No npm package or GitHub release was published by the failed run. Verification: npm run build; node --test test/distribution-artifacts.test.mjs; npm run verify:all.