### PR TITLE
chore(release): cut v3.22.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 28 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this skill are documented here.
 
 ---
 
+## [3.22.0] — 2026-08-02
+
+### Added
+
+- **`ci-reconcile`**: the `reconcile` ground-truth pass is now a command, not just prose. It spawns `git` argv with no shell — no bash, no coreutils, no `.git/`-relative path — so it behaves the same in PowerShell, cmd, Git Bash and WSL, and stays correct inside a linked worktree. `--json`, `--explain`, `--verify-push <branch>`, and `--snapshot` (field-compatible with `scripts/git-state-snapshot.sh`, plus `contentDrift` and `inProgress`). Exits `0` clear / `1` blocked / `2` not a git repository. (#289)
+- **`verify:reconcile-parity`**, the 16th `verify:all` invariant: a fenced code block in each of `skills/reconcile.md` and `commands/reconcile.md` must prescribe every probe in `GROUND_TRUTH_PROBES` verbatim, and no fenced block may reintroduce a retired form. Fenced-only, so prose stays free to explain *why* a command was retired. (#289)
+
+### Fixed
+
+- **`reconcile` no longer reports a false clean state at four boundaries.** Reproduced against real git: asking `git rev-list` for counts against `@{u}` exits **128** with `fatal: no upstream configured` rather than returning zeros; `git branch --show-current` prints an empty string and exits **0** on a detached HEAD, indistinguishable from a successful read; inside a linked worktree `.git` is a **file**, so listing a `.git/`-relative `MERGE_HEAD` exits **2** exactly as it does on a clean tree, meaning a real conflicted merge read as clean; and `git status` overstates drift on an `autocrlf` tree. The skill and command now document a portable probe for each, plus a compatibility matrix. (#289)
+- **Every `git-state` classifier fails closed.** Unparseable ahead/behind counts read as `unknown` (a blocker), never `even`. A failed `git ls-remote` reads as `unverified` — never `not-landed` and never `landed` — so a network failure can no longer be reported as either outcome. An unprobed in-progress marker reads as `unprobed`, never `absent`. An unparseable branch name never matches an expected one. (#289)
+- Verify-lint count prose corrected across `CLAUDE.md` (claimed 14 and omitted `landing-version`), `CONTRIBUTING.md` (13) and `docs/RELEASING.md` (12); the actual count was 15, now 16. (#289)
+
 ## [3.21.0] — 2026-07-11
 
 ### Added

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -204,7 +204,7 @@
           <rect x="13" y="13" width="6" height="6" rx="1.5" fill="currentColor"/>
         </svg>
         <span class="name">continuous-improvement</span>
-        <span class="ver">v3.21.0</span>
+        <span class="ver">v3.22.0</span>
       </a>
       <div class="nav-links">
         <a href="#laws">The 7 Laws</a>
@@ -219,7 +219,7 @@
     <section class="hero">
       <div class="container hero-grid">
         <div class="hero-lead">
-          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.21.0</span>
+          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.22.0</span>
           <h1 class="display reveal" style="--i:1">Claude Code that gets <span class="belt draw">sharper every session</span></h1>
           <p class="hero-sub reveal" style="--i:2">continuous-improvement makes the agent research before it edits, prove every completion before it reports done, and turn each fix into an instinct it reuses next time. Seven laws run the loop; the Mulahazah engine compounds what it learns.</p>
           <div class="install reveal" style="--i:3">
@@ -256,7 +256,7 @@
         <li><span class="v">7</span><span class="k">Laws in force</span></li>
         <li><span class="v">0</span><span class="k">Runtime deps</span></li>
         <li><span class="v">MIT</span><span class="k">License</span></li>
-        <li><span class="v">v3.21.0</span><span class="k">Current rev</span></li>
+        <li><span class="v">v3.22.0</span><span class="k">Current rev</span></li>
       </ul>
     </div>
 
@@ -444,7 +444,7 @@
 
   <footer>
     <div class="container foot-grid">
-      <span class="foot-doc">DOC. CI-7L &middot; REV 3.21.0 &middot; MIT LICENSE</span>
+      <span class="foot-doc">DOC. CI-7L &middot; REV 3.22.0 &middot; MIT LICENSE</span>
       <div class="foot-links">
         <a href="https://github.com/naimkatiman/continuous-improvement">GitHub</a>
         <a href="https://www.npmjs.com/package/continuous-improvement">npm</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "Claude Code that gets sharper every session: the persistent-memory and runtime-discipline layer built on the 7 Laws of AI Agent Discipline. It grounds every edit in real facts before it lands and, through the Mulahazah engine, turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Shipped as 28 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles three grounding skills (gateguard, tdd-workflow, verification-loop) so research, memory, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 28 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.21.0",
+      "version": "3.22.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 28 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.21.0",
+  "version": "3.22.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
Release bump for 3.22.0.

Ships the reconcile ground-truth hardening merged in #289:

- `ci-reconcile` — the ground-truth pass as a cross-platform command (git argv, no shell), with `--json`, `--explain`, `--verify-push`, `--snapshot`
- `verify:reconcile-parity` — 16th `verify:all` invariant keeping the skill/command docs matched to the shipped probe set
- four boundary fixes: no configured upstream, detached HEAD, linked worktree in-progress detection, autocrlf phantom drift

Bump surface per docs/RELEASING.md: `package.json`, `package-lock.json`, `CHANGELOG.md`, all four `docs/landing/index.html` REV markers, and the five generated manifests.

Verification on this branch: `npm run verify:all` 16/16 + typecheck green, `verify:landing-version` confirms all 4 markers match 3.22.0. Full suite 1104/1109 — the 5 are the documented `hook.test.mjs`/`observe` wall-clock flake on a loaded Windows host (2296ms against a 2000ms budget on one run, clean on the next two); Linux CI passed them on #289.

🤖 Generated with [Claude Code](https://claude.com/claude-code)