### PR TITLE
chore(release): cut v3.23.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 29 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.22.1",
+      "version": "3.23.0",
       "source": "./plugins/continuous-improvement",
       "author": {
         "name": "naimkatiman"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this skill are documented here.
 
 ---
 
-## [Unreleased]
+## [3.23.0] — 2026-08-15
 
 ### Added
 

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -204,7 +204,7 @@
           <rect x="13" y="13" width="6" height="6" rx="1.5" fill="currentColor"/>
         </svg>
         <span class="name">continuous-improvement</span>
-        <span class="ver">v3.22.1</span>
+        <span class="ver">v3.23.0</span>
       </a>
       <div class="nav-links">
         <a href="#laws">The 7 Laws</a>
@@ -219,7 +219,7 @@
     <section class="hero">
       <div class="container hero-grid">
         <div class="hero-lead">
-          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.22.1</span>
+          <span class="kicker reveal">SPEC <b>/</b> AI AGENT DISCIPLINE <b>/</b> REV 3.23.0</span>
           <h1 class="display reveal" style="--i:1">Claude Code that gets <span class="belt draw">sharper every session</span></h1>
           <p class="hero-sub reveal" style="--i:2">continuous-improvement makes the agent research before it edits, prove every completion before it reports done, and turn each fix into an instinct it reuses next time. Seven laws run the loop; the Mulahazah engine compounds what it learns.</p>
           <div class="install reveal" style="--i:3">
@@ -256,7 +256,7 @@
         <li><span class="v">7</span><span class="k">Laws in force</span></li>
         <li><span class="v">0</span><span class="k">Runtime deps</span></li>
         <li><span class="v">MIT</span><span class="k">License</span></li>
-        <li><span class="v">v3.22.1</span><span class="k">Current rev</span></li>
+        <li><span class="v">v3.23.0</span><span class="k">Current rev</span></li>
       </ul>
     </div>
 
@@ -444,7 +444,7 @@
 
   <footer>
     <div class="container foot-grid">
-      <span class="foot-doc">DOC. CI-7L &middot; REV 3.22.1 &middot; MIT LICENSE</span>
+      <span class="foot-doc">DOC. CI-7L &middot; REV 3.23.0 &middot; MIT LICENSE</span>
       <div class="foot-links">
         <a href="https://github.com/naimkatiman/continuous-improvement">GitHub</a>
         <a href="https://www.npmjs.com/package/continuous-improvement">npm</a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "continuous-improvement",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "continuous-improvement",
-      "version": "3.22.1",
+      "version": "3.23.0",
       "license": "MIT",
       "bin": {
         "ci": "bin/unified-cli.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "description": "Claude Code that gets sharper every session: the persistent-memory and runtime-discipline layer built on the 7 Laws of AI Agent Discipline. It grounds every edit in real facts before it lands and, through the Mulahazah engine, turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Shipped as 29 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts. Beginner: one /plugin install command. Expert: adds MCP tools and session hooks.",
   "keywords": [
     "claude-code",

--- a/plugins/beginner.json
+++ b/plugins/beginner.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "mode": "beginner",
   "description": "Beginner mode: see what your agent learned, list its instincts, and request a session reflection. Bundles the ship fast path plus grounding skills (gateguard, tdd-workflow, verification-loop) so one-defect delivery, research, tests, and verification happen by default — every edit starts from facts, not guesses.",
   "tools": [

--- a/plugins/continuous-improvement/.claude-plugin/marketplace.json
+++ b/plugins/continuous-improvement/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "continuous-improvement",
       "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 29 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
-      "version": "3.22.1",
+      "version": "3.23.0",
       "source": "./",
       "author": {
         "name": "naimkatiman"

--- a/plugins/continuous-improvement/.claude-plugin/plugin.json
+++ b/plugins/continuous-improvement/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "description": "The persistent-memory and runtime-discipline layer for Claude Code. It remembers the corrections you already gave, grounds every edit in real facts before it lands, and — through the Mulahazah engine — turns each fix into a reusable instinct, so a lesson learned once is applied automatically next time with no re-teaching. Built on the 7 Laws of AI Agent Discipline (research, plan, verify, reflect, learn) and shipped as 29 bundled skills, instinct-aware hooks, an MCP toolset for recall and reflection, and a GitHub Action transcript linter that feeds real work history back into sharper instincts.",
   "author": {
     "name": "naimkatiman",

--- a/plugins/expert.json
+++ b/plugins/expert.json
@@ -1,6 +1,6 @@
 {
   "name": "continuous-improvement",
-  "version": "3.22.1",
+  "version": "3.23.0",
   "mode": "expert",
   "description": "Expert mode: tune confidence, manage instincts, and persist plans on disk. Adds safety, token-budget, and strategic-compact skills plus the /learn-eval command so long sessions stay sharp and learnings survive context resets.",
   "tools": [


### PR DESCRIPTION
Release `continuous-improvement` 3.23.0.

- Promotes the native global `ship` skill release notes.
- Synchronizes package, lockfile, five generated manifests, and four landing markers.
- Contains no runtime or workflow changes beyond merged PR #294.

Verification

- `npm run verify:generated`
- `npm run verify:all`
- `npm pack --dry-run --json --ignore-scripts` confirms version 3.23.0 and all required ship paths
- Feature implementation suite: 1,129 passed
- Independent release audit: approved with zero findings

The protected Linux CI matrix is the final full-suite gate before merge.